### PR TITLE
feat: introduce usable standard mode for SBE 0.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,9 @@ jobs:
       - name: Check code format
         run: cargo fmt --all -- --check
       - name: Check the package for errors
-        run: sbe run --allow-insecure-linux-network -- cargo check --all
+        run: sbe run -- cargo check --all
       - name: Lint rust sources
-        run: sbe run --allow-insecure-linux-network -- cargo clippy --all-targets --all-features --tests --benches -- -D warnings
+        run: sbe run -- cargo clippy --all-targets --all-features --tests --benches -- -D warnings
       - name: Execute rust tests
         run: cargo nextest run --all-features
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -96,7 +96,7 @@ jobs:
           case "$TARGET" in
             aarch64-apple-darwin)
               rustup target add "$TARGET"
-              sbe run --allow-insecure-linux-network -- \
+              sbe run -- \
                 cargo build --release --locked --target "$TARGET" \
                 --manifest-path apps/cli/Cargo.toml
               ;;
@@ -105,7 +105,7 @@ jobs:
               # upload-rust-binary-action provisions internally — avoid
               # duplicating that here. A host-native `cargo check` still
               # gives us a real sbe workload to dogfood against.
-              sbe run --allow-insecure-linux-network -- cargo check --locked \
+              sbe run -- cargo check --locked \
                 --manifest-path apps/cli/Cargo.toml
               ;;
           esac

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -73,15 +73,15 @@ jobs:
           set -euo pipefail
           out=$(sbe inspect -- cargo build 2>&1)
           test -n "$out"
-          echo "$out" | head -40
-          echo "$out" | grep -E "^securityMode: standard" >/dev/null
+          head -40 <<<"$out"
+          grep -E "^securityMode: standard" <<<"$out" >/dev/null
           if [ "${{ runner.os }}" = "Linux" ]; then
-            echo "$out" | grep -E "^backend: landlock\+seccomp" >/dev/null
-            echo "$out" | grep -E "^landlockAbi: v[0-9]+" >/dev/null
-            echo "$out" | grep -E "^seccomp:" >/dev/null
+            grep -E "^backend: landlock\+seccomp" <<<"$out" >/dev/null
+            grep -E "^landlockAbi: v[0-9]+" <<<"$out" >/dev/null
+            grep -E "^seccomp:" <<<"$out" >/dev/null
           else
-            echo "$out" | grep -E "^\(version 1\)" >/dev/null
-            echo "$out" | grep -E "^\(deny default\)" >/dev/null
+            grep -E "^\(version 1\)" <<<"$out" >/dev/null
+            grep -E "^\(deny default\)" <<<"$out" >/dev/null
           fi
 
       - name: sbe inspect for every ecosystem (smoke)

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -71,7 +71,7 @@ jobs:
       - name: sbe inspect renders deterministic policy (rust)
         run: |
           set -euo pipefail
-          out=$(sbe inspect -- cargo build 2>/dev/null)
+          out=$(sbe inspect -- cargo build 2>&1)
           test -n "$out"
           echo "$out" | head -40
           echo "$out" | grep -E "^securityMode: standard" >/dev/null

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -8,9 +8,10 @@ name: test-cli
 #  2. ecosystem (Linux): for each language ecosystem, run a representative
 #     real-world build under the default standard mode against (a) a fresh "happy path"
 #     project that depends on a real upstream package, and (b) the hostile
-#     fixture in /fixtures/<eco>/ that exercises every attack in
-#     fixtures/ATTACKS.md. The fixture output must contain zero `PWNED:`
-#     lines and at least one `SAFE:` line for every attack ID.
+#     fixture in /fixtures/<eco>/ that exercises host credential, persistence,
+#     privilege, and egress attacks. Workspace `.env` confidentiality is
+#     verified separately under strict mode because standard deliberately
+#     treats workspace files as readable input.
 #
 #  3. network-filter (Linux best-effort mode): explicit proxy-allowlist tests — `curl` to
 #     an allowed domain (registry) succeeds; `curl` to an evil domain
@@ -34,7 +35,7 @@ permissions:
 env:
   CARGO_TERM_COLOR: never
   # Used by every "verify-fixture-output" step.
-  ATTACK_IDS: "ssh-read aws-read gcloud-read gh-token-read env-read bashrc-write authorized-keys-write sudo-exec pkexec-exec curl-evil"
+  ATTACK_IDS: "ssh-read aws-read gcloud-read gh-token-read bashrc-write authorized-keys-write sudo-exec pkexec-exec curl-evil"
 
 jobs:
   install:
@@ -119,6 +120,18 @@ jobs:
           out=$(sbe run --profile rust -- /bin/echo "hello from sbe")
           echo "got: $out"
           test "$out" = "hello from sbe"
+
+      - name: standard reads source symlinks into sibling workspaces
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/sbe-source-symlink"
+          rm -rf "$root"
+          mkdir -p "$root/project/src" "$root/shared"
+          printf 'shared-source\n' >"$root/shared/value.txt"
+          ln -s ../../shared "$root/project/src/shared"
+          cd "$root/project"
+          out=$(sbe run --profile rust -- /bin/cat src/shared/value.txt)
+          test "$out" = shared-source
 
       - name: explicit allow-all-network permits real sockets
         run: |
@@ -416,14 +429,25 @@ jobs:
           sbe run -- cargo build --release 2>&1 | tee out.log
           grep -q "Compiling serde" out.log
           ./target/release/real | grep -q '"name":"sbe"'
+          install_root="$RUNNER_TEMP/sbe-explicit-cargo-root"
+          rm -rf "$install_root"
+          sbe run -- cargo install --offline --path . --root "$install_root"
+          "$install_root/bin/real" | grep -q '"name":"sbe"'
 
-      - name: hostile fixture — every attack must be SAFE (10/10)
+      - name: hostile fixture — standard host controls and strict workspace secret
         run: |
           set -euo pipefail
           cd fixtures/rust
           rm -rf target
           sbe run -- cargo build 2>&1 | tee out.log
           ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh out.log
+          printf 'strict-workspace-secret\n' >.env
+          rm -rf target
+          sbe run --strict --allow-all-network --env RUSTC_WRAPPER= -- \
+            cargo build --offline 2>&1 | tee strict.out.log
+          ATTACK_IDS=env-read \
+            ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh strict.out.log
+          rm .env
 
   ecosystem-node:
     name: ecosystem / npm
@@ -488,7 +512,7 @@ jobs:
           test -d node_modules/chalk
           sbe run -- npm exec --offline -- local-sbe-tool | grep -Fx sbe-local-tool-ok
 
-      - name: hostile fixture — every attack must be SAFE (10/10)
+      - name: hostile fixture — standard host controls SAFE (9/9)
         run: |
           set -euo pipefail
           cd fixtures/node
@@ -540,7 +564,7 @@ jobs:
           test -d .venv/lib
           sbe run -- .venv/bin/python -c 'import requests; print(requests.__name__)' | grep -Fx requests
 
-      - name: hostile fixture — every attack must be SAFE (10/10)
+      - name: hostile fixture — standard host controls SAFE (9/9)
         run: |
           set -euo pipefail
           export UV_CACHE_DIR="$HOME/.cache/uv"
@@ -617,7 +641,7 @@ jobs:
           sbe run -- mix compile 2>&1 | tee compile.log
           grep -qE "(Compiled|Generated real)" compile.log
 
-      - name: hostile fixture — every attack must be SAFE (10/10)
+      - name: hostile fixture — standard host controls SAFE (9/9)
         run: |
           set -euo pipefail
           cd fixtures/elixir
@@ -740,7 +764,7 @@ jobs:
           cd fixtures/scala
           rm -rf target project/target project/project
           # The build.sbt evaluates on every sbt task and runs the attack
-          # matrix (10 probes, each subprocess capped at 5s via
+          # host-control matrix (9 asserted probes, each subprocess capped at 5s via
           # ProcessBuilder.waitFor). `sbt test` exercises a full compile +
           # MUnit test run for the cats-effect Greeter, so the sandbox
           # actually has work to mediate (dep resolution → ivy2, scalac,

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -126,12 +126,13 @@ jobs:
           set -euo pipefail
           root="$RUNNER_TEMP/sbe-source-symlink"
           rm -rf "$root"
-          mkdir -p "$root/project/src" "$root/shared"
-          printf 'shared-source\n' >"$root/shared/value.txt"
+          mkdir -p "$root/project/src" "$root/shared" "$root/nested"
+          printf 'nested-shared-source\n' >"$root/nested/value.txt"
           ln -s ../../shared "$root/project/src/shared"
+          ln -s ../nested "$root/shared/nested"
           cd "$root/project"
-          out=$(sbe run --profile rust -- /bin/cat src/shared/value.txt)
-          test "$out" = shared-source
+          out=$(sbe run --profile rust -- /bin/cat src/shared/nested/value.txt)
+          test "$out" = nested-shared-source
 
       - name: explicit allow-all-network permits real sockets
         run: |

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -6,13 +6,13 @@ name: test-cli
 #     profiles / inspect / --dry-run / minimal `run` / capability hygiene.
 #
 #  2. ecosystem (Linux): for each language ecosystem, run a representative
-#     real-world build under `sbe run --allow-insecure-linux-network` against (a) a fresh "happy path"
+#     real-world build under the default standard mode against (a) a fresh "happy path"
 #     project that depends on a real upstream package, and (b) the hostile
 #     fixture in /fixtures/<eco>/ that exercises every attack in
 #     fixtures/ATTACKS.md. The fixture output must contain zero `PWNED:`
 #     lines and at least one `SAFE:` line for every attack ID.
 #
-#  3. network-filter (Linux compatibility mode): explicit proxy-allowlist tests — `curl` to
+#  3. network-filter (Linux best-effort mode): explicit proxy-allowlist tests — `curl` to
 #     an allowed domain (registry) succeeds; `curl` to an evil domain
 #     gets a non-2xx response. Verifies the two-layer defense.
 #
@@ -74,6 +74,7 @@ jobs:
           out=$(sbe inspect -- cargo build 2>/dev/null)
           test -n "$out"
           echo "$out" | head -40
+          echo "$out" | grep -E "^securityMode: standard" >/dev/null
           if [ "${{ runner.os }}" = "Linux" ]; then
             echo "$out" | grep -E "^backend: landlock\+seccomp" >/dev/null
             echo "$out" | grep -E "^landlockAbi: v[0-9]+" >/dev/null
@@ -108,14 +109,14 @@ jobs:
       - name: dry-run prints policy without spawning the child
         run: |
           set -euo pipefail
-          sbe run --allow-insecure-linux-network --dry-run -- echo hello >/tmp/sbe-dry.out 2>&1 || true
+          sbe run --dry-run -- echo hello >/tmp/sbe-dry.out 2>&1 || true
           test -s /tmp/sbe-dry.out
           head -20 /tmp/sbe-dry.out
 
       - name: real sandbox executes an allowed binary
         run: |
           set -euo pipefail
-          out=$(sbe run --allow-insecure-linux-network --profile rust -- /bin/echo "hello from sbe")
+          out=$(sbe run --profile rust -- /bin/echo "hello from sbe")
           echo "got: $out"
           test "$out" = "hello from sbe"
 
@@ -152,12 +153,12 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          if sbe run --profile rust -- /bin/echo should-not-run >strict.out 2>&1; then
+          if sbe run --strict --profile rust -- /bin/echo should-not-run >strict.out 2>&1; then
             echo "::error::strict Linux proxy mode unexpectedly ran"
             exit 1
           fi
           grep -q "strict-domain-egress" strict.out
-          sbe run --allow-insecure-linux-network --profile rust -- /bin/echo compatibility-ok \
+          sbe run --strict --allow-insecure-linux-network --profile rust -- /bin/echo compatibility-ok \
             2>compatibility.err
           grep -q "WARNING: insecure Linux network compatibility" compatibility.err
 
@@ -243,10 +244,10 @@ jobs:
           mkdir -p "$project"
           printf original >"$project/source.txt"
           cd "$project"
-          sbe run --allow-all-network --profile rust -- /bin/sh -c \
+          sbe run --strict --allow-all-network --profile rust -- /bin/sh -c \
             'printf pwned > source.txt' >/dev/null 2>&1 || true
           test "$(cat source.txt)" = original
-          sbe run --allow-all-network --profile rust -- /bin/sh -c \
+          sbe run --strict --allow-all-network --profile rust -- /bin/sh -c \
             'mkdir -p target && printf output > target/artifact'
           test "$(cat target/artifact)" = output
 
@@ -272,7 +273,7 @@ jobs:
           }
           RS
           cd "$project"
-          sbe run --allow-insecure-linux-network --profile rust \
+          sbe run --strict --allow-insecure-linux-network --profile rust \
             --env RUSTC_WRAPPER= -- cargo build --offline
           test -x target/debug/sbe-build-script-smoke
 
@@ -318,7 +319,7 @@ jobs:
             sleep 0.2
           done
           port=$(head -1 "$RUNNER_TEMP/sbe-local-port")
-          if sbe run --profile rust --allow-exec /usr/bin/curl -- \
+          if sbe run --strict --profile rust --allow-exec /usr/bin/curl -- \
               /usr/bin/curl --noproxy '*' --max-time 2 "http://127.0.0.1:$port/"; then
             echo "::error::proxy-only policy reached unrelated localhost service"
             exit 1
@@ -327,8 +328,8 @@ jobs:
       - name: two ordinary invocations succeed in a row
         run: |
           set -euo pipefail
-          sbe run --allow-insecure-linux-network --profile node -- /bin/echo run-1
-          sbe run --allow-insecure-linux-network --profile node -- /bin/echo run-2
+          sbe run --profile node -- /bin/echo run-1
+          sbe run --profile node -- /bin/echo run-2
 
   # Shared verifier shell. Saved here so all ecosystem jobs use the same logic.
   # Asserts: zero "PWNED:" lines AND a "SAFE:" line for every attack ID.
@@ -412,7 +413,7 @@ jobs:
               println!("{s}");
           }
           RS
-          sbe run --allow-insecure-linux-network -- cargo build --release 2>&1 | tee out.log
+          sbe run -- cargo build --release 2>&1 | tee out.log
           grep -q "Compiling serde" out.log
           ./target/release/real | grep -q '"name":"sbe"'
 
@@ -421,7 +422,7 @@ jobs:
           set -euo pipefail
           cd fixtures/rust
           rm -rf target
-          sbe run --allow-insecure-linux-network -- cargo build 2>&1 | tee out.log
+          sbe run -- cargo build 2>&1 | tee out.log
           ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh out.log
 
   ecosystem-node:
@@ -482,17 +483,17 @@ jobs:
             }
           }
           JSON
-          sbe run --allow-insecure-linux-network -- npm install --install-links --no-audit --no-fund 2>&1 | tee out.log
+          sbe run -- npm install --install-links --no-audit --no-fund 2>&1 | tee out.log
           test -d node_modules/lodash
           test -d node_modules/chalk
-          sbe run --allow-insecure-linux-network -- npm exec --offline -- local-sbe-tool | grep -Fx sbe-local-tool-ok
+          sbe run -- npm exec --offline -- local-sbe-tool | grep -Fx sbe-local-tool-ok
 
       - name: hostile fixture — every attack must be SAFE (10/10)
         run: |
           set -euo pipefail
           cd fixtures/node
           rm -rf node_modules
-          sbe run --allow-insecure-linux-network -- npm install --no-audit --no-fund 2>&1 | tee out.log || true
+          sbe run -- npm install --no-audit --no-fund 2>&1 | tee out.log || true
           ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh out.log
 
   ecosystem-python:
@@ -535,9 +536,9 @@ jobs:
           cd "$HOME/sbe-uv"
           rm -rf real && mkdir real && cd real
           uv venv .venv
-          sbe run --allow-insecure-linux-network -- uv pip install --python .venv --no-progress requests httpx
+          sbe run -- uv pip install --python .venv --no-progress requests httpx
           test -d .venv/lib
-          sbe run --allow-insecure-linux-network -- .venv/bin/python -c 'import requests; print(requests.__name__)' | grep -Fx requests
+          sbe run -- .venv/bin/python -c 'import requests; print(requests.__name__)' | grep -Fx requests
 
       - name: hostile fixture — every attack must be SAFE (10/10)
         run: |
@@ -546,7 +547,7 @@ jobs:
           mkdir -p "$UV_CACHE_DIR"
           cd fixtures/python
           rm -rf dist
-          sbe run --allow-insecure-linux-network -- uv build --no-progress 2>&1 | tee out.log || true
+          sbe run -- uv build --no-progress 2>&1 | tee out.log || true
           ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh out.log
 
   ecosystem-elixir:
@@ -613,7 +614,7 @@ jobs:
           # source-immutable sandbox; dependency compilation remains inside.
           mix deps.get 2>&1 | tee deps.log
           grep -qi "jason" deps.log
-          sbe run --allow-insecure-linux-network -- mix compile 2>&1 | tee compile.log
+          sbe run -- mix compile 2>&1 | tee compile.log
           grep -qE "(Compiled|Generated real)" compile.log
 
       - name: hostile fixture — every attack must be SAFE (10/10)
@@ -621,7 +622,7 @@ jobs:
           set -euo pipefail
           cd fixtures/elixir
           rm -rf _build deps
-          sbe run --allow-insecure-linux-network -- mix compile 2>&1 | tee out.log || true
+          sbe run -- mix compile 2>&1 | tee out.log || true
           ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh out.log
 
   # Java/Scala coverage uses sbt and Maven. Gradle daemon IPC needs separate
@@ -702,7 +703,7 @@ jobs:
               }
           }
           JAVA
-          sbe run --allow-insecure-linux-network -- mvn -q -B compile 2>&1 | tee out.log
+          sbe run -- mvn -q -B compile 2>&1 | tee out.log
           test -f target/classes/com/sbetest/App.class
 
       - name: real-dep happy path — sbt compile a fresh Scala project with cats
@@ -730,7 +731,7 @@ jobs:
               def main(args: Array[String]): Unit = println((1, 2).bimap(_ + 1, _ * 2))
           }
           SCALA
-          sbe run --allow-insecure-linux-network -- sbt -batch compile 2>&1 | tee out.log
+          sbe run -- sbt -batch compile 2>&1 | tee out.log
           grep -qiE "(success|done compiling)" out.log
 
       - name: hostile sbt fixture — cats-effect compile + MUnit test
@@ -744,7 +745,7 @@ jobs:
           # MUnit test run for the cats-effect Greeter, so the sandbox
           # actually has work to mediate (dep resolution → ivy2, scalac,
           # MUnit). All 10 attack IDs must come back SAFE.
-          sbe run --allow-insecure-linux-network -- sbt -batch test 2>&1 | tee out.log || true
+          sbe run -- sbt -batch test 2>&1 | tee out.log || true
           ${GITHUB_WORKSPACE}/.github/workflows/verify-attacks.sh out.log
           # Sanity: the MUnit test actually ran.
           grep -qE "GreeterSpec" out.log || {
@@ -772,7 +773,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$HOME/sbe-netfilter" && cd "$HOME/sbe-netfilter"
-          out=$(sbe run --allow-insecure-linux-network --profile rust --allow-fetch registry.npmjs.org -- \
+          out=$(sbe run --profile rust --allow-fetch registry.npmjs.org -- \
                 /usr/bin/curl -sSL --max-time 10 -o /dev/null \
                 -w "%{http_code}" https://registry.npmjs.org/)
           echo "code=$out"
@@ -782,7 +783,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$HOME/sbe-netfilter"
-          out=$(sbe run --allow-insecure-linux-network --profile rust --allow-fetch registry.npmjs.org -- \
+          out=$(sbe run --profile rust --allow-fetch registry.npmjs.org -- \
                 /usr/bin/curl -sSL --max-time 10 -o /dev/null \
                 -w "%{http_code}" https://evil.example.invalid/ || true)
           echo "code=$out"

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -121,6 +121,16 @@ jobs:
           echo "got: $out"
           test "$out" = "hello from sbe"
 
+      - name: project relocation fails early in standard mode
+        run: |
+          set -euo pipefail
+          if sbe run --profile node -- npm --prefix "$RUNNER_TEMP/other-project" prefix \
+              >relocation.out 2>&1; then
+            echo "::error::standard mode accepted a project outside its policy root"
+            exit 1
+          fi
+          grep -q "project relocation option" relocation.out
+
       - name: standard reads source symlinks into sibling workspaces
         run: |
           set -euo pipefail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,9 @@ All notable changes to this project will be documented in this file. See [conven
   W^X, hard-link validation, exact workspace outputs, ambient local-service
   denial, and fail-closed Linux network capability checks.
 - Keep standard-mode symlink referents subject to protected-path denials and
-  filter high-confidence API-key and cloud-credential environment variables,
-  including bare names such as `TOKEN`, `API_KEY`, and `PASSWORD`.
+  filter high-confidence API-key, cloud, and database credential environment
+  variables, including bare or standardized names such as `TOKEN`, `API_KEY`,
+  `PASSWORD`, `PGPASSWORD`, and `MYSQL_PWD`.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,9 +56,10 @@ All notable changes to this project will be documented in this file. See [conven
 - Preserve explicit execute denials when standard mode infers output grants,
   filter custom AWS shared-credentials paths, and permit ordinary Unix-domain
   build-service IPC in macOS standard mode while keeping strict mode isolated.
-- Grant the effective Gradle user home for standard `gradle`/`gradlew` commands,
-  honoring the command-line option before inherited `GRADLE_USER_HOME` and the
-  conventional `~/.gradle` default.
+- Grant only mutable runtime subdirectories beneath the effective Gradle user
+  home for standard `gradle`/`gradlew` commands, honoring the command-line
+  option before inherited `GRADLE_USER_HOME` and the conventional `~/.gradle`
+  default while keeping initialization scripts immutable.
 - Keep macOS `DenyAll` authoritative by withholding standard-mode Unix-socket
   compatibility grants when the effective network policy denies all traffic.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Replace validated writable and executable symlink grants with canonical
   snapshots before launch, so a parallel build cannot retarget the lexical
   link between policy validation and descriptor opening.
+- Create unresolved Linux output grants through the launcher's descriptor-bound
+  no-symlink walk, filter Azure Pipelines `SYSTEM_ACCESSTOKEN`, and bound source
+  symlink discovery by entry and depth budgets.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Support globally configured sccache through ordinary executable/cache grants
   and local IPC; no sccache source or managed adapter is shipped by SBE.
 - Follow pre-existing tool, cache, and source-tree symlinks in standard mode
-  while retaining strict no-follow behavior and protected-path denials.
+  when their referents stay inside the authorized envelope; external writable
+  cache referents require one narrow explicit grant.
 - Allow explicit top-level `cargo install` commands to manage their selected
   install root instead of reimplementing Cargo's transaction format.
 - Stop requiring `--allow-insecure-linux-network` for standard Linux builds;
@@ -37,7 +38,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Keep standard-mode symlink referents subject to protected-path denials and
   filter high-confidence API-key, cloud, and database credential environment
   variables, including bare or standardized names such as `TOKEN`, `API_KEY`,
-  `PASSWORD`, `PGPASSWORD`, `MYSQL_PWD`, and npm `_authToken` forms.
+  `PASSWORD`, `PGPASSWORD`, `MYSQL_PWD`, Terraform `TF_TOKEN_*`, and npm
+  `_authToken` forms.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Filter custom AWS configuration-file locators and inspect direct symlink
   entries beneath generated dependency roots so warm linked dependencies remain
   readable without recursively scanning ordinary generated contents.
+- Filter GitLab job JWT variables, honor direct Cargo
+  `--config install.root='path'` overrides, and reject implicit Cargo-config
+  install roots before launch with explicit `--root` guidance.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,9 @@ All notable changes to this project will be documented in this file. See [conven
   no-symlink walk, filter Azure Pipelines `SYSTEM_ACCESSTOKEN` and OIDC token-file
   variables, and bound Linux source-symlink discovery by entry and depth budgets
   without scanning macOS workspaces that do not need referent grants.
+- Preserve explicit execute denials when standard mode infers output grants,
+  filter custom AWS shared-credentials paths, and permit ordinary Unix-domain
+  build-service IPC in macOS standard mode while keeping strict mode isolated.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,9 @@ All notable changes to this project will be documented in this file. See [conven
   grants beneath the effective `CARGO_HOME` while retaining credential denials.
 - Filter npm's custom `NPM_CONFIG_USERCONFIG` credential-file locator while
   preserving ordinary npm build configuration variables.
+- Filter Kerberos ticket-cache and keytab locators, and derive Maven's local
+  repository from bounded default/selected `settings.xml` reads after all
+  higher-precedence command, environment, and project JVM properties.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,8 @@ All notable changes to this project will be documented in this file. See [conven
   default while keeping initialization scripts immutable.
 - Keep macOS `DenyAll` authoritative by withholding standard-mode Unix-socket
   compatibility grants when the effective network policy denies all traffic.
+- Reject Gradle and Maven project-relocation flags early, with the same
+  actionable working-directory guidance used for other package managers.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ All notable changes to this project will be documented in this file. See [conven
   higher-precedence command, environment, and project JVM properties.
 - Merge explicitly selected Maven global settings beneath user settings and
   honor the effective JVM `user.home` for settings and repository defaults.
+- Follow npm's command/environment cache selection, and grant read-only access
+  to effective Gradle homes and explicitly selected Maven settings.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,6 +133,8 @@ All notable changes to this project will be documented in this file. See [conven
   require explicit read approval for project-selected external Maven settings.
 - Filter the custom `NETRC` credential locator, resolve npm user-config cache
   paths, and follow pnpm store selection across command/configuration sources.
+- Filter pip/uv custom configuration locators and replace their conventional
+  cache grants with command/environment-selected cache directories.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,9 @@ All notable changes to this project will be documented in this file. See [conven
   actionable `--target-dir` guidance.
 - Filter Docker client TLS-directory locators and derive Maven's writable local
   repository from the last `-D`/`--define maven.repo.local` property.
+- Resolve Maven repository overrides from `MAVEN_OPTS` and bounded, no-follow
+  project `.mvn/jvm.config` reads, preserving launcher and last-property
+  precedence while rejecting ambiguous option forms.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Grant the effective Gradle user home for standard `gradle`/`gradlew` commands,
   honoring the command-line option before inherited `GRADLE_USER_HOME` and the
   conventional `~/.gradle` default.
+- Keep macOS `DenyAll` authoritative by withholding standard-mode Unix-socket
+  compatibility grants when the effective network policy denies all traffic.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,8 @@ All notable changes to this project will be documented in this file. See [conven
   removing stale conventional Poetry cache grants.
 - Filter npm global-config and Poetry config-directory locators, honor Poetry's
   global/project configured cache, and grant Gradle's selected project cache.
+- Accept both npm global-config environment spellings and resolve cache/store
+  paths from the explicitly selected global npmrc after higher-priority layers.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,6 +144,8 @@ All notable changes to this project will be documented in this file. See [conven
   the sandboxed tools consume the same settings used during policy preparation.
 - Follow Poetry's command, `POETRY_CACHE_DIR`, and XDG cache selection while
   removing stale conventional Poetry cache grants.
+- Filter npm global-config and Poetry config-directory locators, honor Poetry's
+  global/project configured cache, and grant Gradle's selected project cache.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Resolve missing writable descendants through their nearest existing symlink
   ancestor, validate the reconstructed target, and snapshot it so approved
   symlinked cache roots also work on cold builds.
+- Filter custom Google Cloud SDK and Azure CLI configuration directories so
+  their credential databases cannot bypass the default secret-path denials.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,8 @@ All notable changes to this project will be documented in this file. See [conven
   paths from the explicitly selected global npmrc after higher-priority layers.
 - Filter Git's environment-backed configuration transports and replace
   conventional Coursier cache grants with an inherited `COURSIER_CACHE`.
+- Filter credential-bearing pip/uv index URLs and Git global/system
+  configuration locators from ambient standard-mode inheritance.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to this project will be documented in this file. See [conven
   cache referents require one narrow explicit grant.
 - Allow explicit top-level `cargo install` commands to manage their selected
   install root instead of reimplementing Cargo's transaction format.
+- Derive Cargo target/install grants from the resolved effective environment,
+  and report external output symlinks with a copyable narrow approval instead
+  of a later opaque `EACCES`.
 - Stop requiring `--allow-insecure-linux-network` for standard Linux builds;
   inspection and runtime warnings continue to report that domain egress is
   best-effort on Linux.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,9 @@ All notable changes to this project will be documented in this file. See [conven
 - On Landlock ABI v9+, mediate filesystem Unix sockets independently of TCP
   policy and grant resolution only beneath SBE's private per-run root, keeping
   capability brokers such as `docker.sock` outside the standard envelope.
+- Replace validated writable and executable symlink grants with canonical
+  snapshots before launch, so a parallel build cannot retarget the lexical
+  link between policy validation and descriptor opening.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Honor Cargo's explicit `--target-dir` ahead of its environment/config paths
   and Gradle's `gradle.user.home` command-line system property ahead of its
   environment/default home when deriving standard-mode grants.
+- Distinguish Maven's `-fae`, `-ff`, and `-fn` failure-mode flags from attached
+  `-f<project>` relocation syntax.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,9 @@ All notable changes to this project will be documented in this file. See [conven
   inherited `GRADLE_OPTS` while rejecting shell-expanded forms early.
 - Resolve `gradle.user.home` from inherited `JAVA_OPTS` as well, and honor the
   JVM's last-value-wins behavior for repeated command-line system properties.
+- Filter custom Docker credential-directory locators and inject standard-mode
+  localhost proxy bypasses, including Java `http.nonProxyHosts`, so permitted
+  local developer services do not get rejected by SBE's external proxy.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,11 @@ All notable changes to this project will be documented in this file. See [conven
 - Reject built-in readable or executable symlink aliases whose canonical
   referents overlap protected paths, preventing project wrappers from turning
   execute authority into credential reads.
+- Include Gradle's required `.tmp` runtime directory and recognize its attached
+  `-g/path` user-home form when deriving narrow persistent grants.
+- Honor direct Cargo `--config build.target-dir='path'` overrides ahead of the
+  target environment and reject opaque config-file overrides with actionable
+  `--target-dir` guidance.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Preserve explicit execute denials when standard mode infers output grants,
   filter custom AWS shared-credentials paths, and permit ordinary Unix-domain
   build-service IPC in macOS standard mode while keeping strict mode isolated.
+- Grant the effective Gradle user home for standard `gradle`/`gradlew` commands,
+  honoring the command-line option before inherited `GRADLE_USER_HOME` and the
+  conventional `~/.gradle` default.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
+## [sbexec-v0.4.1](https://github.com/tyrchen/sbe/compare/sbexec-v0.4.0..sbexec-v0.4.1) - 2026-08-28
+
+### Usability
+
+- Make the practical `standard` sandbox the default and preserve the 0.4
+  fail-closed boundary behind `--strict`.
+- Let standard builds write the workspace, execute mutable build outputs,
+  inherit non-sensitive build environment variables, and use local developer
+  services while retaining secret-path, descriptor, privilege, and proxy
+  protections.
+- Support globally configured sccache through ordinary executable/cache grants
+  and local IPC; no sccache source or managed adapter is shipped by SBE.
+- Follow pre-existing tool and cache symlinks in standard mode while retaining
+  strict no-follow behavior and protected-path denials.
+- Allow explicit top-level `cargo install` commands to manage their selected
+  install root instead of reimplementing Cargo's transaction format.
+- Stop requiring `--allow-insecure-linux-network` for standard Linux builds;
+  inspection and runtime warnings continue to report that domain egress is
+  best-effort on Linux.
+
+### Security
+
+- Keep strict mode behavior for positive environment allowlisting, persistent
+  W^X, hard-link validation, exact workspace outputs, ambient local-service
+  denial, and fail-closed Linux network capability checks.
+- Keep standard-mode symlink referents subject to protected-path denials and
+  filter high-confidence API-key and cloud-credential environment variables.
+
+---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Follow `PNPM_HOME/store`, require read approval when project Maven JVM config
   relocates `.m2` outside the workspace, and resolve uv project-configured cache
   directories behind the external-write gate.
+- Grant exact read access to effective npm and pip user configuration files so
+  the sandboxed tools consume the same settings used during policy preparation.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,8 +50,9 @@ All notable changes to this project will be documented in this file. See [conven
   snapshots before launch, so a parallel build cannot retarget the lexical
   link between policy validation and descriptor opening.
 - Create unresolved Linux output grants through the launcher's descriptor-bound
-  no-symlink walk, filter Azure Pipelines `SYSTEM_ACCESSTOKEN`, and bound source
-  symlink discovery by entry and depth budgets.
+  no-symlink walk, filter Azure Pipelines `SYSTEM_ACCESSTOKEN` and OIDC token-file
+  variables, and bound Linux source-symlink discovery by entry and depth budgets
+  without scanning macOS workspaces that do not need referent grants.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Filter custom Docker credential-directory locators and inject standard-mode
   localhost proxy bypasses, including Java `http.nonProxyHosts`, so permitted
   local developer services do not get rejected by SBE's external proxy.
+- Resolve missing writable descendants through their nearest existing symlink
+  ancestor, validate the reconstructed target, and snapshot it so approved
+  symlinked cache roots also work on cold builds.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ All notable changes to this project will be documented in this file. See [conven
 - Keep standard-mode symlink referents subject to protected-path denials and
   filter high-confidence API-key, cloud, and database credential environment
   variables, including bare or standardized names such as `TOKEN`, `API_KEY`,
-  `PASSWORD`, `PGPASSWORD`, and `MYSQL_PWD`.
+  `PASSWORD`, `PGPASSWORD`, `MYSQL_PWD`, and npm `_authToken` forms.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Filter Kerberos ticket-cache and keytab locators, and derive Maven's local
   repository from bounded default/selected `settings.xml` reads after all
   higher-precedence command, environment, and project JVM properties.
+- Merge explicitly selected Maven global settings beneath user settings and
+  honor the effective JVM `user.home` for settings and repository defaults.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,8 @@ All notable changes to this project will be documented in this file. See [conven
   paths, and follow pnpm store selection across command/configuration sources.
 - Filter pip/uv custom configuration locators and replace their conventional
   cache grants with command/environment-selected cache directories.
+- Honor command-selected npm user configuration, pip user-config cache paths,
+  and platform-native macOS pip/uv cache locations.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,9 +87,12 @@ All notable changes to this project will be documented in this file. See [conven
   execute authority into credential reads.
 - Include Gradle's required `.tmp` runtime directory and recognize its attached
   `-g/path` user-home form when deriving narrow persistent grants.
-- Honor direct Cargo `--config build.target-dir='path'` overrides ahead of the
-  target environment and reject opaque config-file overrides with actionable
-  `--target-dir` guidance.
+- Honor direct Cargo `--config build.target-dir='path'` overrides when no
+  higher-precedence target CLI/environment selection exists, avoid injecting a
+  fallback that masks the config, and reject opaque config-file overrides with
+  actionable `--target-dir` guidance.
+- Filter Docker client TLS-directory locators and derive Maven's writable local
+  repository from the last `-D`/`--define maven.repo.local` property.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Filter AzureRM client-certificate and OIDC-token file locators, and discover
   Node monorepo roots in standard mode so parent workspace inputs, lockfiles,
   and generated dependencies remain usable from a member package.
+- Pre-create missing Node workspace-root lockfiles on Linux, include that root
+  in bounded linked-dependency discovery, and relocate Cargo registry/Git cache
+  grants beneath the effective `CARGO_HOME` while retaining credential denials.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ All notable changes to this project will be documented in this file. See [conven
 - Treat the selected workspace as readable input in standard mode, including
   `.env*`, so Linux can support general file creation without reimplementing
   each package manager; strict mode retains project secret-file denials.
-- Keep executable output roots installable before Linux Landlock enforcement
-  and let standard sbt builds use their ordinary persistent package caches.
+- Keep executable output roots installable before Linux Landlock enforcement.
+- Let standard sbt builds use persistent boot/dependency caches while keeping
+  the global settings/plugin base private and non-persistent.
 - Support globally configured sccache through ordinary executable/cache grants
   and local IPC; no sccache source or managed adapter is shipped by SBE.
-- Follow pre-existing tool and cache symlinks in standard mode while retaining
-  strict no-follow behavior and protected-path denials.
+- Follow pre-existing tool, cache, and source-tree symlinks in standard mode
+  while retaining strict no-follow behavior and protected-path denials.
 - Allow explicit top-level `cargo install` commands to manage their selected
   install root instead of reimplementing Cargo's transaction format.
 - Stop requiring `--allow-insecure-linux-network` for standard Linux builds;
@@ -34,7 +35,8 @@ All notable changes to this project will be documented in this file. See [conven
   W^X, hard-link validation, exact workspace outputs, ambient local-service
   denial, and fail-closed Linux network capability checks.
 - Keep standard-mode symlink referents subject to protected-path denials and
-  filter high-confidence API-key and cloud-credential environment variables.
+  filter high-confidence API-key and cloud-credential environment variables,
+  including bare names such as `TOKEN`, `API_KEY`, and `PASSWORD`.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Resolve Maven repository overrides from `MAVEN_OPTS` and bounded, no-follow
   project `.mvn/jvm.config` reads, preserving launcher and last-property
   precedence while rejecting ambiguous option forms.
+- Include `MAVEN_ARGS` and bounded project `.mvn/maven.config` in Maven's local
+  repository precedence, and filter Azure client-certificate path locators.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,8 @@ All notable changes to this project will be documented in this file. See [conven
   global/project configured cache, and grant Gradle's selected project cache.
 - Accept both npm global-config environment spellings and resolve cache/store
   paths from the explicitly selected global npmrc after higher-priority layers.
+- Filter Git's environment-backed configuration transports and replace
+  conventional Coursier cache grants with an inherited `COURSIER_CACHE`.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,8 @@ All notable changes to this project will be documented in this file. See [conven
   precedence while rejecting ambiguous option forms.
 - Include `MAVEN_ARGS` and bounded project `.mvn/maven.config` in Maven's local
   repository precedence, and filter Azure client-certificate path locators.
+- Filter custom GitHub CLI credential directories and grant only Cargo's
+  effective target environment path when both target variables are present.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,8 @@ All notable changes to this project will be documented in this file. See [conven
   honor the effective JVM `user.home` for settings and repository defaults.
 - Follow npm's command/environment cache selection, and grant read-only access
   to effective Gradle homes and explicitly selected Maven settings.
+- Resolve project `.npmrc` cache paths behind the external-write gate, and
+  require explicit read approval for project-selected external Maven settings.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ All notable changes to this project will be documented in this file. See [conven
   compatibility grants when the effective network policy denies all traffic.
 - Reject Gradle and Maven project-relocation flags early, with the same
   actionable working-directory guidance used for other package managers.
+- Honor Cargo's explicit `--target-dir` ahead of its environment/config paths
+  and Gradle's `gradle.user.home` command-line system property ahead of its
+  environment/default home when deriving standard-mode grants.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,9 @@ All notable changes to this project will be documented in this file. See [conven
   cache grants with command/environment-selected cache directories.
 - Honor command-selected npm user configuration, pip user-config cache paths,
   and platform-native macOS pip/uv cache locations.
+- Follow `PNPM_HOME/store`, require read approval when project Maven JVM config
+  relocates `.m2` outside the workspace, and resolve uv project-configured cache
+  directories behind the external-write gate.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Filter ECS container-credential endpoint variables, scope Cargo target grants
   to Cargo commands, and resolve unambiguous `gradle.user.home` values from
   inherited `GRADLE_OPTS` while rejecting shell-expanded forms early.
+- Resolve `gradle.user.home` from inherited `JAVA_OPTS` as well, and honor the
+  JVM's last-value-wins behavior for repeated command-line system properties.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -152,6 +152,8 @@ All notable changes to this project will be documented in this file. See [conven
   conventional Coursier cache grants with an inherited `COURSIER_CACHE`.
 - Filter credential-bearing pip/uv index URLs and Git global/system
   configuration locators from ambient standard-mode inheritance.
+- Filter the credential-bearing `UV_INDEX` input and resolve cache directories
+  from explicit, project, and XDG user uv configuration with exact file grants.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Filter GitLab job JWT variables, honor direct Cargo
   `--config install.root='path'` overrides, and reject implicit Cargo-config
   install roots before launch with explicit `--root` guidance.
+- Deny both Cargo credential-file spellings beneath the effective `CARGO_HOME`,
+  including custom and relative locations, without removing ordinary Cargo
+  configuration from the child environment.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,9 @@ All notable changes to this project will be documented in this file. See [conven
   environment/default home when deriving standard-mode grants.
 - Distinguish Maven's `-fae`, `-ff`, and `-fn` failure-mode flags from attached
   `-f<project>` relocation syntax.
+- Filter ECS container-credential endpoint variables, scope Cargo target grants
+  to Cargo commands, and resolve unambiguous `gradle.user.home` values from
+  inherited `GRADLE_OPTS` while rejecting shell-expanded forms early.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@ All notable changes to this project will be documented in this file. See [conven
   effective target environment path when both target variables are present.
 - Require explicit approval when repository-controlled Maven config selects a
   local repository outside the workspace or conventional Maven cache envelope.
+- Filter custom AWS configuration-file locators and inspect direct symlink
+  entries beneath generated dependency roots so warm linked dependencies remain
+  readable without recursively scanning ordinary generated contents.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to this project will be documented in this file. See [conven
   inherit non-sensitive build environment variables, and use local developer
   services while retaining secret-path, descriptor, privilege, and proxy
   protections.
+- Treat the selected workspace as readable input in standard mode, including
+  `.env*`, so Linux can support general file creation without reimplementing
+  each package manager; strict mode retains project secret-file denials.
 - Support globally configured sccache through ordinary executable/cache grants
   and local IPC; no sccache source or managed adapter is shipped by SBE.
 - Follow pre-existing tool and cache symlinks in standard mode while retaining

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,8 @@ All notable changes to this project will be documented in this file. See [conven
   to effective Gradle homes and explicitly selected Maven settings.
 - Resolve project `.npmrc` cache paths behind the external-write gate, and
   require explicit read approval for project-selected external Maven settings.
+- Filter the custom `NETRC` credential locator, resolve npm user-config cache
+  paths, and follow pnpm store selection across command/configuration sources.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ All notable changes to this project will be documented in this file. See [conven
   symlinked cache roots also work on cold builds.
 - Filter custom Google Cloud SDK and Azure CLI configuration directories so
   their credential databases cannot bypass the default secret-path denials.
+- Reject built-in readable or executable symlink aliases whose canonical
+  referents overlap protected paths, preventing project wrappers from turning
+  execute authority into credential reads.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Deny GitHub CLI credentials beneath an inherited `XDG_CONFIG_HOME`, filter
   custom `GNUPGHOME` locators, and reject Cargo manifests that resolve outside
   the selected workspace while retaining in-workspace `--manifest-path` usage.
+- Filter AzureRM client-certificate and OIDC-token file locators, and discover
+  Node monorepo roots in standard mode so parent workspace inputs, lockfiles,
+  and generated dependencies remain usable from a member package.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ All notable changes to this project will be documented in this file. See [conven
   variables, including bare or standardized names such as `TOKEN`, `API_KEY`,
   `PASSWORD`, `PGPASSWORD`, `MYSQL_PWD`, Terraform `TF_TOKEN_*`, and npm
   `_authToken` forms.
+- On Landlock ABI v9+, mediate filesystem Unix sockets independently of TCP
+  policy and grant resolution only beneath SBE's private per-run root, keeping
+  capability brokers such as `docker.sock` outside the standard envelope.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Pre-create missing Node workspace-root lockfiles on Linux, include that root
   in bounded linked-dependency discovery, and relocate Cargo registry/Git cache
   grants beneath the effective `CARGO_HOME` while retaining credential denials.
+- Filter npm's custom `NPM_CONFIG_USERCONFIG` credential-file locator while
+  preserving ordinary npm build configuration variables.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,8 @@ All notable changes to this project will be documented in this file. See [conven
   directories behind the external-write gate.
 - Grant exact read access to effective npm and pip user configuration files so
   the sandboxed tools consume the same settings used during policy preparation.
+- Follow Poetry's command, `POETRY_CACHE_DIR`, and XDG cache selection while
+  removing stale conventional Poetry cache grants.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ All notable changes to this project will be documented in this file. See [conven
 - Deny both Cargo credential-file spellings beneath the effective `CARGO_HOME`,
   including custom and relative locations, without removing ordinary Cargo
   configuration from the child environment.
+- Deny GitHub CLI credentials beneath an inherited `XDG_CONFIG_HOME`, filter
+  custom `GNUPGHOME` locators, and reject Cargo manifests that resolve outside
+  the selected workspace while retaining in-workspace `--manifest-path` usage.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,8 @@ All notable changes to this project will be documented in this file. See [conven
   repository precedence, and filter Azure client-certificate path locators.
 - Filter custom GitHub CLI credential directories and grant only Cargo's
   effective target environment path when both target variables are present.
+- Require explicit approval when repository-controlled Maven config selects a
+  local repository outside the workspace or conventional Maven cache envelope.
 
 ---
 ## [sbexec-v0.4.0](https://github.com/tyrchen/sbe/compare/sbexec-v0.3.3..sbexec-v0.4.0) - 2026-08-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Treat the selected workspace as readable input in standard mode, including
   `.env*`, so Linux can support general file creation without reimplementing
   each package manager; strict mode retains project secret-file denials.
+- Keep executable output roots installable before Linux Landlock enforcement
+  and let standard sbt builds use their ordinary persistent package caches.
 - Support globally configured sccache through ordinary executable/cache grants
   and local IPC; no sccache source or managed adapter is shipped by SBE.
 - Follow pre-existing tool and cache symlinks in standard mode while retaining

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sbe-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "dirs",
  "idna",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "sbe-proxy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "base64",
  "getrandom 0.4.3",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "sbexec"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "apps/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Tyr Chen <tyr.chen@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -45,5 +45,5 @@ getrandom = "0.4.3"
 idna = "1.1.0"
 
 # workspace crates
-sbe-core = { path = "crates/core", version = "0.4.0" }
-sbe-proxy = { path = "crates/proxy", version = "0.4.0" }
+sbe-core = { path = "crates/core", version = "0.4.1" }
+sbe-proxy = { path = "crates/proxy", version = "0.4.1" }

--- a/README.md
+++ b/README.md
@@ -200,12 +200,16 @@ In standard mode the workspace and conventional package caches are writable,
 and expected build/dependency roots are executable. This makes install-then-run
 workflows, sccache, Gradle daemons, virtual environments, and normal incremental
 builds usable in one invocation. Top-level `cargo install` also receives its
-selected install root; the installed binary is not made trustworthy by SBE.
+selected install root from `--root`, `CARGO_INSTALL_ROOT`, a direct
+`--config install.root='path'`, or the Cargo-home default; the installed binary
+is not made trustworthy by SBE. An implicit `[install] root` in Cargo config is
+rejected with `--root` guidance instead of failing later inside the sandbox.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file
-paths are rejected because SBE cannot determine their effective target without
-reimplementing Cargo's layered configuration; use `--target-dir` instead.
+paths are rejected because SBE cannot determine their effective target or
+install root without reimplementing Cargo's layered configuration; use
+`--target-dir` or `--root` instead.
 Without an explicit or inherited override, standard mode selects `$PWD/target`
 instead of trying to reproduce Cargo's layered configuration rules.
 

--- a/README.md
+++ b/README.md
@@ -280,11 +280,18 @@ result tainted. Strict mode keeps the 0.4 W^X and hard-link checks. Toolchains
 such as `~/.rustup` remain non-writable during ordinary builds in both modes.
 
 On Linux, standard grants follow an existing ordinary symlink to its opened
-referent and install the Landlock rule from that descriptor; magic links remain
-rejected. Strict mode retains no-follow resolution except for immutable system
-aliases. Denied paths include their current canonical target. Strict mode also
-retains hard-link alias rejection; standard mode does not recursively scan
-historical caches before every launch.
+referent and install the Landlock rule from that descriptor. Before launch it
+discovers source-tree symlinks outside generated dependency/output directories,
+so a link into an ordinary sibling checkout is readable without granting the
+sibling's parent. Magic links and protected referents remain rejected. Strict
+mode retains no-follow resolution except for immutable system aliases. Denied
+paths include their current canonical target. Strict mode also retains
+hard-link alias rejection; standard mode does not recursively scan historical
+caches before every launch.
+
+For sbt, standard keeps boot, Ivy, and Coursier dependency caches persistent,
+but places the mutable global base in the private per-run directory. This keeps
+`~/.sbt` settings and global-plugin locations from becoming a persistence path.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
 user `.npmrc` similarly select the store. Relative paths are anchored to the
 selected project. An external project-selected cache/store requires explicit
 `--allow-write` approval.
+For uv and pip, command `--cache-dir` overrides `UV_CACHE_DIR` or
+`PIP_CACHE_DIR`, then `XDG_CACHE_HOME` and the conventional cache. The effective
+cache replaces only that tool's default writable grant.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -314,8 +314,9 @@ caches before every launch.
 For sbt, standard keeps boot, Ivy, and Coursier dependency caches persistent,
 but places the mutable global base in the private per-run directory. This keeps
 `~/.sbt` settings and global-plugin locations from becoming a persistence path.
-Maven `-Dmaven.repo.local=path` and `--define` select a replacement for the
-default writable local repository; relative paths are resolved from the project.
+Maven command properties, `MAVEN_OPTS`, and project `.mvn/jvm.config` can select
+a replacement for the default writable local repository; relative paths are
+resolved from the project and ambiguous launcher-option forms are rejected.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -294,7 +294,8 @@ or another declared writable root; an external referent fails with a copyable
 outside generated dependency/output directories, including nested links in an
 external source referent, so a link into an ordinary sibling checkout is
 readable without granting the sibling's parent. Canonical directory identities
-prevent traversal cycles. Magic links and protected referents remain rejected.
+prevent traversal cycles, while entry and depth budgets bound discovery work.
+Magic links and protected referents remain rejected.
 Strict mode retains no-follow resolution except for immutable system aliases.
 Denied paths include their current canonical target. Strict mode also retains
 hard-link alias rejection; standard mode does not recursively scan historical

--- a/README.md
+++ b/README.md
@@ -289,6 +289,8 @@ Standard mode does not hide files inside the selected workspace, including
 carve individual project files breaks general output creation on Linux. Keep
 real credentials outside untrusted workspaces or use `--strict`. Host SSH,
 cloud, package-registry, browser, and keychain credential paths remain denied.
+Cargo credential files remain denied beneath the effective `CARGO_HOME`,
+including a custom or relative location.
 
 Standard mode permits expected persistent write/execute overlap and labels the
 result tainted. Strict mode keeps the 0.4 W^X and hard-link checks. Toolchains

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ is not made trustworthy by SBE. An implicit `[install] root` in Cargo config is
 rejected with `--root` guidance instead of failing later inside the sandbox.
 Registry and Git dependency caches follow the effective `CARGO_HOME`; its two
 credential-file spellings remain denied.
+For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE` and
+replaces the default `~/.npm` write grant; relative cache paths are anchored to
+the selected project.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file
@@ -344,7 +347,9 @@ settings values fail early with `-Dmaven.repo.local` guidance. Explicit
 select a repository. `-Duser.home` in `MAVEN_OPTS` or `.mvn/jvm.config` changes
 both the default user-settings location and Maven's default repository; a
 repository-controlled home or settings selection retains the external-write
-approval gate.
+approval gate. Explicit user/global settings files and an alternate effective
+user `.m2` directory receive read-only grants so Maven can consume the same
+configuration SBE inspected.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -212,17 +212,19 @@ rejected with `--root` guidance instead of failing later inside the sandbox.
 Registry and Git dependency caches follow the effective `CARGO_HOME`; its two
 credential-file spellings remain denied.
 For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE`, then a
-simple project `.npmrc` `cache=path`, user `~/.npmrc`, and the default `~/.npm`.
+simple project `.npmrc` `cache=path`, user `~/.npmrc`, an explicitly selected
+global npmrc, and the default `~/.npm`.
 `--userconfig` or an explicitly restored user-config locator selects that user
 layer. The effective existing user configuration receives an exact read grant
 so npm can consume registry and other settings without exposing its directory.
 An explicitly restored or command-selected global configuration likewise
 receives only an exact file grant.
 For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
-user `.npmrc` similarly select the store. Relative paths are anchored to the
-selected project. Without a store override, `PNPM_HOME/store` precedes the XDG
-and conventional defaults. An external project-selected cache/store requires
-explicit `--allow-write` approval.
+user `.npmrc`, then an explicitly selected global npmrc similarly select the
+store. Relative paths are anchored to the selected project. Without a store
+override, `PNPM_HOME/store` precedes the XDG and conventional defaults. An
+external project-selected cache/store requires explicit `--allow-write`
+approval.
 For uv and pip, command `--cache-dir` overrides `UV_CACHE_DIR` or
 `PIP_CACHE_DIR`. uv then reads project `uv.toml`, or `[tool.uv]` in
 `pyproject.toml` when no `uv.toml` exists; an external project-selected cache

--- a/README.md
+++ b/README.md
@@ -291,7 +291,10 @@ On Linux, standard grants follow an existing ordinary symlink to its opened
 referent and install the Landlock rule from that descriptor. Built-in writable
 cache links must resolve within the workspace, a conventional cache namespace,
 or another declared writable root; an external referent fails with a copyable
-`--allow-write` approval. Before launch SBE discovers source-tree symlinks
+`--allow-write` approval. If the final cache or output directory does not exist,
+SBE resolves its nearest existing ancestor and reconstructs the missing suffix
+beneath the approved referent, so symlinked cache roots work on a cold build.
+Before launch SBE discovers source-tree symlinks
 outside generated dependency/output directories, including nested links in an
 external source referent, so a link into an ordinary sibling checkout is
 readable without granting the sibling's parent. Canonical directory identities

--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ caches before every launch.
 For sbt, standard keeps boot, Ivy, and Coursier dependency caches persistent,
 but places the mutable global base in the private per-run directory. This keeps
 `~/.sbt` settings and global-plugin locations from becoming a persistence path.
-Maven command properties, `MAVEN_OPTS`, and project `.mvn/jvm.config` can select
-a replacement for the default writable local repository; relative paths are
-resolved from the project and ambiguous launcher-option forms are rejected.
+Maven command properties, `MAVEN_ARGS`, project `.mvn/maven.config`,
+`MAVEN_OPTS`, and project `.mvn/jvm.config` can select a replacement for the
+default writable local repository. SBE follows Maven's source precedence,
+resolves relative paths from the project, and rejects ambiguous option forms.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -5,12 +5,11 @@ process, and network policy. SBE supports macOS Seatbelt/SBPL and Linux
 Landlock plus seccomp.
 
 ```bash
-# macOS: strict domain-filtered proxy mode
+# Standard mode: practical containment for everyday builds
 sbe run -- cargo build
 
-# Linux: the current kernel can only enforce the proxy destination port.
-# This explicit compatibility option acknowledges that limitation.
-sbe run --allow-insecure-linux-network -- cargo build
+# Strict mode: retain the fail-closed 0.4 security boundary
+sbe run --strict -- cargo build
 ```
 
 SBE is designed for repositories, dependencies, build scripts, compiler
@@ -19,26 +18,32 @@ SBE executable remain trusted.
 
 ## Security boundary
 
-SBE 0.4 fails closed when a requested guarantee cannot be enforced.
+SBE 0.4.1 defaults to a practical `standard` mode so ordinary build tools,
+compiler wrappers, mutable outputs, and local developer services work without
+broad escape flags. `--strict` retains the fail-closed 0.4 boundary for offline
+or explicitly provisioned high-assurance builds.
 
 | Capability | macOS | Linux |
 |---|---|---|
 | Filesystem writes | SBPL allowlist | Landlock allowlist |
 | Secret-path reads | SBPL deny rules | Descriptor-based read rules with denied descendants carved out |
 | Executable paths | SBPL allow/deny rules | Landlock allowlist; broad privilege-bearing directories are rejected |
-| Ambient environment | Cleared, then rebuilt from a small positive allowlist | Same |
+| Ambient environment | Sensitive/capability variables removed in standard mode; positive allowlist under `--strict` | Same |
 | Ambient file descriptors | `CLOEXEC` before target exec | `close_range(CLOEXEC)` with bounded fallback |
-| Domain-filtered HTTPS | Enforced through the exact authenticated proxy port | Not currently enforceable; strict mode refuses to run |
-| Restricted TCP/UDP | SBPL network policy | Landlock TCP plus seccomp Internet datagram/raw-socket rules |
-| Same-user signals and Unix sockets | SBPL signal/network rules | Landlock ABI v6 signal and abstract-socket scopes; ABI v9 pathname-socket mediation |
-| Persistent W^X | Validated before launch | Validated before launch, including existing symlink aliases |
+| Domain-filtered HTTPS | Enforced through the authenticated proxy; standard mode also permits localhost tooling | Best-effort in standard mode; strict domain mode refuses to run |
+| Restricted TCP/UDP | External traffic remains proxy-mediated | Best-effort in standard mode; Landlock/seccomp restrictions under `--strict` |
+| Same-user signals and Unix sockets | Local services allowed in standard mode; narrow under `--strict` | Signals scoped on ABI v6+; local services allowed in standard mode |
+| Persistent W^X | Allowed and tainted in standard mode; validated under `--strict` | Same |
 | Private temporary storage | Per-run root; other shared temp roots denied | Per-run root; other temp paths omitted from Landlock grants |
 | Violation audit stream | Reported unavailable unless a correlatable source exists | Reported unavailable until kernel-domain correlation is verifiable |
 
 Important Linux distinction: Landlock ABI v4 can authorize a destination
 **port**, not a destination IP address. A malicious process that knows the
 proxy's random port can connect to a different host listening on that port.
-SBE therefore does not call this domain confinement. A proxy profile either:
+SBE therefore does not describe Linux standard networking as domain-confined.
+Standard mode keeps the filesystem, environment, descriptor, privilege, and
+proxy protections active and reports the limitation. A strict proxy profile
+either:
 
 - refuses by default; or
 - runs only after `--allow-insecure-linux-network`, with a warning explaining
@@ -54,7 +59,7 @@ Unix-socket mediation requires ABI v9.
 `--allow-all-network` remains an explicit request to remove network isolation.
 `--no-proxy` selects direct-TCP-443 compatibility mode and is never described
 as domain-filtered. On Linux it also permits Internet datagram sockets so libc
-can resolve DNS; use proxy mode when UDP egress must remain blocked.
+can resolve DNS. Only strict proxy mode blocks Internet datagram sockets.
 
 See the [security hardening design](specs/security-hardening-design.md) for the
 threat model, findings, and adversarial verification plan.
@@ -85,7 +90,7 @@ No exact Rust patch version is pinned. CI installs `stable`.
 Release 0.4.0 and newer publishes SHA-256 checksums, an SPDX SBOM, and GitHub
 build-provenance attestations. The composite action verifies both the checksum
 and the attestation before installing the binary. The action defaults to the
-audited `0.4.0` release; pass `version: latest` only when intentionally opting
+audited `0.4.1` release; pass `version: latest` only when intentionally opting
 into automatic release upgrades.
 
 ```yaml
@@ -94,11 +99,11 @@ permissions:
 
 steps:
   - uses: actions/checkout@<full-commit-sha>
-  - uses: tyrchen/sbe@sbexec-v0.4.0
+  - uses: tyrchen/sbe@sbexec-v0.4.1
     with:
-      version: '0.4.0'
+      version: '0.4.1'
   - run: sbe --version
-  - run: sbe run --allow-insecure-linux-network -- cargo build
+  - run: sbe run -- cargo build
 ```
 
 For high-assurance workflows, replace the SBE release tag in `uses:` with the
@@ -106,8 +111,8 @@ full commit SHA belonging to that tag. Supported release targets are
 `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`, and
 `aarch64-apple-darwin`.
 
-The action accepts `0.4.0`, `v0.4.0`, or `sbexec-v0.4.0` and reports the
-resolved `sbexec-v0.4.0` tag through its `version` output. Releases older than
+The action accepts `0.4.1`, `v0.4.1`, or `sbexec-v0.4.1` and reports the
+resolved `sbexec-v0.4.1` tag through its `version` output. Releases older than
 0.4.0 are rejected because they do not provide the required checksum and
 provenance artifacts.
 
@@ -118,8 +123,8 @@ provenance artifacts.
 sbe run -- npm install
 sbe run -- cargo build
 
-# Linux proxy compatibility (required for current networked defaults)
-sbe run --allow-insecure-linux-network -- npm install
+# Opt into the high-assurance boundary for an offline build
+sbe run --strict -- cargo build --offline
 
 # Explicit profile
 sbe run --profile python -- uv build
@@ -140,10 +145,10 @@ sbe profiles
 
 ### Environment grants
 
-The child does not inherit the complete parent environment. SBE keeps only a
-small CLI baseline such as `PATH`, `HOME`, locale, terminal, and selected tool
-home variables. Credential variables and agent sockets are absent unless the
-user grants them explicitly:
+Standard mode inherits ordinary build configuration such as `RUSTFLAGS`,
+`CFLAGS`, and feature switches, while removing high-confidence credential,
+agent, dynamic-loader, and SBE-reserved variables. Strict mode keeps only a
+small positive baseline. Removed values can be granted explicitly:
 
 ```bash
 sbe run --keep-env MY_REQUIRED_TOKEN -- cargo build
@@ -154,14 +159,15 @@ Proxy, temporary-directory, and SBE-controlled build-output variables are
 reserved and cannot be replaced through configuration or CLI flags. `inspect`
 prints effective variable names and origins, but all values are redacted.
 
-On current stable Cargo, SBE keeps final Rust artifacts in `$PWD/target` while
+Under `--strict`, SBE keeps final Rust artifacts in `$PWD/target` while
 placing intermediate artifacts and executable build scripts in the private
 per-run tree through `CARGO_BUILD_BUILD_DIR`. This preserves persistent W^X
 without discarding the final build output. Commands that execute target
 artifacts—including `cargo test`, `cargo run`, and `cargo nextest`—instead use
 the private executable `CARGO_TARGET_DIR`.
 
-Node dependency installation keeps `node_modules` writable but non-executable.
+In strict mode, Node dependency installation keeps `node_modules` writable but
+non-executable.
 Commands that explicitly run already-installed tools, such as `npm test`,
 `npm exec`, `npx`, and corresponding Yarn/pnpm/Bun forms, switch the built-in
 dependency-tree grant to read/execute and remove its write grant for that
@@ -180,17 +186,29 @@ that relocate the project
 forms) are rejected before policy preparation; change directory before running
 SBE instead.
 
-Python installation and synchronization commands similarly keep project
+Strict Python installation and synchronization commands similarly keep project
 `.venv`/`venv` directories writable but non-executable. Run/test commands,
 including `uv run`, `poetry run`, activated entry points, and direct
 `.venv/bin/...` paths, switch those built-in grants to read/execute without
 write. This mode is for an already-installed environment; synchronize it in a
 separate invocation before running tools.
 
+In standard mode the workspace and conventional package caches are writable,
+and expected build/dependency roots are executable. This makes install-then-run
+workflows, sccache, Gradle daemons, virtual environments, and normal incremental
+builds usable in one invocation. Top-level `cargo install` also receives its
+selected install root; the installed binary is not made trustworthy by SBE.
+An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
+or granted explicitly with matching `--allow-write` and `--allow-exec` paths.
+Without that inherited variable, standard mode selects `$PWD/target` instead of
+trying to reproduce Cargo's layered configuration rules.
+
 Persistent outputs and package caches are still attacker-controlled data after
-an untrusted build. W^X prevents direct execution during that invocation; it
-does not make generated binaries, scripts, dynamic libraries, or interpreted
-packages trustworthy. Review or discard them before running them outside SBE.
+an untrusted build. Strict W^X prevents direct execution during that invocation;
+standard mode deliberately allows expected mutable build outputs to execute.
+Neither mode makes generated binaries, scripts, dynamic libraries, or
+interpreted packages trustworthy. Review or discard them before running them
+outside SBE.
 
 Stdin, stdout, and stderr are intentional capabilities. For example,
 `sbe run -- tool < secret.txt` explicitly gives that file's contents to the
@@ -244,28 +262,23 @@ project, explicit-file, CLI, parent-environment, or runtime origin.
 
 ## Filesystem and process policy
 
-Built-in profiles grant specific outputs and lockfiles rather than the entire
-working tree. Source, `.git`, workflow definitions, manifests, and SBE policy
-remain non-writable unless explicitly granted. Shared system temporary roots
-are not writable; every invocation gets a canonical private root used for
-`TMPDIR`, `TMP`, `TEMP`, and `XDG_RUNTIME_DIR`.
+Standard profiles grant the working tree and conventional tool data so package
+managers can evolve without SBE reimplementing their command grammars. Strict
+profiles retain exact output/lockfile grants and source immutability. Shared
+system temporary roots are not granted broadly; every invocation gets a
+canonical private root used for `TMPDIR`, `TMP`, `TEMP`, and
+`XDG_RUNTIME_DIR`.
 
-Persistent write and execute grants may not overlap. The only default W+X
-exception is the private per-run root, which is deleted when the invocation
-finishes. Toolchains such as `~/.rustup` are executable/readable but not
-writable. Mutable caches are readable/writable but not executable. Before
-launch, SBE also rejects a writable regular file unless all of its hard-link
-pathnames are contained in writable roots. This prevents a writable cache
-alias from mutating executable tools, source, workflows, or any other protected
-path. Hard links wholly contained in writable roots remain valid.
+Standard mode permits expected persistent write/execute overlap and labels the
+result tainted. Strict mode keeps the 0.4 W^X and hard-link checks. Toolchains
+such as `~/.rustup` remain non-writable during ordinary builds in both modes.
 
-On Linux, paths are opened with descriptor-relative `openat2` resolution using
-`RESOLVE_BENEATH`, `RESOLVE_NO_SYMLINKS`, and
-`RESOLVE_NO_MAGICLINKS`. Writable directories are created component by
-component with directory FDs. Root-owned immutable distribution symlinks are
-the only symlink exception. Because Landlock authorizes inodes rather than
-pathnames, SBE fails closed if a denied regular file—or a file below a denied
-directory—has multiple hard links.
+On Linux, standard grants follow an existing ordinary symlink to its opened
+referent and install the Landlock rule from that descriptor; magic links remain
+rejected. Strict mode retains no-follow resolution except for immutable system
+aliases. Denied paths include their current canonical target. Strict mode also
+retains hard-link alias rejection; standard mode does not recursively scan
+historical caches before every launch.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory
@@ -325,12 +338,14 @@ target itself returning exit code 126.
 
 ## Limitations
 
-- Linux has no strict domain-egress backend yet. The explicit port-only mode is
-  bypassable and should be combined with a network namespace, firewall, or
-  trusted CI egress controls when the repository may be malicious.
-- On Linux kernels before Landlock ABI v4, restricted TCP modes refuse unless
-  the same insecure compatibility option is supplied; in that case TCP
-  confinement is unavailable and SBE says so.
+- Linux has no strict domain-egress backend yet. Standard mode permits local
+  developer services and cannot force hostile TCP through the proxy. Use
+  strict offline mode or combine SBE with a network namespace/firewall in
+  hostile CI.
+- On Linux kernels before Landlock ABI v4, strict restricted TCP modes refuse
+  unless the insecure compatibility option is supplied; in that case TCP
+  confinement is unavailable and SBE says so. Standard mode already reports
+  network restriction as best-effort.
 - Path-based Unix-socket mediation depends on newer Landlock ABIs. Local IPC is
   a separate capability from Internet egress.
 - macOS retains an allow-most/read-deny model for compatibility. The curated
@@ -359,7 +374,8 @@ Run `sbe run --help` and `sbe inspect --help` for the complete current
 reference. Security-relevant options include:
 
 ```text
---allow-insecure-linux-network  Explicit port-only Linux compatibility
+--allow-insecure-linux-network  Strict port-only Linux compatibility
+--strict                        Require the fail-closed 0.4 boundary
 --allow-all-network             Remove network confinement
 --no-proxy                      Direct-TCP-443 compatibility
 --trust-project-config          Let auto-discovered project policy add grants

--- a/README.md
+++ b/README.md
@@ -213,13 +213,17 @@ Registry and Git dependency caches follow the effective `CARGO_HOME`; its two
 credential-file spellings remain denied.
 For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE`, then a
 simple project `.npmrc` `cache=path`, user `~/.npmrc`, and the default `~/.npm`.
+`--userconfig` or an explicitly restored user-config locator selects that user
+layer and receives an exact read grant.
 For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
 user `.npmrc` similarly select the store. Relative paths are anchored to the
 selected project. An external project-selected cache/store requires explicit
 `--allow-write` approval.
 For uv and pip, command `--cache-dir` overrides `UV_CACHE_DIR` or
 `PIP_CACHE_DIR`, then `XDG_CACHE_HOME` and the conventional cache. The effective
-cache replaces only that tool's default writable grant.
+cache replaces only that tool's default writable grant. pip also reads its
+legacy/current user configuration for `cache-dir`. Without overrides, macOS
+uses `~/Library/Caches/{pip,uv}` and Linux uses the XDG cache home.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -181,8 +181,10 @@ Classic Yarn and the `node-modules` linker remain lockfile-only. Mutating Bun
 commands receive only their own `bun.lock` output, plus `yarn.lock` when Bun's
 `--yarn` compatibility output is requested. SBE walks bounded, no-follow
 workspace metadata up to the Git boundary, including workspace roots between
-the current directory and repository root, and grants/pre-creates outputs at
-exactly one active Node workspace root. `npm --no-package-lock` and
+the current directory and repository root. Standard mode reads the discovered
+Node workspace root and grants executable generated dependency roots, while
+writes remain scoped to the active root's lockfile and dependency outputs.
+`npm --no-package-lock` and
 `--package-lock=false` never create an empty lockfile. Package-manager options
 that relocate the project
 (`--prefix`, `--cwd`, `--dir`, `--directory`, `--project`, and equivalent short

--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Maven command properties, `MAVEN_ARGS`, project `.mvn/maven.config`,
 `MAVEN_OPTS`, and project `.mvn/jvm.config` can select a replacement for the
 default writable local repository. SBE follows Maven's source precedence,
 resolves relative paths from the project, and rejects ambiguous option forms.
+Repository-controlled Maven config can select an external local repository only
+when that target is explicitly approved with `--allow-write`.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -186,8 +186,9 @@ exactly one active Node workspace root. `npm --no-package-lock` and
 `--package-lock=false` never create an empty lockfile. Package-manager options
 that relocate the project
 (`--prefix`, `--cwd`, `--dir`, `--directory`, `--project`, and equivalent short
-forms) are rejected before policy preparation; change directory before running
-SBE instead.
+forms) are rejected before policy preparation. Cargo `--manifest-path` remains
+supported inside the selected workspace but rejects an external manifest;
+change directory before running SBE instead.
 
 Strict Python installation and synchronization commands similarly keep project
 `.venv`/`venv` directories writable but non-executable. Run/test commands,
@@ -281,8 +282,9 @@ canonical private root used for `TMPDIR`, `TMP`, `TEMP`, and
 
 Workspace grants are anchored to the launch directory. Package-manager project
 relocation options such as npm `--prefix`, Cargo `-C`, Gradle `--project-dir`,
-or Maven `--file` fail early with an actionable error in both modes; change
-directory before invoking SBE.
+or Maven `--file`, plus Cargo manifests outside the selected workspace, fail
+early with an actionable error in both modes; change directory before invoking
+SBE.
 
 Standard mode does not hide files inside the selected workspace, including
 `.env*`; dependencies already run with the repository as input, and trying to

--- a/README.md
+++ b/README.md
@@ -212,9 +212,11 @@ rejected with `--root` guidance instead of failing later inside the sandbox.
 Registry and Git dependency caches follow the effective `CARGO_HOME`; its two
 credential-file spellings remain denied.
 For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE`, then a
-simple project `.npmrc` `cache=path`, and replaces the default `~/.npm` write
-grant; relative cache paths are anchored to the selected project. An external
-project-selected cache requires explicit `--allow-write` approval.
+simple project `.npmrc` `cache=path`, user `~/.npmrc`, and the default `~/.npm`.
+For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
+user `.npmrc` similarly select the store. Relative paths are anchored to the
+selected project. An external project-selected cache/store requires explicit
+`--allow-write` approval.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -339,7 +339,12 @@ when that target is explicitly approved with `--allow-write`.
 When no property overrides it, SBE also reads a bounded default user
 `~/.m2/settings.xml` or settings selected by command, `MAVEN_ARGS`, or
 `.mvn/maven.config`, and resolves a simple `<localRepository>` value. Ambiguous
-settings values fail early with `-Dmaven.repo.local` guidance.
+settings values fail early with `-Dmaven.repo.local` guidance. Explicit
+`-gs`/`--global-settings` files provide the fallback when user settings do not
+select a repository. `-Duser.home` in `MAVEN_OPTS` or `.mvn/jvm.config` changes
+both the default user-settings location and Maven's default repository; a
+repository-controlled home or settings selection retains the external-write
+approval gate.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -202,9 +202,12 @@ workflows, sccache, Gradle daemons, virtual environments, and normal incremental
 builds usable in one invocation. Top-level `cargo install` also receives its
 selected install root; the installed binary is not made trustworthy by SBE.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
-or granted explicitly with matching `--allow-write` and `--allow-exec` paths.
-Without that inherited variable, standard mode selects `$PWD/target` instead of
-trying to reproduce Cargo's layered configuration rules.
+or a direct `--config build.target-dir='path'` override, or granted explicitly
+with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file
+paths are rejected because SBE cannot determine their effective target without
+reimplementing Cargo's layered configuration; use `--target-dir` instead.
+Without an explicit or inherited override, standard mode selects `$PWD/target`
+instead of trying to reproduce Cargo's layered configuration rules.
 
 Persistent outputs and package caches are still attacker-controlled data after
 an untrusted build. Strict W^X prevents direct execution during that invocation;

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ sbe profiles
 
 Standard mode inherits ordinary build configuration such as `RUSTFLAGS`,
 `CFLAGS`, and feature switches, while removing high-confidence credential,
-agent, dynamic-loader, and SBE-reserved variables. Strict mode keeps only a
-small positive baseline. Removed values can be granted explicitly:
+OIDC token-file, agent, dynamic-loader, and SBE-reserved variables. Strict mode
+keeps only a small positive baseline. Removed values can be granted explicitly:
 
 ```bash
 sbe run --keep-env MY_REQUIRED_TOKEN -- cargo build

--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ is not made trustworthy by SBE. An implicit `[install] root` in Cargo config is
 rejected with `--root` guidance instead of failing later inside the sandbox.
 Registry and Git dependency caches follow the effective `CARGO_HOME`; its two
 credential-file spellings remain denied.
-For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE` and
-replaces the default `~/.npm` write grant; relative cache paths are anchored to
-the selected project.
+For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE`, then a
+simple project `.npmrc` `cache=path`, and replaces the default `~/.npm` write
+grant; relative cache paths are anchored to the selected project. An external
+project-selected cache requires explicit `--allow-write` approval.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file
@@ -349,7 +350,9 @@ both the default user-settings location and Maven's default repository; a
 repository-controlled home or settings selection retains the external-write
 approval gate. Explicit user/global settings files and an alternate effective
 user `.m2` directory receive read-only grants so Maven can consume the same
-configuration SBE inspected.
+configuration SBE inspected. A project-selected external settings file requires
+explicit `--allow-read` approval; actual command and host-environment settings
+selections remain direct user intent.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory
@@ -454,6 +457,7 @@ reference. Security-relevant options include:
 --keep-env NAME                 Preserve one parent variable
 --env NAME=VALUE                Add one explicit variable
 --allow-write PATH              Add a writable path
+--allow-read PATH               Add a readable path; secret denials still win
 --deny-read PATH                Add a protected read path
 --allow-exec PATH               Add an executable path
 --allow-fetch DOMAIN            Add downloader execution and proxy destination

--- a/README.md
+++ b/README.md
@@ -297,11 +297,13 @@ or another declared writable root; an external referent fails with a copyable
 `--allow-write` approval. If the final cache or output directory does not exist,
 SBE resolves its nearest existing ancestor and reconstructs the missing suffix
 beneath the approved referent, so symlinked cache roots work on a cold build.
-Before launch SBE discovers source-tree symlinks
-outside generated dependency/output directories, including nested links in an
-external source referent, so a link into an ordinary sibling checkout is
-readable without granting the sibling's parent. Canonical directory identities
-prevent traversal cycles, while entry and depth budgets bound discovery work.
+Before launch SBE discovers source-tree symlinks, including direct linked
+dependency entries beneath generated roots such as `node_modules` and nested
+links in an external source referent, so a link into an ordinary sibling
+checkout is readable without granting the sibling's parent. Generated roots
+receive only a shallow symlink-entry check; their ordinary contents are not
+recursively scanned. Canonical directory identities prevent traversal cycles,
+while entry and depth budgets bound discovery work.
 Magic links and protected referents remain rejected.
 This validation also applies to built-in readable and executable entries such
 as project-local `gradlew` and `mvnw`; a wrapper symlink cannot turn an execute

--- a/README.md
+++ b/README.md
@@ -273,8 +273,9 @@ canonical private root used for `TMPDIR`, `TMP`, `TEMP`, and
 `XDG_RUNTIME_DIR`.
 
 Workspace grants are anchored to the launch directory. Package-manager project
-relocation options such as npm `--prefix` or Cargo `-C` fail early with an
-actionable error in both modes; change directory before invoking SBE.
+relocation options such as npm `--prefix`, Cargo `-C`, Gradle `--project-dir`,
+or Maven `--file` fail early with an actionable error in both modes; change
+directory before invoking SBE.
 
 Standard mode does not hide files inside the selected workspace, including
 `.env*`; dependencies already run with the repository as input, and trying to

--- a/README.md
+++ b/README.md
@@ -284,14 +284,16 @@ result tainted. Strict mode keeps the 0.4 W^X and hard-link checks. Toolchains
 such as `~/.rustup` remain non-writable during ordinary builds in both modes.
 
 On Linux, standard grants follow an existing ordinary symlink to its opened
-referent and install the Landlock rule from that descriptor. Before launch it
-discovers source-tree symlinks outside generated dependency/output directories,
-including nested links in an external source referent, so a link into an
-ordinary sibling checkout is readable without granting the sibling's parent.
-Canonical directory identities prevent traversal cycles. Magic links and
-protected referents remain rejected. Strict
-mode retains no-follow resolution except for immutable system aliases. Denied
-paths include their current canonical target. Strict mode also retains
+referent and install the Landlock rule from that descriptor. Built-in writable
+cache links must resolve within the workspace, a conventional cache namespace,
+or another declared writable root; an external referent fails with a copyable
+`--allow-write` approval. Before launch SBE discovers source-tree symlinks
+outside generated dependency/output directories, including nested links in an
+external source referent, so a link into an ordinary sibling checkout is
+readable without granting the sibling's parent. Canonical directory identities
+prevent traversal cycles. Magic links and protected referents remain rejected.
+Strict mode retains no-follow resolution except for immutable system aliases.
+Denied paths include their current canonical target. Strict mode also retains
 hard-link alias rejection; standard mode does not recursively scan historical
 caches before every launch.
 

--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ workspace metadata up to the Git boundary, including workspace roots between
 the current directory and repository root. Standard mode reads the discovered
 Node workspace root and grants executable generated dependency roots, while
 writes remain scoped to the active root's lockfile and dependency outputs.
+Linux pre-creates a selected missing root lockfile before Landlock enforcement
+and scans root-level linked dependencies with the same bounded symlink walk.
 `npm --no-package-lock` and
 `--package-lock=false` never create an empty lockfile. Package-manager options
 that relocate the project
@@ -207,6 +209,8 @@ selected install root from `--root`, `CARGO_INSTALL_ROOT`, a direct
 `--config install.root='path'`, or the Cargo-home default; the installed binary
 is not made trustworthy by SBE. An implicit `[install] root` in Cargo config is
 rejected with `--root` guidance instead of failing later inside the sandbox.
+Registry and Git dependency caches follow the effective `CARGO_HOME`; its two
+credential-file spellings remain denied.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ or explicitly provisioned high-assurance builds.
 | Capability | macOS | Linux |
 |---|---|---|
 | Filesystem writes | SBPL allowlist | Landlock allowlist |
-| Secret-path reads | SBPL deny rules | Descriptor-based read rules with denied descendants carved out |
+| Host credential reads | SBPL deny rules | Descriptor-based read rules with denied descendants carved out |
 | Executable paths | SBPL allow/deny rules | Landlock allowlist; broad privilege-bearing directories are rejected |
 | Ambient environment | Sensitive/capability variables removed in standard mode; positive allowlist under `--strict` | Same |
 | Ambient file descriptors | `CLOEXEC` before target exec | `close_range(CLOEXEC)` with bounded fallback |
@@ -268,6 +268,12 @@ profiles retain exact output/lockfile grants and source immutability. Shared
 system temporary roots are not granted broadly; every invocation gets a
 canonical private root used for `TMPDIR`, `TMP`, `TEMP`, and
 `XDG_RUNTIME_DIR`.
+
+Standard mode does not hide files inside the selected workspace, including
+`.env*`; dependencies already run with the repository as input, and trying to
+carve individual project files breaks general output creation on Linux. Keep
+real credentials outside untrusted workspaces or use `--strict`. Host SSH,
+cloud, package-registry, browser, and keychain credential paths remain denied.
 
 Standard mode permits expected persistent write/execute overlap and labels the
 result tainted. Strict mode keeps the 0.4 W^X and hard-link checks. Toolchains

--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ credential-file spellings remain denied.
 For npm/npx, a command `--cache` selection overrides `NPM_CONFIG_CACHE`, then a
 simple project `.npmrc` `cache=path`, user `~/.npmrc`, and the default `~/.npm`.
 `--userconfig` or an explicitly restored user-config locator selects that user
-layer and receives an exact read grant.
+layer. The effective existing user configuration receives an exact read grant
+so npm can consume registry and other settings without exposing its directory.
 For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
 user `.npmrc` similarly select the store. Relative paths are anchored to the
 selected project. Without a store override, `PNPM_HOME/store` precedes the XDG
@@ -224,7 +225,8 @@ For uv and pip, command `--cache-dir` overrides `UV_CACHE_DIR` or
 `PIP_CACHE_DIR`. uv then reads project `uv.toml`, or `[tool.uv]` in
 `pyproject.toml` when no `uv.toml` exists; an external project-selected cache
 requires explicit `--allow-write` approval. pip reads its legacy/current user
-configuration for `cache-dir`. The XDG or conventional platform cache is the
+configuration for `cache-dir`; each effective existing user configuration file
+receives an exact read grant. The XDG or conventional platform cache is the
 final fallback, and the effective cache replaces only that tool's default
 writable grant. Without overrides, macOS uses `~/Library/Caches/{pip,uv}` and
 Linux uses the XDG cache home.

--- a/README.md
+++ b/README.md
@@ -336,6 +336,10 @@ default writable local repository. SBE follows Maven's source precedence,
 resolves relative paths from the project, and rejects ambiguous option forms.
 Repository-controlled Maven config can select an external local repository only
 when that target is explicitly approved with `--allow-write`.
+When no property overrides it, SBE also reads a bounded default user
+`~/.m2/settings.xml` or settings selected by command, `MAVEN_ARGS`, or
+`.mvn/maven.config`, and resolves a simple `<localRepository>` value. Ambiguous
+settings values fail early with `-Dmaven.repo.local` guidance.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -314,6 +314,8 @@ caches before every launch.
 For sbt, standard keeps boot, Ivy, and Coursier dependency caches persistent,
 but places the mutable global base in the private per-run directory. This keeps
 `~/.sbt` settings and global-plugin locations from becoming a persistence path.
+Maven `-Dmaven.repo.local=path` and `--define` select a replacement for the
+default writable local repository; relative paths are resolved from the project.
 
 On macOS, secret read denials include both the configured pathname and its
 canonical target. A symlinked `~/.ssh`, `.aws`, or similar protected directory

--- a/README.md
+++ b/README.md
@@ -282,8 +282,10 @@ such as `~/.rustup` remain non-writable during ordinary builds in both modes.
 On Linux, standard grants follow an existing ordinary symlink to its opened
 referent and install the Landlock rule from that descriptor. Before launch it
 discovers source-tree symlinks outside generated dependency/output directories,
-so a link into an ordinary sibling checkout is readable without granting the
-sibling's parent. Magic links and protected referents remain rejected. Strict
+including nested links in an external source referent, so a link into an
+ordinary sibling checkout is readable without granting the sibling's parent.
+Canonical directory identities prevent traversal cycles. Magic links and
+protected referents remain rejected. Strict
 mode retains no-follow resolution except for immutable system aliases. Denied
 paths include their current canonical target. Strict mode also retains
 hard-link alias rejection; standard mode does not recursively scan historical

--- a/README.md
+++ b/README.md
@@ -227,13 +227,15 @@ external project-selected cache/store requires explicit `--allow-write`
 approval.
 For uv and pip, command `--cache-dir` overrides `UV_CACHE_DIR` or
 `PIP_CACHE_DIR`. uv then reads project `uv.toml`, or `[tool.uv]` in
-`pyproject.toml` when no `uv.toml` exists; an external project-selected cache
-requires explicit `--allow-write` approval. pip reads its legacy/current user
-configuration for `cache-dir`; each effective existing user configuration file
-receives an exact read grant. The XDG or conventional platform cache is the
-final fallback, and the effective cache replaces only that tool's default
-writable grant. Without overrides, macOS uses `~/Library/Caches/{pip,uv}` and
-Linux uses the XDG cache home.
+`pyproject.toml` when no `uv.toml` exists, followed by its XDG user `uv.toml`.
+An explicit `--config-file` or restored `UV_CONFIG_FILE` replaces discovery.
+Selected user/explicit files receive exact read grants; an external
+project-selected cache requires explicit `--allow-write` approval. pip reads
+its legacy/current user configuration for `cache-dir`; each effective existing
+user configuration file receives an exact read grant. The XDG or conventional
+platform cache is the final fallback, and the effective cache replaces only
+that tool's default writable grant. Without overrides, macOS uses
+`~/Library/Caches/{pip,uv}` and Linux uses the XDG cache home.
 Poetry similarly follows command `--cache-dir`, `POETRY_CACHE_DIR`, project
 `poetry.toml`, global `config.toml`, then `XDG_CACHE_HOME`. Its effective global
 configuration receives an exact read grant, while an external project-selected

--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ receives an exact read grant. The XDG or conventional platform cache is the
 final fallback, and the effective cache replaces only that tool's default
 writable grant. Without overrides, macOS uses `~/Library/Caches/{pip,uv}` and
 Linux uses the XDG cache home.
+Poetry similarly follows command `--cache-dir`, `POETRY_CACHE_DIR`, then
+`XDG_CACHE_HOME`; the selected `pypoetry` cache replaces both conventional
+macOS-compatible cache grants.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -216,6 +216,8 @@ simple project `.npmrc` `cache=path`, user `~/.npmrc`, and the default `~/.npm`.
 `--userconfig` or an explicitly restored user-config locator selects that user
 layer. The effective existing user configuration receives an exact read grant
 so npm can consume registry and other settings without exposing its directory.
+An explicitly restored or command-selected global configuration likewise
+receives only an exact file grant.
 For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
 user `.npmrc` similarly select the store. Relative paths are anchored to the
 selected project. Without a store override, `PNPM_HOME/store` precedes the XDG
@@ -230,9 +232,11 @@ receives an exact read grant. The XDG or conventional platform cache is the
 final fallback, and the effective cache replaces only that tool's default
 writable grant. Without overrides, macOS uses `~/Library/Caches/{pip,uv}` and
 Linux uses the XDG cache home.
-Poetry similarly follows command `--cache-dir`, `POETRY_CACHE_DIR`, then
-`XDG_CACHE_HOME`; the selected `pypoetry` cache replaces both conventional
-macOS-compatible cache grants.
+Poetry similarly follows command `--cache-dir`, `POETRY_CACHE_DIR`, project
+`poetry.toml`, global `config.toml`, then `XDG_CACHE_HOME`. Its effective global
+configuration receives an exact read grant, while an external project-selected
+cache requires `--allow-write`. The selected `pypoetry` cache replaces both
+conventional macOS-compatible cache grants.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -217,13 +217,17 @@ simple project `.npmrc` `cache=path`, user `~/.npmrc`, and the default `~/.npm`.
 layer and receives an exact read grant.
 For pnpm, `--store-dir`, its configuration environment, project `.npmrc`, and
 user `.npmrc` similarly select the store. Relative paths are anchored to the
-selected project. An external project-selected cache/store requires explicit
-`--allow-write` approval.
+selected project. Without a store override, `PNPM_HOME/store` precedes the XDG
+and conventional defaults. An external project-selected cache/store requires
+explicit `--allow-write` approval.
 For uv and pip, command `--cache-dir` overrides `UV_CACHE_DIR` or
-`PIP_CACHE_DIR`, then `XDG_CACHE_HOME` and the conventional cache. The effective
-cache replaces only that tool's default writable grant. pip also reads its
-legacy/current user configuration for `cache-dir`. Without overrides, macOS
-uses `~/Library/Caches/{pip,uv}` and Linux uses the XDG cache home.
+`PIP_CACHE_DIR`. uv then reads project `uv.toml`, or `[tool.uv]` in
+`pyproject.toml` when no `uv.toml` exists; an external project-selected cache
+requires explicit `--allow-write` approval. pip reads its legacy/current user
+configuration for `cache-dir`. The XDG or conventional platform cache is the
+final fallback, and the effective cache replaces only that tool's default
+writable grant. Without overrides, macOS uses `~/Library/Caches/{pip,uv}` and
+Linux uses the XDG cache home.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -300,6 +300,9 @@ external source referent, so a link into an ordinary sibling checkout is
 readable without granting the sibling's parent. Canonical directory identities
 prevent traversal cycles, while entry and depth budgets bound discovery work.
 Magic links and protected referents remain rejected.
+This validation also applies to built-in readable and executable entries such
+as project-local `gradlew` and `mvnw`; a wrapper symlink cannot turn an execute
+grant into read access to a protected credential.
 Strict mode retains no-follow resolution except for immutable system aliases.
 Denied paths include their current canonical target. Strict mode also retains
 hard-link alias rejection; standard mode does not recursively scan historical

--- a/README.md
+++ b/README.md
@@ -239,6 +239,9 @@ Poetry similarly follows command `--cache-dir`, `POETRY_CACHE_DIR`, project
 configuration receives an exact read grant, while an external project-selected
 cache requires `--allow-write`. The selected `pypoetry` cache replaces both
 conventional macOS-compatible cache grants.
+Java/sbt commands likewise follow an inherited `COURSIER_CACHE`, replacing the
+conventional Coursier cache grants; relative paths are anchored to the selected
+project.
 An external Cargo target can be selected with an inherited `CARGO_TARGET_DIR`
 or a direct `--config build.target-dir='path'` override, or granted explicitly
 with matching `--allow-write` and `--allow-exec` paths. Cargo `--config` file

--- a/README.md
+++ b/README.md
@@ -269,6 +269,10 @@ system temporary roots are not granted broadly; every invocation gets a
 canonical private root used for `TMPDIR`, `TMP`, `TEMP`, and
 `XDG_RUNTIME_DIR`.
 
+Workspace grants are anchored to the launch directory. Package-manager project
+relocation options such as npm `--prefix` or Cargo `-C` fail early with an
+actionable error in both modes; change directory before invoking SBE.
+
 Standard mode does not hide files inside the selected workspace, including
 `.env*`; dependencies already run with the repository as input, and trying to
 carve individual project files breaks general output creation on Linux. Keep

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or explicitly provisioned high-assurance builds.
 | Ambient file descriptors | `CLOEXEC` before target exec | `close_range(CLOEXEC)` with bounded fallback |
 | Domain-filtered HTTPS | Enforced through the authenticated proxy; standard mode also permits localhost tooling | Best-effort in standard mode; strict domain mode refuses to run |
 | Restricted TCP/UDP | External traffic remains proxy-mediated | Best-effort in standard mode; Landlock/seccomp restrictions under `--strict` |
-| Same-user signals and Unix sockets | Local services allowed in standard mode; narrow under `--strict` | Signals scoped on ABI v6+; local services allowed in standard mode |
+| Same-user signals and Unix sockets | Local services allowed in standard mode; narrow under `--strict` | Signals scoped on ABI v6+; filesystem sockets limited to private roots on ABI v9+ |
 | Persistent W^X | Allowed and tainted in standard mode; validated under `--strict` | Same |
 | Private temporary storage | Per-run root; other shared temp roots denied | Per-run root; other temp paths omitted from Landlock grants |
 | Violation audit stream | Reported unavailable unless a correlatable source exists | Reported unavailable until kernel-domain correlation is verifiable |
@@ -54,7 +54,10 @@ Linux intentionally exposes only curated public procfs nodes such as
 `/proc/self` inode would not follow spawned descendants to their different proc
 inodes and would create a false guarantee. On kernels before Landlock ABI v6,
 same-user signal and abstract Unix-socket isolation is unavailable; pathname
-Unix-socket mediation requires ABI v9.
+Unix-socket mediation requires ABI v9. On ABI v9+, SBE keeps filesystem-backed
+capability brokers such as `docker.sock` outside the standard envelope and
+permits socket resolution only in its private per-run root. Older kernels
+cannot enforce this distinction and report the capability as unavailable.
 
 `--allow-all-network` remains an explicit request to remove network isolation.
 `--no-proxy` selects direct-TCP-443 compatibility mode and is never described
@@ -367,8 +370,9 @@ target itself returning exit code 126.
   unless the insecure compatibility option is supplied; in that case TCP
   confinement is unavailable and SBE says so. Standard mode already reports
   network restriction as best-effort.
-- Path-based Unix-socket mediation depends on newer Landlock ABIs. Local IPC is
-  a separate capability from Internet egress.
+- Path-based Unix-socket mediation depends on Landlock ABI v9. Where available,
+  it remains active even when TCP is unrestricted and grants only SBE's private
+  per-run socket root; older kernels cannot mediate filesystem socket paths.
 - macOS retains an allow-most/read-deny model for compatibility. The curated
   secret paths, Keychain service, shared temp roots, environment, and inherited
   descriptors are protected, but this is not a complete home-directory read

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   version:
-    description: 'attested sbe version to install (defaults to 0.4.0; accepts tag form or "latest")'
+    description: 'attested sbe version to install (defaults to 0.4.1; accepts tag form or "latest")'
     required: false
-    default: '0.4.0'
+    default: '0.4.1'
   github-token:
     description: 'GitHub token used to query releases and download assets (avoids API rate limits)'
     required: false
@@ -17,7 +17,7 @@ inputs:
 
 outputs:
   version:
-    description: 'The resolved release tag that was installed (e.g. "sbexec-v0.4.0")'
+    description: 'The resolved release tag that was installed (e.g. "sbexec-v0.4.1")'
     value: ${{ steps.resolve.outputs.tag }}
   bin-path:
     description: 'Absolute path to the installed sbe binary'

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -52,6 +52,10 @@ pub struct RunArgs {
     #[arg(short = 'w', long = "allow-write", action = clap::ArgAction::Append)]
     pub allow_write: Vec<PathBuf>,
 
+    /// Add readable path (repeatable). Built-in secret denials still win.
+    #[arg(long = "allow-read", action = clap::ArgAction::Append)]
+    pub allow_read: Vec<PathBuf>,
+
     /// Add read-denied path (repeatable).
     #[arg(short = 'r', long = "deny-read", action = clap::ArgAction::Append)]
     pub deny_read: Vec<PathBuf>,
@@ -145,6 +149,10 @@ pub struct InspectArgs {
     #[arg(short = 'w', long = "allow-write", action = clap::ArgAction::Append)]
     pub allow_write: Vec<PathBuf>,
 
+    /// Add readable path (repeatable). Built-in secret denials still win.
+    #[arg(long = "allow-read", action = clap::ArgAction::Append)]
+    pub allow_read: Vec<PathBuf>,
+
     /// Add read-denied path (repeatable).
     #[arg(short = 'r', long = "deny-read", action = clap::ArgAction::Append)]
     pub deny_read: Vec<PathBuf>,
@@ -207,6 +215,7 @@ impl InspectArgs {
             allow_domain: self.allow_domain.clone(),
             deny_domain: self.deny_domain.clone(),
             allow_write: self.allow_write.clone(),
+            allow_read: self.allow_read.clone(),
             deny_read: self.deny_read.clone(),
             allow_exec: self.allow_exec.clone(),
             deny_exec: self.deny_exec.clone(),

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -31,6 +31,11 @@ pub enum Commands {
 /// Arguments shared between `run` and `inspect`.
 #[derive(Debug, Parser)]
 pub struct RunArgs {
+    /// Require the fail-closed 0.4 security boundary. The default standard
+    /// mode favors compatibility while preserving core host protections.
+    #[arg(long)]
+    pub strict: bool,
+
     /// Use a specific profile (overrides auto-detect).
     #[arg(short = 'p', long)]
     pub profile: Option<String>,
@@ -120,6 +125,10 @@ pub struct RunArgs {
 
 #[derive(Debug, Parser)]
 pub struct InspectArgs {
+    /// Inspect the fail-closed strict policy instead of the standard policy.
+    #[arg(long)]
+    pub strict: bool,
+
     /// Use a specific profile (overrides auto-detect).
     #[arg(short = 'p', long)]
     pub profile: Option<String>,
@@ -193,6 +202,7 @@ impl InspectArgs {
     /// Convert inspect args into equivalent run args for profile resolution.
     pub fn as_run_args(&self) -> RunArgs {
         RunArgs {
+            strict: self.strict,
             profile: self.profile.clone(),
             allow_domain: self.allow_domain.clone(),
             deny_domain: self.deny_domain.clone(),

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -798,6 +798,13 @@ fn apply_standard_profile(
         replace_builtin_write_path(profile, &conventional, SandboxPath::dir(pnpm_store.path));
     }
     if let Some(cache) = effective_python_cache(profile, command, home, project_dir)? {
+        if cache.project_controlled
+            && !project_write_path_is_approved(profile, &cache.selected, project_dir)
+        {
+            let resolved = resolve_existing_ancestor(&cache.selected)
+                .unwrap_or_else(|| cache.selected.clone());
+            return Err(external_write_approval_error(&cache.selected, &resolved));
+        }
         replace_builtin_write_path(
             profile,
             &cache.conventional,
@@ -1236,8 +1243,12 @@ fn effective_pnpm_store(
             None
         };
     let project_controlled = project_store.is_some();
-    let default_store = effective_environment_path(profile, "XDG_DATA_HOME")
-        .map(|directory| directory.join("pnpm"))
+    let default_store = effective_environment_path(profile, "PNPM_HOME")
+        .map(|directory| directory.join("store"))
+        .or_else(|| {
+            effective_environment_path(profile, "XDG_DATA_HOME")
+                .map(|directory| directory.join("pnpm"))
+        })
         .unwrap_or_else(|| home.join(".local/share/pnpm"));
     let selected = command_store
         .or(environment_store)
@@ -1260,6 +1271,7 @@ fn effective_pnpm_store(
 struct CacheReplacement {
     conventional: PathBuf,
     selected: PathBuf,
+    project_controlled: bool,
 }
 
 fn effective_python_cache(
@@ -1291,6 +1303,16 @@ fn effective_python_cache(
         } else {
             None
         };
+    let project_cache = if command_cache.is_none()
+        && environment_cache.is_none()
+        && config_cache.is_none()
+        && default_name == "uv"
+    {
+        effective_project_uv_cache(project_dir)?
+    } else {
+        None
+    };
+    let project_controlled = project_cache.is_some();
     let conventional = home.join(".cache").join(default_name);
     let default_cache = effective_environment_path(profile, "XDG_CACHE_HOME")
         .map(|directory| directory.join(default_name))
@@ -1298,6 +1320,7 @@ fn effective_python_cache(
     let selected = command_cache
         .or(environment_cache)
         .or(config_cache)
+        .or(project_cache)
         .unwrap_or(default_cache);
     if selected.as_os_str().is_empty() {
         anyhow::bail!("{environment_name} must select a non-empty path");
@@ -1309,7 +1332,93 @@ fn effective_python_cache(
         } else {
             project_dir.join(selected)
         },
+        project_controlled,
     }))
+}
+
+fn effective_project_uv_cache(project_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let uv_toml = project_dir.join("uv.toml");
+    if let Some(contents) = read_bounded_project_file(&uv_toml)? {
+        // uv.toml takes precedence over an adjacent pyproject.toml even when it does not set
+        // cache-dir, so do not fall through once the higher-priority file exists.
+        return uv_config_cache_path(&contents, &uv_toml, false);
+    }
+
+    let pyproject = project_dir.join("pyproject.toml");
+    let Some(contents) = read_bounded_project_file(&pyproject)? else {
+        return Ok(None);
+    };
+    uv_config_cache_path(&contents, &pyproject, true)
+}
+
+fn uv_config_cache_path(
+    contents: &[u8],
+    path: &Path,
+    pyproject: bool,
+) -> anyhow::Result<Option<PathBuf>> {
+    let contents = std::str::from_utf8(contents)
+        .with_context(|| format!("uv configuration is not UTF-8: {}", path.display()))?;
+    let mut selected = None;
+    let mut in_selected_table = !pyproject;
+    for raw_line in contents.lines() {
+        let line = strip_toml_comment(raw_line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            let table = line.trim_matches(['[', ']']).trim();
+            in_selected_table =
+                pyproject && simple_toml_key_path(table).is_some_and(|path| path == ["tool", "uv"]);
+            continue;
+        }
+        if !in_selected_table {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        if !simple_toml_key_path(key.trim()).is_some_and(|path| path == ["cache-dir"]) {
+            continue;
+        }
+        if selected.is_some() {
+            anyhow::bail!(
+                "uv configuration '{}' defines cache-dir more than once; use an explicit uv \
+                 --cache-dir path",
+                path.display()
+            );
+        }
+        selected = Some(simple_uv_cache_path(value.trim(), path)?);
+    }
+    Ok(selected)
+}
+
+fn simple_uv_cache_path(value: &str, source: &Path) -> anyhow::Result<PathBuf> {
+    let unquoted = if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
+        &value[1..value.len() - 1]
+    } else if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        let unquoted = &value[1..value.len() - 1];
+        if unquoted.contains('\\') || unquoted.contains('"') {
+            anyhow::bail!(
+                "uv configuration '{}' uses an escaped or multiline cache-dir; use an explicit \
+                 uv --cache-dir path",
+                source.display()
+            );
+        }
+        unquoted
+    } else {
+        anyhow::bail!(
+            "uv configuration '{}' selects cache-dir in a form sbe cannot resolve safely; use an \
+             explicit uv --cache-dir path",
+            source.display()
+        );
+    };
+    if unquoted.is_empty() || unquoted.chars().any(char::is_control) {
+        anyhow::bail!(
+            "uv configuration '{}' must select a non-empty unambiguous cache-dir",
+            source.display()
+        );
+    }
+    Ok(PathBuf::from(unquoted))
 }
 
 fn effective_pip_config_cache(
@@ -1425,6 +1534,17 @@ fn project_cache_is_approved(
         || explicit_write_covers(profile, &resolved)
 }
 
+fn project_write_path_is_approved(
+    profile: &SandboxProfile,
+    path: &Path,
+    project_dir: &Path,
+) -> bool {
+    let resolved = resolve_existing_ancestor(path).unwrap_or_else(|| path.to_path_buf());
+    let project =
+        resolve_existing_ancestor(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+    resolved.starts_with(project) || explicit_write_covers(profile, &resolved)
+}
+
 fn effective_cargo_home(profile: &SandboxProfile, home: &Path, project_dir: &Path) -> PathBuf {
     let cargo_home =
         effective_environment_path(profile, "CARGO_HOME").unwrap_or_else(|| home.join(".cargo"));
@@ -1533,10 +1653,21 @@ fn effective_maven_settings_read_paths(
     if !command_is(command, "mvn") && !command_is(command, "mvnw") {
         return Ok(Vec::new());
     }
-    let (user_home, _) = effective_maven_user_home(profile, home, project_dir)?;
+    let (user_home, user_home_project_controlled) =
+        effective_maven_user_home(profile, home, project_dir)?;
     let mut paths = Vec::new();
     if user_home != home {
-        paths.push(SandboxPath::dir(user_home.join(".m2")));
+        let maven_config = user_home.join(".m2");
+        if user_home_project_controlled {
+            let resolved =
+                resolve_existing_ancestor(&maven_config).unwrap_or_else(|| maven_config.clone());
+            let project =
+                resolve_existing_ancestor(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+            if !resolved.starts_with(project) && !explicit_read_covers(profile, &resolved) {
+                return Err(external_read_approval_error(&maven_config, &resolved));
+            }
+        }
+        paths.push(SandboxPath::dir(maven_config));
     }
     for settings in [
         selected_maven_settings(profile, command, project_dir, "--global-settings", "-gs")?,
@@ -4900,6 +5031,82 @@ mod tests {
                 .contains(&SandboxPath::dir(project.join("relative-uv-cache")))
         );
 
+        let project_uv_cache = root.path().join("project-uv-cache");
+        let ignored_pyproject_cache = root.path().join("ignored-pyproject-cache");
+        std::fs::create_dir_all(&project_uv_cache).unwrap();
+        std::fs::write(
+            project.join("uv.toml"),
+            format!("cache-dir = '{}'\n", project_uv_cache.display()),
+        )
+        .unwrap();
+        std::fs::write(
+            project.join("pyproject.toml"),
+            format!(
+                "[tool.uv]\ncache-dir = '{}'\n",
+                ignored_pyproject_cache.display()
+            ),
+        )
+        .unwrap();
+        let mut uv_project_unapproved =
+            SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        let error = apply_standard_profile(
+            &mut uv_project_unapproved,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+        assert!(
+            error
+                .to_string()
+                .contains(&project_uv_cache.display().to_string())
+        );
+
+        let mut uv_project_approved =
+            SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        uv_project_approved
+            .allow_write
+            .push(SandboxPath::dir(project_uv_cache.clone()));
+        apply_standard_profile(
+            &mut uv_project_approved,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            uv_project_approved
+                .allow_write
+                .contains(&SandboxPath::dir(project_uv_cache))
+        );
+        assert!(
+            !uv_project_approved
+                .allow_write
+                .contains(&SandboxPath::dir(ignored_pyproject_cache)),
+            "uv.toml must take precedence over an adjacent pyproject.toml"
+        );
+
+        let pyproject_only = root.path().join("pyproject-only");
+        std::fs::create_dir_all(&pyproject_only).unwrap();
+        std::fs::write(
+            pyproject_only.join("pyproject.toml"),
+            "[tool.uv]\ncache-dir = 'relative-project-cache'\n",
+        )
+        .unwrap();
+        let mut uv_pyproject =
+            SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &pyproject_only);
+        apply_standard_profile(
+            &mut uv_pyproject,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &pyproject_only,
+        )
+        .unwrap();
+        assert!(uv_pyproject.allow_write.contains(&SandboxPath::dir(
+            pyproject_only.join("relative-project-cache")
+        )));
+
         let pip_cache = root.path().join("pip-environment-cache");
         let mut pip = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
         pip.env.insert(
@@ -5957,6 +6164,23 @@ mod tests {
             .insert("MAVEN_OPTS".to_owned(), "-Xmx1g".to_owned());
         let error = apply_standard_profile(
             &mut project_selected_home,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-read"));
+
+        let mut project_home_read_approved =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        project_home_read_approved
+            .allow_read
+            .push(SandboxPath::dir(project_home.path().join(".m2")));
+        project_home_read_approved
+            .env
+            .insert("MAVEN_OPTS".to_owned(), "-Xmx1g".to_owned());
+        let error = apply_standard_profile(
+            &mut project_home_read_approved,
             &["mvn".to_owned(), "validate".to_owned()],
             home.path(),
             project.path(),
@@ -7168,6 +7392,26 @@ mod tests {
             command_userconfig_selected
                 .allow_read
                 .contains(&SandboxPath::file(command_userconfig))
+        );
+
+        let pnpm_home = root.path().join("custom-pnpm-home");
+        let mut pnpm_home_selected =
+            SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        pnpm_home_selected.env.insert(
+            "PNPM_HOME".to_owned(),
+            pnpm_home.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut pnpm_home_selected,
+            &["pnpm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            pnpm_home_selected
+                .allow_write
+                .contains(&SandboxPath::dir(pnpm_home.join("store")))
         );
 
         let command_store = root.path().join("command-pnpm-store");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -35,6 +35,7 @@ const EXIT_SANDBOX_FAILED: u8 = 126;
 const STANDARD_NO_PROXY: &str = "localhost,.localhost,127.0.0.1,::1";
 const STANDARD_JAVA_NON_PROXY_HOSTS: &str = "localhost|*.localhost|127.*|[::1]";
 const STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES: &[&str] = &[
+    ".tmp",
     "caches",
     "daemon",
     "jdks",
@@ -774,7 +775,12 @@ fn apply_standard_profile(
 
     if command_is(command, "cargo") {
         let cargo_cli_target = command_option_value(command, "--target-dir").map(PathBuf::from);
-        if let Some(path) = cargo_cli_target {
+        let cargo_config_target = if cargo_cli_target.is_none() {
+            cargo_config_target_dir(command)?
+        } else {
+            None
+        };
+        if let Some(path) = cargo_cli_target.or(cargo_config_target) {
             let path = if path.is_absolute() {
                 path
             } else {
@@ -847,8 +853,7 @@ fn effective_gradle_user_home(
     if !command_is(command, "gradle") && !command_is(command, "gradlew") {
         return Ok(None);
     }
-    let command_home = command_option_value(command, "--gradle-user-home")
-        .or_else(|| command_option_value(command, "-g"))
+    let command_home = command_aliased_option_value(command, "--gradle-user-home", "-g")
         .map(PathBuf::from)
         .or_else(|| command_system_property(command, "gradle.user.home").map(PathBuf::from));
     let inherited_jvm_home = if command_home.is_none() {
@@ -1587,6 +1592,97 @@ fn command_option_value<'a>(command: &'a [String], option: &str) -> Option<&'a s
         }
     }
     None
+}
+
+fn command_aliased_option_value<'a>(
+    command: &'a [String],
+    long: &str,
+    short: &str,
+) -> Option<&'a str> {
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    let mut selected = None;
+    while let Some(argument) = arguments.next() {
+        if argument == long || argument == short {
+            selected = arguments.next().map(String::as_str);
+            continue;
+        }
+        if let Some(value) = argument
+            .strip_prefix(long)
+            .and_then(|suffix| suffix.strip_prefix('='))
+        {
+            selected = Some(value);
+            continue;
+        }
+        if let Some(suffix) = argument.strip_prefix(short) {
+            selected = Some(suffix.strip_prefix('=').unwrap_or(suffix));
+        }
+    }
+    selected.filter(|value| !value.is_empty())
+}
+
+fn cargo_config_target_dir(command: &[String]) -> anyhow::Result<Option<PathBuf>> {
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    let mut selected = None;
+    while let Some(argument) = arguments.next() {
+        let config = if argument == "--config" {
+            arguments
+                .next()
+                .map(String::as_str)
+                .context("cargo --config requires a value")?
+        } else if let Some(value) = argument.strip_prefix("--config=") {
+            value
+        } else {
+            continue;
+        };
+        let Some((key, value)) = config.split_once('=') else {
+            anyhow::bail!(
+                "cargo --config file paths cannot be inspected safely for build.target-dir; use \
+                 --target-dir or a direct --config build.target-dir='path' override"
+            );
+        };
+        let key = key.trim();
+        if key == "build.target-dir" {
+            selected = Some(parse_cargo_config_path(value)?);
+        } else if key == "build" || key.contains("target-dir") {
+            anyhow::bail!(
+                "cargo --config target-directory override '{key}' is unsupported; use \
+                 --target-dir or a direct --config build.target-dir='path' override"
+            );
+        }
+    }
+    Ok(selected)
+}
+
+fn parse_cargo_config_path(value: &str) -> anyhow::Result<PathBuf> {
+    let value = value.trim();
+    let path = if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
+        let path = &value[1..value.len() - 1];
+        if path.contains('\'') {
+            anyhow::bail!("cargo build.target-dir contains an unsupported quoted path");
+        }
+        path
+    } else if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
+        let path = &value[1..value.len() - 1];
+        if path.contains('\\') || path.contains('"') {
+            anyhow::bail!("cargo build.target-dir contains unsupported TOML escapes");
+        }
+        path
+    } else {
+        anyhow::bail!(
+            "cargo build.target-dir must be a simple quoted path; use --target-dir for complex \
+             values"
+        );
+    };
+    if path.is_empty() || path.chars().any(char::is_control) {
+        anyhow::bail!("cargo build.target-dir must be a non-empty path without control characters");
+    }
+    Ok(PathBuf::from(path))
 }
 
 fn command_system_property<'a>(command: &'a [String], name: &str) -> Option<&'a str> {
@@ -3199,6 +3295,36 @@ mod tests {
         }
         assert!(!cli.allow_write.contains(&SandboxPath::dir(cli_home)));
 
+        let attached_home = root.path().join("attached-gradle");
+        let mut attached = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        attached.env.insert(
+            "GRADLE_USER_HOME".to_owned(),
+            root.path()
+                .join("ignored-attached-environment")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        apply_standard_profile(
+            &mut attached,
+            &[
+                "gradle".to_owned(),
+                format!("-g{}", attached_home.display()),
+                "help".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+            let path = attached_home.join(name);
+            assert!(
+                attached
+                    .allow_write
+                    .contains(&SandboxPath::dir(path.clone()))
+            );
+            assert!(attached.allow_exec.contains(&SandboxPath::dir(path)));
+        }
+
         let property_home = root.path().join("property-gradle");
         let mut property = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
         property.env.insert(
@@ -3792,6 +3918,7 @@ mod tests {
         let project = tempfile::tempdir().unwrap();
         let home = tempfile::tempdir().unwrap();
         let target = tempfile::tempdir().unwrap();
+        let config_target = tempfile::tempdir().unwrap();
         let install_root = tempfile::tempdir().unwrap();
 
         let mut build_profile =
@@ -3852,6 +3979,57 @@ mod tests {
                 .contains(&SandboxPath::dir(target.path().to_path_buf())),
             "the CLI target directory must replace the lower-precedence environment path"
         );
+
+        let mut config_build_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        config_build_profile.env.insert(
+            "CARGO_TARGET_DIR".to_owned(),
+            target.path().to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut config_build_profile,
+            &[
+                "cargo".to_owned(),
+                "build".to_owned(),
+                "--config".to_owned(),
+                format!("build.target-dir='{}'", config_target.path().display()),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            config_build_profile
+                .allow_write
+                .contains(&SandboxPath::dir(config_target.path().to_path_buf()))
+        );
+        assert!(
+            config_build_profile
+                .allow_exec
+                .contains(&SandboxPath::dir(config_target.path().to_path_buf()))
+        );
+        assert!(
+            !config_build_profile
+                .allow_write
+                .contains(&SandboxPath::dir(target.path().to_path_buf())),
+            "a direct Cargo config target must replace the environment path"
+        );
+
+        let mut config_file_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        let error = apply_standard_profile(
+            &mut config_file_profile,
+            &[
+                "cargo".to_owned(),
+                "--config".to_owned(),
+                "cargo-extra.toml".to_owned(),
+                "build".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--target-dir"));
 
         let mut node_profile =
             SandboxProfile::for_ecosystem(Ecosystem::Node, home.path(), project.path());

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -807,11 +807,13 @@ fn apply_standard_profile(
                 .unwrap_or_else(|| cache.selected.clone());
             return Err(external_write_approval_error(&cache.selected, &resolved));
         }
-        replace_builtin_write_path(
-            profile,
-            &cache.conventional,
-            SandboxPath::dir(cache.selected),
-        );
+        for conventional in &cache.conventional {
+            replace_builtin_write_path(
+                profile,
+                conventional,
+                SandboxPath::dir(cache.selected.clone()),
+            );
+        }
     }
     if profile.name == "python" && command_uses_pip(command) {
         for config in effective_pip_config_read_paths(profile, home, project_dir)? {
@@ -1276,7 +1278,7 @@ fn effective_pnpm_store(
 }
 
 struct CacheReplacement {
-    conventional: PathBuf,
+    conventional: Vec<PathBuf>,
     selected: PathBuf,
     project_controlled: bool,
 }
@@ -1295,6 +1297,8 @@ fn effective_python_cache(
             ("UV_CACHE_DIR", "uv")
         } else if command_uses_pip(command) {
             ("PIP_CACHE_DIR", "pip")
+        } else if command_is(command, "poetry") {
+            ("POETRY_CACHE_DIR", "pypoetry")
         } else {
             return Ok(None);
         };
@@ -1320,7 +1324,7 @@ fn effective_python_cache(
         None
     };
     let project_controlled = project_cache.is_some();
-    let conventional = home.join(".cache").join(default_name);
+    let conventional = conventional_python_caches(home, default_name);
     let default_cache = effective_environment_path(profile, "XDG_CACHE_HOME")
         .map(|directory| directory.join(default_name))
         .unwrap_or_else(|| platform_python_cache(home, default_name));
@@ -1341,6 +1345,15 @@ fn effective_python_cache(
         },
         project_controlled,
     }))
+}
+
+fn conventional_python_caches(home: &Path, name: &str) -> Vec<PathBuf> {
+    let xdg = home.join(".cache").join(name);
+    #[cfg(target_os = "macos")]
+    if name == "pypoetry" {
+        return vec![xdg, home.join("Library/Caches/pypoetry")];
+    }
+    vec![xdg]
 }
 
 fn effective_project_uv_cache(project_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
@@ -5041,6 +5054,76 @@ mod tests {
             default_pip
                 .allow_write
                 .contains(&SandboxPath::dir(platform_python_cache(&home, "pip")))
+        );
+
+        let mut default_poetry = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        apply_standard_profile(
+            &mut default_poetry,
+            &["poetry".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            default_poetry
+                .allow_write
+                .contains(&SandboxPath::dir(platform_python_cache(&home, "pypoetry")))
+        );
+
+        let poetry_environment_cache = root.path().join("poetry-environment-cache");
+        let ignored_xdg_cache = root.path().join("ignored-xdg-cache");
+        let mut poetry_environment =
+            SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        poetry_environment.env.insert(
+            "POETRY_CACHE_DIR".to_owned(),
+            poetry_environment_cache.to_string_lossy().into_owned(),
+        );
+        poetry_environment.env.insert(
+            "XDG_CACHE_HOME".to_owned(),
+            ignored_xdg_cache.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut poetry_environment,
+            &["poetry".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            poetry_environment
+                .allow_write
+                .contains(&SandboxPath::dir(poetry_environment_cache))
+        );
+        assert!(
+            !poetry_environment
+                .allow_write
+                .contains(&SandboxPath::dir(ignored_xdg_cache.join("pypoetry")))
+        );
+        for conventional in conventional_python_caches(&home, "pypoetry") {
+            assert!(
+                !poetry_environment
+                    .allow_write
+                    .contains(&SandboxPath::dir(conventional))
+            );
+        }
+
+        let poetry_xdg_home = root.path().join("poetry-xdg-cache");
+        let mut poetry_xdg = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        poetry_xdg.env.insert(
+            "XDG_CACHE_HOME".to_owned(),
+            poetry_xdg_home.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut poetry_xdg,
+            &["poetry".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            poetry_xdg
+                .allow_write
+                .contains(&SandboxPath::dir(poetry_xdg_home.join("pypoetry")))
         );
 
         let uv_environment_cache = root.path().join("uv-environment-cache");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1000,6 +1000,17 @@ struct MavenRepositorySelection {
     project_controlled: bool,
 }
 
+struct MavenSettingsSelection {
+    path: PathBuf,
+    project_controlled: bool,
+    explicit: bool,
+}
+
+struct MavenSettingsRepository {
+    path: PathBuf,
+    user_home_dependent: bool,
+}
+
 fn effective_maven_local_repository(
     profile: &SandboxProfile,
     command: &[String],
@@ -1133,8 +1144,60 @@ fn effective_maven_settings_repository(
     home: &Path,
     project_dir: &Path,
 ) -> anyhow::Result<Option<MavenRepositorySelection>> {
-    let command_settings =
-        command_aliased_option_value(command, "--settings", "-s").map(str::to_owned);
+    let (user_home, user_home_project_controlled) =
+        effective_maven_user_home(profile, home, project_dir)?;
+    let global_settings =
+        selected_maven_settings(profile, command, project_dir, "--global-settings", "-gs")?;
+    let user_settings = selected_maven_settings(profile, command, project_dir, "--settings", "-s")?;
+
+    let user_settings = user_settings.unwrap_or_else(|| MavenSettingsSelection {
+        path: user_home.join(".m2/settings.xml"),
+        project_controlled: user_home_project_controlled,
+        explicit: false,
+    });
+    let user_repository =
+        read_maven_settings_repository(&user_settings, &user_home, home, user_settings.explicit)?
+            .map(|repository| MavenRepositorySelection {
+                project_controlled: user_settings.project_controlled
+                    || (repository.user_home_dependent && user_home_project_controlled),
+                path: repository.path,
+            });
+    if user_repository.is_some() {
+        return Ok(user_repository);
+    }
+
+    let global_repository = global_settings
+        .as_ref()
+        .map(|settings| {
+            read_maven_settings_repository(settings, &user_home, home, settings.explicit).map(
+                |repository| {
+                    repository.map(|repository| MavenRepositorySelection {
+                        project_controlled: settings.project_controlled
+                            || (repository.user_home_dependent && user_home_project_controlled),
+                        path: repository.path,
+                    })
+                },
+            )
+        })
+        .transpose()?
+        .flatten();
+
+    Ok(global_repository.or_else(|| {
+        (user_home != home).then(|| MavenRepositorySelection {
+            path: user_home.join(".m2/repository"),
+            project_controlled: user_home_project_controlled,
+        })
+    }))
+}
+
+fn selected_maven_settings(
+    profile: &SandboxProfile,
+    command: &[String],
+    project_dir: &Path,
+    long: &str,
+    short: &str,
+) -> anyhow::Result<Option<MavenSettingsSelection>> {
+    let command_settings = command_aliased_option_value(command, long, short).map(str::to_owned);
     let maven_args_settings = if command_settings.is_none() {
         let arguments = profile
             .env
@@ -1143,7 +1206,7 @@ fn effective_maven_settings_repository(
             .or_else(|| std::env::var("MAVEN_ARGS").ok());
         arguments
             .as_deref()
-            .and_then(maven_settings_option_value)
+            .and_then(|arguments| maven_settings_option_value(arguments, long, short))
             .map(str::to_owned)
     } else {
         None
@@ -1161,7 +1224,9 @@ fn effective_maven_settings_repository(
                     .filter(|line| !line.is_empty() && !line.starts_with('#'))
                     .collect::<Vec<_>>()
                     .join(" ");
-                Ok::<_, anyhow::Error>(maven_settings_option_value(&arguments).map(str::to_owned))
+                Ok::<_, anyhow::Error>(
+                    maven_settings_option_value(&arguments, long, short).map(str::to_owned),
+                )
             })
             .transpose()?
             .flatten()
@@ -1178,53 +1243,44 @@ fn effective_maven_settings_repository(
                 .chars()
                 .any(|character| matches!(character, '$' | '`' | '\'' | '"'))
     }) {
-        anyhow::bail!(
-            "Maven settings path must be unambiguous; use --settings=/absolute/settings.xml"
-        );
+        anyhow::bail!("Maven settings path must be unambiguous; use {long}=/absolute/settings.xml");
     }
-    let path = selected
-        .as_deref()
-        .map_or_else(|| home.join(".m2/settings.xml"), PathBuf::from);
-    let path = if path.is_absolute() {
-        path
-    } else {
-        project_dir.join(path)
-    };
-    let Some(contents) = read_bounded_following_metadata_file(&path)? else {
-        if selected.is_some() {
-            anyhow::bail!(
-                "could not inspect explicit Maven settings file: {}",
-                path.display()
-            );
+    Ok(selected.map(|path| {
+        let path = PathBuf::from(path);
+        MavenSettingsSelection {
+            path: if path.is_absolute() {
+                path
+            } else {
+                project_dir.join(path)
+            },
+            project_controlled,
+            explicit: true,
         }
-        return Ok(None);
-    };
-    let Some(repository) = maven_settings_local_repository(&contents, &path, home)? else {
-        return Ok(None);
-    };
-    Ok(Some(MavenRepositorySelection {
-        path: repository,
-        project_controlled,
     }))
 }
 
-fn maven_settings_option_value(arguments: &str) -> Option<&str> {
+fn maven_settings_option_value<'a>(arguments: &'a str, long: &str, short: &str) -> Option<&'a str> {
     let mut selected = None;
     let mut arguments = arguments.split_whitespace();
     while let Some(argument) = arguments.next() {
-        if argument == "--settings" || argument == "-s" {
+        if argument == long || argument == short {
             selected = arguments.next();
             continue;
         }
         if let Some(value) = argument
-            .strip_prefix("--settings=")
-            .or_else(|| argument.strip_prefix("-s="))
+            .strip_prefix(long)
+            .and_then(|suffix| suffix.strip_prefix('='))
+            .or_else(|| {
+                argument
+                    .strip_prefix(short)
+                    .and_then(|suffix| suffix.strip_prefix('='))
+            })
         {
             selected = Some(value);
             continue;
         }
         if let Some(value) = argument
-            .strip_prefix("-s")
+            .strip_prefix(short)
             .filter(|value| !value.is_empty())
         {
             selected = Some(value);
@@ -1233,11 +1289,73 @@ fn maven_settings_option_value(arguments: &str) -> Option<&str> {
     selected
 }
 
+fn effective_maven_user_home(
+    profile: &SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<(PathBuf, bool)> {
+    let maven_opts = profile
+        .env
+        .get("MAVEN_OPTS")
+        .cloned()
+        .or_else(|| std::env::var("MAVEN_OPTS").ok());
+    let maven_opts_home = maven_opts
+        .as_deref()
+        .map(|options| maven_options_user_home(options, "MAVEN_OPTS"))
+        .transpose()?
+        .flatten();
+    let project_home = if maven_opts_home.is_none() {
+        let path = project_dir.join(".mvn/jvm.config");
+        read_bounded_project_file(&path)?
+            .map(|contents| {
+                let contents = std::str::from_utf8(&contents).with_context(|| {
+                    format!("Maven JVM config is not UTF-8: {}", path.display())
+                })?;
+                maven_options_user_home(contents, ".mvn/jvm.config")
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let project_controlled = project_home.is_some();
+    let selected = maven_opts_home
+        .or(project_home)
+        .unwrap_or_else(|| home.to_path_buf());
+    Ok((
+        if selected.is_absolute() {
+            selected
+        } else {
+            project_dir.join(selected)
+        },
+        project_controlled,
+    ))
+}
+
+fn read_maven_settings_repository(
+    settings: &MavenSettingsSelection,
+    user_home: &Path,
+    environment_home: &Path,
+    required: bool,
+) -> anyhow::Result<Option<MavenSettingsRepository>> {
+    let Some(contents) = read_bounded_following_metadata_file(&settings.path)? else {
+        if required {
+            anyhow::bail!(
+                "could not inspect explicit Maven settings file: {}",
+                settings.path.display()
+            );
+        }
+        return Ok(None);
+    };
+    maven_settings_local_repository(&contents, &settings.path, user_home, environment_home)
+}
+
 fn maven_settings_local_repository(
     contents: &[u8],
     path: &Path,
-    home: &Path,
-) -> anyhow::Result<Option<PathBuf>> {
+    user_home: &Path,
+    environment_home: &Path,
+) -> anyhow::Result<Option<MavenSettingsRepository>> {
     let contents = std::str::from_utf8(contents)
         .with_context(|| format!("Maven settings are not UTF-8: {}", path.display()))?;
     let contents = xml_without_comments(contents, path)?;
@@ -1270,10 +1388,11 @@ fn maven_settings_local_repository(
                 path.display()
             )
         })?;
-    let value = contents[value_start..end]
-        .trim()
-        .replace("${user.home}", &home.to_string_lossy())
-        .replace("${env.HOME}", &home.to_string_lossy());
+    let raw_value = contents[value_start..end].trim();
+    let user_home_dependent = raw_value.contains("${user.home}");
+    let value = raw_value
+        .replace("${user.home}", &user_home.to_string_lossy())
+        .replace("${env.HOME}", &environment_home.to_string_lossy());
     if value.is_empty()
         || value
             .chars()
@@ -1285,7 +1404,10 @@ fn maven_settings_local_repository(
             path.display()
         );
     }
-    Ok(Some(PathBuf::from(value)))
+    Ok(Some(MavenSettingsRepository {
+        path: PathBuf::from(value),
+        user_home_dependent,
+    }))
 }
 
 fn xml_without_comments(contents: &str, path: &Path) -> anyhow::Result<String> {
@@ -1382,6 +1504,33 @@ fn maven_options_local_repository(options: &str, source: &str) -> anyhow::Result
         anyhow::bail!(
             "{source} selects maven.repo.local in an unsupported form; use \
              -Dmaven.repo.local=/unambiguous/path"
+        );
+    }
+    Ok(selected)
+}
+
+fn maven_options_user_home(options: &str, source: &str) -> anyhow::Result<Option<PathBuf>> {
+    let mut selected = None;
+    for token in options.split_whitespace() {
+        let Some(value) = token.strip_prefix("-Duser.home=") else {
+            continue;
+        };
+        if value.is_empty()
+            || value.chars().any(|character| {
+                matches!(character, '$' | '`' | '\\' | '\'' | '"' | '*' | '?' | '[')
+            })
+        {
+            anyhow::bail!(
+                "{source} selects user.home in a form that sbe cannot resolve safely; use an \
+                 unambiguous -Duser.home=/absolute/path"
+            );
+        }
+        selected = Some(PathBuf::from(value));
+    }
+    if selected.is_none() && options.contains("-Duser.home") {
+        anyhow::bail!(
+            "{source} selects user.home in an unsupported form; use an unambiguous \
+             -Duser.home=/absolute/path"
         );
     }
     Ok(selected)
@@ -4868,6 +5017,72 @@ mod tests {
                 .contains(&SandboxPath::dir(explicit_repository.path().to_path_buf()))
         );
 
+        std::fs::write(home.path().join(".m2/settings.xml"), "<settings/>").unwrap();
+        let global_repository = tempfile::tempdir().unwrap();
+        let global_settings = project.path().join("global-settings.xml");
+        std::fs::write(
+            &global_settings,
+            format!(
+                "<settings><localRepository>{}</localRepository></settings>",
+                global_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut explicit_global =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        apply_standard_profile(
+            &mut explicit_global,
+            &[
+                "mvn".to_owned(),
+                "-gs".to_owned(),
+                global_settings.display().to_string(),
+                "validate".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            explicit_global
+                .allow_write
+                .contains(&SandboxPath::dir(global_repository.path().to_path_buf()))
+        );
+
+        std::fs::write(
+            home.path().join(".m2/settings.xml"),
+            format!(
+                "<settings><localRepository>{}</localRepository></settings>",
+                settings_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut user_over_global =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        apply_standard_profile(
+            &mut user_over_global,
+            &[
+                "mvn".to_owned(),
+                "--global-settings".to_owned(),
+                global_settings.display().to_string(),
+                "validate".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            user_over_global
+                .allow_write
+                .contains(&SandboxPath::dir(settings_repository.path().to_path_buf()))
+        );
+        assert!(
+            !user_over_global
+                .allow_write
+                .contains(&SandboxPath::dir(global_repository.path().to_path_buf())),
+            "effective user settings must override the global localRepository"
+        );
+        std::fs::write(home.path().join(".m2/settings.xml"), "<settings/>").unwrap();
+
         std::fs::create_dir_all(project.path().join(".mvn")).unwrap();
         std::fs::write(
             project.path().join(".mvn/maven.config"),
@@ -4878,6 +5093,87 @@ mod tests {
             SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
         let error = apply_standard_profile(
             &mut project_selected_settings,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+
+        std::fs::write(
+            project.path().join(".mvn/maven.config"),
+            "# no settings override\n",
+        )
+        .unwrap();
+        let alternate_home = tempfile::tempdir().unwrap();
+        let alternate_home_repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(alternate_home.path().join(".m2")).unwrap();
+        std::fs::write(
+            alternate_home.path().join(".m2/settings.xml"),
+            format!(
+                "<settings><localRepository>{}</localRepository></settings>",
+                alternate_home_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut alternate_user_home =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        alternate_user_home.env.insert(
+            "MAVEN_OPTS".to_owned(),
+            format!("-Duser.home={}", alternate_home.path().display()),
+        );
+        apply_standard_profile(
+            &mut alternate_user_home,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(alternate_user_home.allow_write.contains(&SandboxPath::dir(
+            alternate_home_repository.path().to_path_buf()
+        )));
+
+        let alternate_default_home = tempfile::tempdir().unwrap();
+        let mut alternate_default =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        alternate_default.env.insert(
+            "MAVEN_OPTS".to_owned(),
+            format!("-Duser.home={}", alternate_default_home.path().display()),
+        );
+        apply_standard_profile(
+            &mut alternate_default,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(alternate_default.allow_write.contains(&SandboxPath::dir(
+            alternate_default_home.path().join(".m2/repository")
+        )));
+
+        let project_home = tempfile::tempdir().unwrap();
+        let project_home_repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(project_home.path().join(".m2")).unwrap();
+        std::fs::write(
+            project_home.path().join(".m2/settings.xml"),
+            format!(
+                "<settings><localRepository>{}</localRepository></settings>",
+                project_home_repository.path().display()
+            ),
+        )
+        .unwrap();
+        std::fs::write(
+            project.path().join(".mvn/jvm.config"),
+            format!("-Duser.home={}\n", project_home.path().display()),
+        )
+        .unwrap();
+        let mut project_selected_home =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        project_selected_home
+            .env
+            .insert("MAVEN_OPTS".to_owned(), "-Xmx1g".to_owned());
+        let error = apply_standard_profile(
+            &mut project_selected_home,
             &["mvn".to_owned(), "validate".to_owned()],
             home.path(),
             project.path(),

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -644,7 +644,9 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "GPG_AGENT_INFO",
         "GH_CONFIG_DIR",
         "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_GLOBAL",
         "GIT_CONFIG_PARAMETERS",
+        "GIT_CONFIG_SYSTEM",
         "GNUPGHOME",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
@@ -662,6 +664,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "PGPASSFILE",
         "PGPASSWORD",
         "PIP_CONFIG_FILE",
+        "PIP_EXTRA_INDEX_URL",
+        "PIP_INDEX_URL",
         "POETRY_CONFIG_DIR",
         "PRIVATE_KEY",
         "REDISCLI_AUTH",
@@ -671,6 +675,9 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "SYSTEM_ACCESSTOKEN",
         "TOKEN",
         "UV_CONFIG_FILE",
+        "UV_DEFAULT_INDEX",
+        "UV_EXTRA_INDEX_URL",
+        "UV_INDEX_URL",
     ];
     const RESERVED: &[&str] = &[
         "HTTP_PROXY",
@@ -4822,6 +4829,14 @@ mod tests {
                 ("CI_JOB_JWT_V2".to_owned(), "sentinel".to_owned()),
                 ("GIT_CONFIG_COUNT".to_owned(), "1".to_owned()),
                 (
+                    "GIT_CONFIG_GLOBAL".to_owned(),
+                    "/tmp/global-gitconfig".to_owned(),
+                ),
+                (
+                    "GIT_CONFIG_SYSTEM".to_owned(),
+                    "/tmp/system-gitconfig".to_owned(),
+                ),
+                (
                     "GIT_CONFIG_KEY_0".to_owned(),
                     "http.https://example.com.extraHeader".to_owned(),
                 ),
@@ -4871,12 +4886,32 @@ mod tests {
                     "/tmp/custom-pip.conf".to_owned(),
                 ),
                 (
+                    "PIP_INDEX_URL".to_owned(),
+                    "https://user:sentinel@example.com/simple".to_owned(),
+                ),
+                (
+                    "PIP_EXTRA_INDEX_URL".to_owned(),
+                    "https://user:sentinel@example.net/simple".to_owned(),
+                ),
+                (
                     "POETRY_CONFIG_DIR".to_owned(),
                     "/tmp/custom-poetry".to_owned(),
                 ),
                 (
                     "UV_CONFIG_FILE".to_owned(),
                     "/tmp/custom-uv.toml".to_owned(),
+                ),
+                (
+                    "UV_INDEX_URL".to_owned(),
+                    "https://user:sentinel@example.com/simple".to_owned(),
+                ),
+                (
+                    "UV_EXTRA_INDEX_URL".to_owned(),
+                    "https://user:sentinel@example.net/simple".to_owned(),
+                ),
+                (
+                    "UV_DEFAULT_INDEX".to_owned(),
+                    "https://user:sentinel@example.org/simple".to_owned(),
                 ),
                 ("KRB5CCNAME".to_owned(), "FILE:/tmp/krb5cc".to_owned()),
                 (

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -606,6 +606,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
     const EXACT: &[&str] = &[
         "API_KEY",
         "AWS_ACCESS_KEY_ID",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SHARED_CREDENTIALS_FILE",
         "AWS_SESSION_TOKEN",
@@ -742,7 +744,8 @@ fn apply_standard_profile(
             SandboxPath::dir(home.join("Library/Caches/Coursier")),
         );
 
-        if let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir) {
+        if let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir)?
+        {
             // Keep init.d and root-level initialization scripts immutable.
             // Standard mode accepts cache poisoning, but should not provide a
             // direct unsandboxed-startup persistence mechanism.
@@ -758,27 +761,9 @@ fn apply_standard_profile(
         }
     }
 
-    let cargo_cli_target = command_is(command, "cargo")
-        .then(|| command_option_value(command, "--target-dir"))
-        .flatten()
-        .map(PathBuf::from);
-    if let Some(path) = cargo_cli_target {
-        let path = if path.is_absolute() {
-            path
-        } else {
-            project_dir.join(path)
-        };
-        insert_builtin_path_grant(
-            profile,
-            GrantKind::AllowWrite,
-            SandboxPath::dir(path.clone()),
-        );
-        insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
-    } else {
-        for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
-            let Some(path) = effective_environment_path(profile, name) else {
-                continue;
-            };
+    if command_is(command, "cargo") {
+        let cargo_cli_target = command_option_value(command, "--target-dir").map(PathBuf::from);
+        if let Some(path) = cargo_cli_target {
             let path = if path.is_absolute() {
                 path
             } else {
@@ -790,6 +775,23 @@ fn apply_standard_profile(
                 SandboxPath::dir(path.clone()),
             );
             insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
+        } else {
+            for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
+                let Some(path) = effective_environment_path(profile, name) else {
+                    continue;
+                };
+                let path = if path.is_absolute() {
+                    path
+                } else {
+                    project_dir.join(path)
+                };
+                insert_builtin_path_grant(
+                    profile,
+                    GrantKind::AllowWrite,
+                    SandboxPath::dir(path.clone()),
+                );
+                insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
+            }
         }
     }
     if command_is(command, "cargo") && top_level_subcommand(command).is_command(&["install"]) {
@@ -830,22 +832,65 @@ fn effective_gradle_user_home(
     command: &[String],
     home: &Path,
     project_dir: &Path,
-) -> Option<PathBuf> {
+) -> anyhow::Result<Option<PathBuf>> {
     if !command_is(command, "gradle") && !command_is(command, "gradlew") {
-        return None;
+        return Ok(None);
     }
-    let selected = command_option_value(command, "--gradle-user-home")
+    let command_home = command_option_value(command, "--gradle-user-home")
         .or_else(|| command_option_value(command, "-g"))
         .map(PathBuf::from)
-        .or_else(|| command_system_property(command, "gradle.user.home").map(PathBuf::from))
+        .or_else(|| command_system_property(command, "gradle.user.home").map(PathBuf::from));
+    let gradle_opts_home = if command_home.is_none() {
+        gradle_opts_user_home(profile)?
+    } else {
+        None
+    };
+    let selected = command_home
+        .or(gradle_opts_home)
         .or_else(|| effective_environment_path(profile, "GRADLE_USER_HOME"))
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| home.join(".gradle"));
-    Some(if selected.is_absolute() {
+    Ok(Some(if selected.is_absolute() {
         selected
     } else {
         project_dir.join(selected)
-    })
+    }))
+}
+
+fn gradle_opts_user_home(profile: &SandboxProfile) -> anyhow::Result<Option<PathBuf>> {
+    let Some(options) = profile
+        .env
+        .get("GRADLE_OPTS")
+        .cloned()
+        .or_else(|| std::env::var("GRADLE_OPTS").ok())
+    else {
+        return Ok(None);
+    };
+    let mut selected = None;
+    for token in options.split_whitespace() {
+        let Some(value) = token.strip_prefix("-Dgradle.user.home=") else {
+            continue;
+        };
+        if value.is_empty()
+            || value
+                .chars()
+                .any(|character| matches!(character, '$' | '`' | '\\' | '\'' | '"'))
+        {
+            anyhow::bail!(
+                "GRADLE_OPTS selects gradle.user.home with quoting or expansion that sbe cannot \
+                 resolve safely; use --gradle-user-home or GRADLE_USER_HOME"
+            );
+        }
+        // JVM system properties use the last repeated value.
+        selected = Some(PathBuf::from(value));
+    }
+    if selected.is_none() && options.contains("-Dgradle.user.home") {
+        anyhow::bail!(
+            "GRADLE_OPTS selects gradle.user.home in an unsupported form; use --gradle-user-home \
+             or GRADLE_USER_HOME"
+        );
+    }
+    Ok(selected)
 }
 
 #[cfg(target_os = "macos")]
@@ -859,7 +904,7 @@ fn prepare_standard_gradle_directories(
     home: &Path,
     project_dir: &Path,
 ) -> anyhow::Result<()> {
-    let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir) else {
+    let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir)? else {
         return Ok(());
     };
     for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
@@ -2727,6 +2772,14 @@ mod tests {
                 ("LANG".to_owned(), "C.UTF-8".to_owned()),
                 ("RUSTFLAGS".to_owned(), "-Cdebuginfo=1".to_owned()),
                 ("GITHUB_TOKEN".to_owned(), "sentinel".to_owned()),
+                (
+                    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI".to_owned(),
+                    "/v2/credentials/task".to_owned(),
+                ),
+                (
+                    "AWS_CONTAINER_CREDENTIALS_FULL_URI".to_owned(),
+                    "http://127.0.0.1/credentials".to_owned(),
+                ),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
                 (
                     "AWS_SHARED_CREDENTIALS_FILE".to_owned(),
@@ -3112,6 +3165,58 @@ mod tests {
             );
             assert!(property.allow_exec.contains(&SandboxPath::dir(path)));
         }
+
+        let opts_home = root.path().join("opts-gradle");
+        let mut opts = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        opts.env.insert(
+            "GRADLE_OPTS".to_owned(),
+            format!(
+                "-Xmx1g -Dgradle.user.home={} -Dfile.encoding=UTF-8",
+                opts_home.display()
+            ),
+        );
+        apply_standard_profile(
+            &mut opts,
+            &["gradle".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+            let path = opts_home.join(name);
+            assert!(opts.allow_write.contains(&SandboxPath::dir(path.clone())));
+            assert!(opts.allow_exec.contains(&SandboxPath::dir(path)));
+        }
+
+        let mut ambiguous = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        ambiguous.env.insert(
+            "GRADLE_OPTS".to_owned(),
+            "-Dgradle.user.home='$HOME/Gradle Home'".to_owned(),
+        );
+        let error = apply_standard_profile(
+            &mut ambiguous,
+            &["gradle".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--gradle-user-home"));
+        assert_eq!(
+            effective_gradle_user_home(
+                &ambiguous,
+                &[
+                    "gradle".to_owned(),
+                    "-g".to_owned(),
+                    "explicit-gradle".to_owned(),
+                    "build".to_owned(),
+                ],
+                &home,
+                &project,
+            )
+            .unwrap(),
+            Some(project.join("explicit-gradle")),
+            "a higher-precedence explicit home must bypass ambiguous lower-precedence options"
+        );
     }
 
     #[test]
@@ -3512,6 +3617,31 @@ mod tests {
                 .allow_write
                 .contains(&SandboxPath::dir(target.path().to_path_buf())),
             "the CLI target directory must replace the lower-precedence environment path"
+        );
+
+        let mut node_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Node, home.path(), project.path());
+        node_profile.env.insert(
+            "CARGO_TARGET_DIR".to_owned(),
+            target.path().to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut node_profile,
+            &["npm".to_owned(), "install".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            !node_profile
+                .allow_write
+                .contains(&SandboxPath::dir(target.path().to_path_buf())),
+            "Cargo configuration must not expand a non-Cargo command's authority"
+        );
+        assert!(
+            !node_profile
+                .allow_exec
+                .contains(&SandboxPath::dir(target.path().to_path_buf()))
         );
 
         let mut install_profile =

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -653,12 +653,14 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "MONGO_URL",
         "MYSQL_PWD",
         "NETRC",
+        "NPM_CONFIG_GLOBALCONFIG",
         "NPM_CONFIG_USERCONFIG",
         "PASSWORD",
         "PASSWD",
         "PGPASSFILE",
         "PGPASSWORD",
         "PIP_CONFIG_FILE",
+        "POETRY_CONFIG_DIR",
         "PRIVATE_KEY",
         "REDISCLI_AUTH",
         "SECRET",
@@ -787,6 +789,13 @@ fn apply_standard_profile(
                 SandboxPath::file(user_config.path),
             );
         }
+        if let Some(global_config) = effective_npm_global_config(profile, command, project_dir)? {
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowRead,
+                SandboxPath::file(global_config),
+            );
+        }
     }
     if let Some(pnpm_store) = effective_pnpm_store(profile, command, home, project_dir)? {
         let conventional = home.join(".local/share/pnpm");
@@ -817,6 +826,11 @@ fn apply_standard_profile(
     }
     if profile.name == "python" && command_uses_pip(command) {
         for config in effective_pip_config_read_paths(profile, home, project_dir)? {
+            insert_builtin_path_grant(profile, GrantKind::AllowRead, SandboxPath::file(config));
+        }
+    }
+    if profile.name == "python" && command_is(command, "poetry") {
+        for config in effective_poetry_config_read_paths(profile, home, project_dir)? {
             insert_builtin_path_grant(profile, GrantKind::AllowRead, SandboxPath::file(config));
         }
     }
@@ -881,6 +895,15 @@ fn apply_standard_profile(
                 );
                 insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
             }
+        }
+        if (command_is(command, "gradle") || command_is(command, "gradlew"))
+            && let Some(project_cache) = command_long_path_option(command, "--project-cache-dir")?
+        {
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowWrite,
+                SandboxPath::dir(anchor_project_path(project_cache, project_dir)),
+            );
         }
     }
 
@@ -1109,6 +1132,20 @@ fn effective_npm_user_config(
     })
 }
 
+fn effective_npm_global_config(
+    profile: &SandboxProfile,
+    command: &[String],
+    project_dir: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    let selected = command_long_path_option(command, "--globalconfig")?.or_else(|| {
+        profile
+            .env
+            .get("NPM_CONFIG_GLOBALCONFIG")
+            .map(PathBuf::from)
+    });
+    Ok(selected.map(|path| anchor_project_path(path, project_dir)))
+}
+
 fn user_npm_config_path(
     selection: &NpmUserConfigSelection,
     home: &Path,
@@ -1308,12 +1345,19 @@ fn effective_python_cache(
     } else {
         None
     };
-    let config_cache =
-        if command_cache.is_none() && environment_cache.is_none() && default_name == "pip" {
-            effective_pip_config_cache(profile, home, project_dir)?
-        } else {
-            None
-        };
+    let (config_cache, config_project_controlled) = if command_cache.is_none()
+        && environment_cache.is_none()
+        && default_name == "pip"
+    {
+        (
+            effective_pip_config_cache(profile, home, project_dir)?,
+            false,
+        )
+    } else if command_cache.is_none() && environment_cache.is_none() && default_name == "pypoetry" {
+        effective_poetry_config_cache(profile, home, project_dir)?
+    } else {
+        (None, false)
+    };
     let project_cache = if command_cache.is_none()
         && environment_cache.is_none()
         && config_cache.is_none()
@@ -1323,7 +1367,7 @@ fn effective_python_cache(
     } else {
         None
     };
-    let project_controlled = project_cache.is_some();
+    let project_controlled = config_project_controlled || project_cache.is_some();
     let conventional = conventional_python_caches(home, default_name);
     let default_cache = effective_environment_path(profile, "XDG_CACHE_HOME")
         .map(|directory| directory.join(default_name))
@@ -1465,6 +1509,66 @@ fn effective_pip_config_cache(
         selected = Some(cache);
     }
     Ok(selected)
+}
+
+fn effective_poetry_config_cache(
+    profile: &SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<(Option<PathBuf>, bool)> {
+    let global = effective_poetry_config_file(profile, home, project_dir);
+    let mut selected = read_poetry_config_cache(&global, home)?;
+    let local = project_dir.join("poetry.toml");
+    if let Some(cache) = read_bounded_project_file(&local)?
+        .map(|contents| {
+            npm_config_path_value(&contents, &local, home, "cache-dir", "project poetry.toml")
+        })
+        .transpose()?
+        .flatten()
+    {
+        selected = Some(cache);
+        return Ok((selected, true));
+    }
+    Ok((selected, false))
+}
+
+fn read_poetry_config_cache(path: &Path, home: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let Some(contents) = read_bounded_following_metadata_file(path)? else {
+        return Ok(None);
+    };
+    npm_config_path_value(&contents, path, home, "cache-dir", "Poetry configuration")
+}
+
+fn effective_poetry_config_file(
+    profile: &SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> PathBuf {
+    let directory = profile
+        .env
+        .get("POETRY_CONFIG_DIR")
+        .map(PathBuf::from)
+        .map(|path| anchor_project_path(path, project_dir))
+        .unwrap_or_else(|| {
+            effective_environment_path(profile, "XDG_CONFIG_HOME")
+                .map(|path| anchor_project_path(path, project_dir))
+                .unwrap_or_else(|| platform_config_home(home))
+                .join("pypoetry")
+        });
+    directory.join("config.toml")
+}
+
+fn effective_poetry_config_read_paths(
+    profile: &SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let config = effective_poetry_config_file(profile, home, project_dir);
+    if read_bounded_following_metadata_file(&config)?.is_some() {
+        Ok(vec![config])
+    } else {
+        Ok(Vec::new())
+    }
 }
 
 fn effective_pip_config_read_paths(
@@ -4685,6 +4789,10 @@ mod tests {
                 ("SYSTEM_ACCESSTOKEN".to_owned(), "sentinel".to_owned()),
                 ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
                 (
+                    "NPM_CONFIG_GLOBALCONFIG".to_owned(),
+                    "/tmp/global-npmrc".to_owned(),
+                ),
+                (
                     "NPM_CONFIG_USERCONFIG".to_owned(),
                     "/tmp/custom-npmrc".to_owned(),
                 ),
@@ -4692,6 +4800,10 @@ mod tests {
                 (
                     "PIP_CONFIG_FILE".to_owned(),
                     "/tmp/custom-pip.conf".to_owned(),
+                ),
+                (
+                    "POETRY_CONFIG_DIR".to_owned(),
+                    "/tmp/custom-poetry".to_owned(),
                 ),
                 (
                     "UV_CONFIG_FILE".to_owned(),
@@ -5126,6 +5238,73 @@ mod tests {
                 .contains(&SandboxPath::dir(poetry_xdg_home.join("pypoetry")))
         );
 
+        let poetry_config_dir = root.path().join("poetry-config");
+        let poetry_config_cache = root.path().join("poetry-config-cache");
+        std::fs::create_dir_all(&poetry_config_dir).unwrap();
+        std::fs::write(
+            poetry_config_dir.join("config.toml"),
+            format!("cache-dir = '{}'\n", poetry_config_cache.display()),
+        )
+        .unwrap();
+        let mut poetry_config = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        poetry_config.env.insert(
+            "POETRY_CONFIG_DIR".to_owned(),
+            poetry_config_dir.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut poetry_config,
+            &["poetry".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            poetry_config
+                .allow_write
+                .contains(&SandboxPath::dir(poetry_config_cache))
+        );
+        assert!(
+            poetry_config
+                .allow_read
+                .contains(&SandboxPath::file(poetry_config_dir.join("config.toml")))
+        );
+
+        let project_poetry_cache = root.path().join("project-poetry-cache");
+        std::fs::create_dir_all(&project_poetry_cache).unwrap();
+        std::fs::write(
+            project.join("poetry.toml"),
+            format!("cache-dir = '{}'\n", project_poetry_cache.display()),
+        )
+        .unwrap();
+        let mut poetry_project_unapproved =
+            SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        let error = apply_standard_profile(
+            &mut poetry_project_unapproved,
+            &["poetry".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+
+        let mut poetry_project_approved =
+            SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        poetry_project_approved
+            .allow_write
+            .push(SandboxPath::dir(project_poetry_cache.clone()));
+        apply_standard_profile(
+            &mut poetry_project_approved,
+            &["poetry".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            poetry_project_approved
+                .allow_write
+                .contains(&SandboxPath::dir(project_poetry_cache))
+        );
+
         let uv_environment_cache = root.path().join("uv-environment-cache");
         let mut uv_environment = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
         uv_environment.env.insert(
@@ -5403,6 +5582,26 @@ mod tests {
         }
         assert!(cli.allow_read.contains(&SandboxPath::dir(cli_home.clone())));
         assert!(!cli.allow_write.contains(&SandboxPath::dir(cli_home)));
+
+        let project_cache = root.path().join("gradle-project-cache");
+        let mut project_cache_selected =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        apply_standard_profile(
+            &mut project_cache_selected,
+            &[
+                "./gradlew".to_owned(),
+                "build".to_owned(),
+                format!("--project-cache-dir={}", project_cache.display()),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            project_cache_selected
+                .allow_write
+                .contains(&SandboxPath::dir(project_cache))
+        );
 
         let attached_home = root.path().join("attached-gradle");
         let mut attached = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
@@ -7546,6 +7745,27 @@ mod tests {
             command_userconfig_selected
                 .allow_read
                 .contains(&SandboxPath::file(command_userconfig))
+        );
+
+        let global_config = root.path().join("global-npmrc");
+        std::fs::write(&global_config, "registry=https://registry.npmjs.org/\n").unwrap();
+        let mut global_config_selected =
+            SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        global_config_selected.env.insert(
+            "NPM_CONFIG_GLOBALCONFIG".to_owned(),
+            global_config.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut global_config_selected,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            global_config_selected
+                .allow_read
+                .contains(&SandboxPath::file(global_config))
         );
 
         let pnpm_home = root.path().join("custom-pnpm-home");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1,5 +1,7 @@
+#[cfg(any(target_os = "linux", test))]
+use std::collections::BTreeSet;
 use std::{
-    collections::{BTreeSet, HashMap},
+    collections::HashMap,
     ffi::CString,
     os::{
         fd::{AsRawFd, FromRawFd},
@@ -30,7 +32,9 @@ use crate::cli::RunArgs;
 /// sbe exit codes for its own errors (matching docker run / env conventions).
 const EXIT_SBE_ERROR: u8 = 125;
 const EXIT_SANDBOX_FAILED: u8 = 126;
+#[cfg(target_os = "linux")]
 const MAX_SOURCE_SYMLINK_SCAN_ENTRIES: usize = 100_000;
+#[cfg(target_os = "linux")]
 const MAX_SOURCE_SYMLINK_SCAN_DEPTH: usize = 128;
 
 const SAFE_PARENT_ENV: &[&str] = &[
@@ -591,6 +595,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
         "AZURE_CLIENT_SECRET",
         "CREDENTIAL",
         "CREDENTIALS",
@@ -634,6 +639,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         || upper == "LD_LIBRARY_PATH"
         || [
             "_TOKEN",
+            "_TOKEN_FILE",
             "_API_KEY",
             "_SECRET",
             "_PASSWORD",
@@ -903,6 +909,16 @@ fn resolve_standard_path_aliases(
     snapshot_standard_write_aliases(profile, home, project_dir)?;
     snapshot_standard_exec_aliases(profile);
     snapshot_standard_read_aliases(profile);
+    #[cfg(target_os = "linux")]
+    append_standard_workspace_read_aliases(profile, project_dir)?;
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn append_standard_workspace_read_aliases(
+    profile: &mut SandboxProfile,
+    project_dir: &Path,
+) -> anyhow::Result<()> {
     let read_aliases = workspace_read_aliases(profile, project_dir)?;
     for alias in read_aliases {
         if !profile.allow_read.contains(&alias) {
@@ -1121,6 +1137,7 @@ fn grant_covers(grant: &SandboxPath, target: &Path) -> bool {
     }
 }
 
+#[cfg(target_os = "linux")]
 fn workspace_read_aliases(
     profile: &SandboxProfile,
     project_dir: &Path,
@@ -1137,6 +1154,7 @@ fn workspace_read_aliases(
     clippy::disallowed_methods,
     reason = "standard mode snapshots source symlink referents before launching untrusted code"
 )]
+#[cfg(any(target_os = "linux", test))]
 fn workspace_read_aliases_with_limits(
     profile: &SandboxProfile,
     project_dir: &Path,
@@ -1257,6 +1275,7 @@ fn workspace_read_aliases_with_limits(
     clippy::disallowed_methods,
     reason = "standard mode compares source symlink referents with protected paths before launch"
 )]
+#[cfg(any(target_os = "linux", test))]
 fn overlaps_denied_read(profile: &SandboxProfile, candidate: &Path) -> bool {
     profile.deny_read.iter().any(|denied| {
         let denied = resolve_existing_ancestor(&denied.path).unwrap_or_else(|| denied.path.clone());
@@ -2571,6 +2590,14 @@ mod tests {
                 ("RUSTFLAGS".to_owned(), "-Cdebuginfo=1".to_owned()),
                 ("GITHUB_TOKEN".to_owned(), "sentinel".to_owned()),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
+                (
+                    "AWS_WEB_IDENTITY_TOKEN_FILE".to_owned(),
+                    "/tmp/aws-oidc-token".to_owned(),
+                ),
+                (
+                    "AZURE_FEDERATED_TOKEN_FILE".to_owned(),
+                    "/tmp/azure-oidc-token".to_owned(),
+                ),
                 ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
                 ("SYSTEM_ACCESSTOKEN".to_owned(), "sentinel".to_owned()),
                 ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
@@ -2930,6 +2957,7 @@ mod tests {
         );
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     #[allow(
         clippy::disallowed_methods,

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1205,7 +1205,7 @@ fn snapshot_standard_write_aliases(
     let mut records = Vec::new();
 
     for (index, grant) in original.into_iter().enumerate() {
-        let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+        let Some(resolved) = resolve_existing_ancestor(&grant.path) else {
             snapped.push(grant);
             continue;
         };
@@ -3412,6 +3412,70 @@ mod tests {
                 .iter()
                 .any(|grant| grant.path == home.join(".npm")),
             "the launcher must not reopen the mutable lexical symlink"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test resolves a missing cache directory beneath an isolated symlink"
+    )]
+    fn standard_profile_resolves_missing_descendants_beneath_approved_symlinks() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let external_cache = root.path().join("external-cache");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&external_cache).unwrap();
+        std::os::unix::fs::symlink(&external_cache, home.join(".cache")).unwrap();
+        let resolved_cache = std::fs::canonicalize(&external_cache)
+            .unwrap()
+            .join("coursier");
+
+        let mut unapproved = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        apply_standard_profile(
+            &mut unapproved,
+            &["sbt".to_owned(), "update".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        let error = resolve_standard_path_aliases(&mut unapproved, &home, &project).unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+        assert!(
+            error
+                .to_string()
+                .contains(&resolved_cache.display().to_string())
+        );
+
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        profile
+            .allow_write
+            .push(SandboxPath::dir(external_cache.clone()));
+        apply_standard_profile(
+            &mut profile,
+            &["sbt".to_owned(), "update".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        resolve_standard_path_aliases(&mut profile, &home, &project).unwrap();
+
+        assert!(!resolved_cache.exists());
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(resolved_cache)),
+            "resolved grants: {:?}",
+            profile.allow_write
+        );
+        assert!(
+            !profile
+                .allow_write
+                .iter()
+                .any(|grant| grant.path == home.join(".cache/coursier")),
+            "the launcher must receive the reconstructed canonical target, not its symlinked spelling"
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -12,7 +12,7 @@ use std::{
 use anyhow::Context;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use sbe_core::{
-    BackendOptions, Sandbox, SandboxBackend,
+    BackendOptions, Sandbox, SandboxBackend, SecurityMode,
     config::{SandboxPath, expand_path, load_configs, resolve_profile},
     detect::{self, Ecosystem},
     error::CoreError,
@@ -22,8 +22,7 @@ use sbe_core::{
     },
 };
 use sbe_proxy::{ProxyEndpoint, ProxyServer, allowlist::DomainAllowlist};
-use tokio::io::AsyncWriteExt;
-use tokio::sync::watch;
+use tokio::{io::AsyncWriteExt, sync::watch};
 use tracing::{info, warn};
 
 use crate::cli::RunArgs;
@@ -68,7 +67,9 @@ pub async fn execute(args: &RunArgs) -> ExitCode {
 async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
     let pwd = std::env::current_dir().context("failed to get current directory")?;
     let home = dirs::home_dir().context("could not determine home directory")?;
-    reject_project_relocation(&args.command)?;
+    if args.strict {
+        reject_project_relocation(&args.command)?;
+    }
 
     // Determine ecosystem
     let command_name = &args.command[0];
@@ -78,7 +79,7 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
 
     // Build and resolve profile
     let mut profile = SandboxProfile::for_ecosystem(ecosystem, &home, &pwd);
-    if ecosystem == Ecosystem::Node {
+    if args.strict && ecosystem == Ecosystem::Node {
         configure_node_workspace(&mut profile, &args.command, &pwd)?;
     }
     let configs = load_configs(&pwd, args.config.as_deref(), args.trust_project_config).await?;
@@ -96,9 +97,14 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         });
     }
     profile.finalize();
-    enable_existing_dependency_execution(&mut profile, &args.command);
+    if args.strict {
+        enable_existing_dependency_execution(&mut profile, &args.command);
+    } else {
+        apply_standard_profile(&mut profile, &args.command, &home, &pwd);
+        resolve_standard_path_aliases(&mut profile, &pwd);
+    }
 
-    if !args.dry_run {
+    if args.strict && !args.dry_run {
         if cargo_uses_persistent_target(&args.command) {
             ensure_child_directory(&pwd, c"target")?;
         }
@@ -135,14 +141,22 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
     // Normal execution performs the filesystem identity scan exactly once in
     // the platform backend immediately before spawn. Inspection has no spawn,
     // so its branch below runs the complete validation explicitly.
-    profile.validate_structural_security_invariants()?;
+    if args.strict {
+        profile.validate_structural_security_invariants()?;
+    }
 
     // Construct backend (kernel probe runs once here).
     let backend_options = BackendOptions {
         allow_degraded: cli_allow_degraded,
         allow_insecure_network: args.allow_insecure_linux_network || cli_allow_degraded,
     };
-    let backend = Sandbox::new_with_options(backend_options).map_err(|e| anyhow::anyhow!("{e}"))?;
+    let security_mode = if args.strict {
+        SecurityMode::Strict
+    } else {
+        SecurityMode::Standard
+    };
+    let backend = Sandbox::new_with_mode(backend_options, security_mode)
+        .map_err(|e| anyhow::anyhow!("{e}"))?;
     info!(
         backend = backend.name(),
         kernel = %backend.info().kernel,
@@ -159,13 +173,16 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         &runtime_temp_path,
         &pwd,
         &args.command,
+        args.strict,
     )
     .await?;
 
     // Dry run / inspect: print policy and exit
     if args.dry_run {
-        profile.validate_security_invariants()?;
-        print_inspect_output(&profile, &backend, proxy_port, &extra_env)?;
+        if args.strict {
+            profile.validate_security_invariants()?;
+        }
+        print_inspect_output(&profile, &backend, proxy_port, &extra_env, args.strict)?;
         let _ = shutdown_tx.send(true);
         if let Some(runtime) = proxy.take() {
             await_proxy_shutdown(runtime).await?;
@@ -315,8 +332,9 @@ async fn build_extra_env(
     runtime_temp: &Path,
     project_dir: &Path,
     command: &[String],
+    strict: bool,
 ) -> anyhow::Result<HashMap<String, String>> {
-    let mut env = filter_parent_environment(std::env::vars());
+    let mut env = filter_parent_environment(std::env::vars(), strict);
     let mut inherited: Vec<String> = env.keys().cloned().collect();
     inherited.sort();
     for name in inherited {
@@ -328,8 +346,8 @@ async fn build_extra_env(
     insert_runtime_environment(profile, &mut env, "TEMP", temp.clone());
     insert_runtime_environment(profile, &mut env, "XDG_RUNTIME_DIR", temp.clone());
     let profile_name = profile.name.clone();
-    match profile_name.as_str() {
-        "rust" => {
+    match (strict, profile_name.as_str()) {
+        (true, "rust") => {
             let target_dir = if cargo_executes_target(command) {
                 runtime_temp.join("cargo-target")
             } else {
@@ -351,7 +369,7 @@ async fn build_extra_env(
                     .into_owned(),
             );
         }
-        "python" => {
+        (true, "python") => {
             insert_runtime_environment(
                 profile,
                 &mut env,
@@ -368,7 +386,7 @@ async fn build_extra_env(
                 runtime_temp.join("uv-cache").to_string_lossy().into_owned(),
             );
         }
-        "elixir" => {
+        (true, "elixir") => {
             insert_runtime_environment(
                 profile,
                 &mut env,
@@ -391,7 +409,7 @@ async fn build_extra_env(
                     .into_owned(),
             );
         }
-        "java" => {
+        (true, "java") => {
             insert_runtime_environment(
                 profile,
                 &mut env,
@@ -424,6 +442,18 @@ async fn build_extra_env(
             );
         }
         _ => {}
+    }
+    if !strict
+        && profile_name == "rust"
+        && !env.contains_key("CARGO_TARGET_DIR")
+        && !env.contains_key("CARGO_BUILD_TARGET_DIR")
+    {
+        insert_runtime_environment(
+            profile,
+            &mut env,
+            "CARGO_TARGET_DIR",
+            project_dir.join("target").to_string_lossy().into_owned(),
+        );
     }
     if let Some(endpoint) = proxy_endpoint {
         let proxy_url = endpoint.url();
@@ -517,13 +547,275 @@ fn record_effective_environment(profile: &mut SandboxProfile, name: &str, origin
     });
 }
 
-fn filter_parent_environment<I>(variables: I) -> HashMap<String, String>
+fn filter_parent_environment<I>(variables: I, strict: bool) -> HashMap<String, String>
 where
     I: IntoIterator<Item = (String, String)>,
 {
     variables
         .into_iter()
-        .filter(|(name, _)| SAFE_PARENT_ENV.contains(&name.as_str()))
+        .filter(|(name, _)| {
+            if strict {
+                SAFE_PARENT_ENV.contains(&name.as_str())
+            } else {
+                !is_sensitive_environment_name(name)
+            }
+        })
+        .collect()
+}
+
+fn is_sensitive_environment_name(name: &str) -> bool {
+    const EXACT: &[&str] = &[
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_SESSION_TOKEN",
+        "AZURE_CLIENT_SECRET",
+        "DOCKER_AUTH_CONFIG",
+        "GPG_AGENT_INFO",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "KUBECONFIG",
+        "SSH_AGENT_PID",
+        "SSH_AUTH_SOCK",
+    ];
+    const RESERVED: &[&str] = &[
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "TMPDIR",
+        "TMP",
+        "TEMP",
+        "XDG_RUNTIME_DIR",
+        "SBE_PROXY_TOKEN",
+    ];
+
+    let upper = name.to_ascii_uppercase();
+    EXACT.contains(&upper.as_str())
+        || RESERVED.contains(&upper.as_str())
+        || upper.starts_with("DYLD_")
+        || upper == "LD_PRELOAD"
+        || upper == "LD_LIBRARY_PATH"
+        || [
+            "_TOKEN",
+            "_API_KEY",
+            "_SECRET",
+            "_PASSWORD",
+            "_PASSWD",
+            "_PRIVATE_KEY",
+            "_CREDENTIAL",
+            "_CREDENTIALS",
+        ]
+        .iter()
+        .any(|suffix| upper.ends_with(suffix))
+}
+
+fn apply_standard_profile(
+    profile: &mut SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) {
+    let project_outputs = replace_builtin_project_writes(profile, project_dir);
+
+    insert_builtin_path_grant(
+        profile,
+        GrantKind::AllowWrite,
+        SandboxPath::dir(project_dir.to_path_buf()),
+    );
+    for output in project_outputs
+        .into_iter()
+        .filter(|output| resolves_within(output, project_dir))
+    {
+        insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(output));
+    }
+
+    for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
+        if let Some(path) = std::env::var_os(name).map(PathBuf::from) {
+            let path = if path.is_absolute() {
+                path
+            } else {
+                project_dir.join(path)
+            };
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowWrite,
+                SandboxPath::dir(path.clone()),
+            );
+            insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
+        }
+    }
+
+    if command_is(command, "cargo") && top_level_subcommand(command).is_command(&["install"]) {
+        let cargo_root = std::env::var_os("CARGO_INSTALL_ROOT")
+            .or_else(|| std::env::var_os("CARGO_HOME"))
+            .map_or_else(|| home.join(".cargo"), PathBuf::from);
+        let cargo_root = if cargo_root.is_absolute() {
+            cargo_root
+        } else {
+            project_dir.join(cargo_root)
+        };
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowWrite,
+            SandboxPath::dir(cargo_root.clone()),
+        );
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowExec,
+            SandboxPath::dir(cargo_root.join("bin")),
+        );
+    }
+}
+
+fn replace_builtin_project_writes(
+    profile: &mut SandboxProfile,
+    project_dir: &Path,
+) -> Vec<PathBuf> {
+    let built_in_boundary = profile
+        .first_user_allow_write
+        .min(profile.allow_write.len());
+    let mut project_outputs = Vec::new();
+    let mut removed = Vec::new();
+    let mut retained = Vec::with_capacity(profile.allow_write.len());
+    for (index, grant) in profile.allow_write.drain(..).enumerate() {
+        if index < built_in_boundary
+            && grant.path != project_dir
+            && grant.path.starts_with(project_dir)
+        {
+            if grant.kind == sbe_core::config::PathKind::Subpath {
+                project_outputs.push(grant.path.clone());
+            }
+            removed.push(grant.path);
+        } else {
+            retained.push(grant);
+        }
+    }
+    profile.allow_write = retained;
+    profile.first_user_allow_write = built_in_boundary.saturating_sub(removed.len());
+    profile.grant_origins.retain(|record| {
+        record.kind != GrantKind::AllowWrite
+            || record.origin != GrantOrigin::BuiltIn
+            || !removed
+                .iter()
+                .any(|path| record.value == path.to_string_lossy())
+    });
+    project_outputs
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode resolves existing ancestors before granting executable project output"
+)]
+fn resolves_within(path: &Path, root: &Path) -> bool {
+    let Ok(root) = std::fs::canonicalize(root) else {
+        return false;
+    };
+    let mut existing = Some(path);
+    while let Some(candidate) = existing {
+        match std::fs::canonicalize(candidate) {
+            Ok(resolved) => return resolved.starts_with(&root),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                existing = candidate.parent();
+            }
+            Err(_) => return false,
+        }
+    }
+    false
+}
+
+fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, grant: SandboxPath) {
+    let paths = match kind {
+        GrantKind::AllowWrite => &mut profile.allow_write,
+        GrantKind::AllowExec => &mut profile.allow_exec,
+        _ => return,
+    };
+    if paths.iter().any(|existing| existing == &grant) {
+        return;
+    }
+    let value = grant.path.to_string_lossy().into_owned();
+    match kind {
+        GrantKind::AllowWrite => {
+            let index = profile.first_user_allow_write.min(paths.len());
+            paths.insert(index, grant);
+            profile.first_user_allow_write = index + 1;
+        }
+        GrantKind::AllowExec => {
+            let index = profile.first_user_allow_exec.min(paths.len());
+            paths.insert(index, grant);
+            profile.first_user_allow_exec = index + 1;
+        }
+        _ => return,
+    }
+    profile.grant_origins.push(GrantRecord {
+        kind,
+        value,
+        origin: GrantOrigin::BuiltIn,
+    });
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode snapshots pre-existing user tool and cache symlinks before launch"
+)]
+fn resolve_standard_path_aliases(profile: &mut SandboxProfile, project_dir: &Path) {
+    let write_aliases = resolved_aliases(
+        &profile.allow_write,
+        profile.first_user_allow_write,
+        project_dir,
+    );
+    let exec_aliases = resolved_aliases(
+        &profile.allow_exec,
+        profile.first_user_allow_exec,
+        project_dir,
+    );
+    for alias in write_aliases {
+        if !profile.allow_write.contains(&alias) {
+            profile.grant_origins.push(GrantRecord {
+                kind: GrantKind::AllowWrite,
+                value: alias.path.to_string_lossy().into_owned(),
+                origin: GrantOrigin::Runtime,
+            });
+            profile.allow_write.push(alias);
+        }
+    }
+    for alias in exec_aliases {
+        if !profile.allow_exec.contains(&alias) {
+            profile.grant_origins.push(GrantRecord {
+                kind: GrantKind::AllowExec,
+                value: alias.path.to_string_lossy().into_owned(),
+                origin: GrantOrigin::Runtime,
+            });
+            profile.allow_exec.push(alias);
+        }
+    }
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode snapshots pre-existing user tool and cache symlinks before launch"
+)]
+fn resolved_aliases(
+    paths: &[SandboxPath],
+    built_in_boundary: usize,
+    project_dir: &Path,
+) -> Vec<SandboxPath> {
+    paths
+        .iter()
+        .enumerate()
+        .filter_map(|(index, grant)| {
+            let resolved = std::fs::canonicalize(&grant.path).ok()?;
+            if resolved == grant.path {
+                return None;
+            }
+            let built_in_project_path = index < built_in_boundary
+                && grant.path.starts_with(project_dir)
+                && !resolved.starts_with(project_dir);
+            if built_in_project_path {
+                return None;
+            }
+            Some(SandboxPath {
+                path: resolved,
+                kind: grant.kind,
+            })
+        })
         .collect()
 }
 
@@ -1031,8 +1323,9 @@ fn ensure_literal_write_targets(
     command: &[String],
     project_dir: &Path,
 ) -> anyhow::Result<()> {
-    use sbe_core::config::PathKind;
     use std::os::fd::OwnedFd;
+
+    use sbe_core::config::PathKind;
 
     reject_project_relocation(command)?;
     let program = command
@@ -1571,10 +1864,15 @@ fn print_inspect_output(
     backend: &Sandbox,
     proxy_port: Option<u16>,
     effective_environment: &HashMap<String, String>,
+    strict: bool,
 ) -> anyhow::Result<()> {
     eprintln!("--- Backend ---");
     eprintln!("name:    {}", backend.name());
     eprintln!("kernel:  {}", backend.info().kernel);
+    eprintln!(
+        "securityMode: {}",
+        if strict { "strict" } else { "standard" }
+    );
     eprintln!("features:");
     let f = &backend.info().features;
     eprintln!("  fs_write       : {}", f.fs_write);
@@ -1778,17 +2076,40 @@ mod tests {
 
     #[test]
     fn ambient_credentials_are_not_inherited() {
-        let inherited = filter_parent_environment([
-            ("PATH".to_owned(), "/usr/bin".to_owned()),
-            ("LANG".to_owned(), "C.UTF-8".to_owned()),
-            ("GITHUB_TOKEN".to_owned(), "sentinel".to_owned()),
-            ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
-            ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
-            ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
-        ]);
-        assert_eq!(inherited.len(), 2);
+        let inherited = filter_parent_environment(
+            [
+                ("PATH".to_owned(), "/usr/bin".to_owned()),
+                ("LANG".to_owned(), "C.UTF-8".to_owned()),
+                ("RUSTFLAGS".to_owned(), "-Cdebuginfo=1".to_owned()),
+                ("GITHUB_TOKEN".to_owned(), "sentinel".to_owned()),
+                ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
+                ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
+                ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
+                ("OPENAI_API_KEY".to_owned(), "sentinel".to_owned()),
+                (
+                    "GOOGLE_APPLICATION_CREDENTIALS".to_owned(),
+                    "/tmp/google-credentials.json".to_owned(),
+                ),
+            ],
+            false,
+        );
+        assert_eq!(inherited.len(), 3);
         assert_eq!(inherited.get("PATH").map(String::as_str), Some("/usr/bin"));
+        assert_eq!(
+            inherited.get("RUSTFLAGS").map(String::as_str),
+            Some("-Cdebuginfo=1")
+        );
         assert!(!inherited.values().any(|value| value == "sentinel"));
+
+        let strict = filter_parent_environment(
+            [
+                ("PATH".to_owned(), "/usr/bin".to_owned()),
+                ("RUSTFLAGS".to_owned(), "-Cdebuginfo=1".to_owned()),
+            ],
+            true,
+        );
+        assert!(strict.contains_key("PATH"));
+        assert!(!strict.contains_key("RUSTFLAGS"));
     }
 
     #[tokio::test]
@@ -1798,9 +2119,16 @@ mod tests {
         let mut profile =
             SandboxProfile::for_ecosystem(Ecosystem::Java, Path::new("/home/test"), project.path());
 
-        let environment = build_extra_env(&mut profile, None, runtime.path(), project.path(), &[])
-            .await
-            .unwrap();
+        let environment = build_extra_env(
+            &mut profile,
+            None,
+            runtime.path(),
+            project.path(),
+            &[],
+            true,
+        )
+        .await
+        .unwrap();
         let sbt_options = environment.get("SBT_OPTS").unwrap();
 
         assert!(sbt_options.contains("-Dsbt.boot.directory="));
@@ -1820,6 +2148,7 @@ mod tests {
             runtime.path(),
             project.path(),
             &["cargo".to_owned(), "test".to_owned()],
+            true,
         )
         .await
         .unwrap();
@@ -1839,6 +2168,7 @@ mod tests {
             runtime.path(),
             project.path(),
             &["cargo".to_owned(), "build".to_owned()],
+            true,
         )
         .await
         .unwrap();
@@ -1863,6 +2193,7 @@ mod tests {
             runtime.path(),
             project.path(),
             &["cargo".to_owned(), "nextest".to_owned(), "run".to_owned()],
+            true,
         )
         .await
         .unwrap();
@@ -1877,6 +2208,124 @@ mod tests {
             "nextest".to_owned(),
             "run".to_owned(),
         ]));
+    }
+
+    #[tokio::test]
+    async fn standard_rust_profile_keeps_normal_outputs_and_wrapper_support() {
+        let project = tempfile::tempdir().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
+        let mut profile = SandboxProfile::for_ecosystem(
+            Ecosystem::Rust,
+            Path::new("/Users/test"),
+            project.path(),
+        );
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "test".to_owned()],
+            Path::new("/Users/test"),
+            project.path(),
+        );
+
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(project.path().to_path_buf()))
+        );
+        assert!(
+            profile
+                .allow_exec
+                .contains(&SandboxPath::dir(project.path().join("target")))
+        );
+        assert!(
+            profile.validate_structural_security_invariants().is_err(),
+            "standard mode deliberately permits mutable executable build output"
+        );
+
+        let environment = build_extra_env(
+            &mut profile,
+            None,
+            runtime.path(),
+            project.path(),
+            &["cargo".to_owned(), "test".to_owned()],
+            false,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            environment.get("CARGO_TARGET_DIR").map(String::as_str),
+            project.path().join("target").to_str()
+        );
+        assert!(!environment.contains_key("SCCACHE_CLIENT_SIDE"));
+        assert!(!environment.contains_key("CARGO_BUILD_BUILD_DIR"));
+    }
+
+    #[test]
+    fn standard_profile_does_not_follow_project_output_symlinks_outside_project() {
+        let project = tempfile::tempdir().unwrap();
+        let external = tempfile::tempdir().unwrap();
+        std::os::unix::fs::symlink(external.path(), project.path().join("target")).unwrap();
+        let mut profile = SandboxProfile::for_ecosystem(
+            Ecosystem::Rust,
+            Path::new("/Users/test"),
+            project.path(),
+        );
+
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "build".to_owned()],
+            Path::new("/Users/test"),
+            project.path(),
+        );
+        resolve_standard_path_aliases(&mut profile, project.path());
+
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(project.path().to_path_buf()))
+        );
+        assert!(!profile.allow_write.iter().any(|grant| {
+            grant.path == project.path().join("target") || grant.path == external.path()
+        }));
+        assert!(!profile.allow_exec.iter().any(|grant| {
+            grant.path == project.path().join("target") || grant.path == external.path()
+        }));
+    }
+
+    #[test]
+    fn standard_cargo_install_only_executes_the_install_bin_directory() {
+        let project = tempfile::tempdir().unwrap();
+        let home = Path::new("/Users/test");
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, home, project.path());
+        apply_standard_profile(
+            &mut profile,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "ripgrep".to_owned(),
+            ],
+            home,
+            project.path(),
+        );
+
+        let cargo_root = std::env::var_os("CARGO_INSTALL_ROOT")
+            .or_else(|| std::env::var_os("CARGO_HOME"))
+            .map_or_else(|| home.join(".cargo"), PathBuf::from);
+        let cargo_root = if cargo_root.is_absolute() {
+            cargo_root
+        } else {
+            project.path().join(cargo_root)
+        };
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(cargo_root.clone()))
+        );
+        assert!(
+            profile
+                .allow_exec
+                .contains(&SandboxPath::dir(cargo_root.join("bin")))
+        );
+        assert!(!profile.allow_exec.contains(&SandboxPath::dir(cargo_root)));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -677,6 +677,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "UV_CONFIG_FILE",
         "UV_DEFAULT_INDEX",
         "UV_EXTRA_INDEX_URL",
+        "UV_INDEX",
         "UV_INDEX_URL",
     ];
     const RESERVED: &[&str] = &[
@@ -833,6 +834,9 @@ fn apply_standard_profile(
                 conventional,
                 SandboxPath::dir(cache.selected.clone()),
             );
+        }
+        for config in cache.config_reads {
+            insert_builtin_path_grant(profile, GrantKind::AllowRead, SandboxPath::file(config));
         }
     }
     if profile.name == "python" && command_uses_pip(command) {
@@ -1375,6 +1379,7 @@ struct CacheReplacement {
     conventional: Vec<PathBuf>,
     selected: PathBuf,
     project_controlled: bool,
+    config_reads: Vec<PathBuf>,
 }
 
 fn effective_python_cache(
@@ -1402,29 +1407,25 @@ fn effective_python_cache(
     } else {
         None
     };
-    let (config_cache, config_project_controlled) = if command_cache.is_none()
+    let (config_cache, config_project_controlled, config_reads) = if command_cache.is_none()
         && environment_cache.is_none()
         && default_name == "pip"
     {
         (
             effective_pip_config_cache(profile, home, project_dir)?,
             false,
+            Vec::new(),
         )
     } else if command_cache.is_none() && environment_cache.is_none() && default_name == "pypoetry" {
-        effective_poetry_config_cache(profile, home, project_dir)?
+        let (cache, project_controlled) =
+            effective_poetry_config_cache(profile, home, project_dir)?;
+        (cache, project_controlled, Vec::new())
+    } else if command_cache.is_none() && environment_cache.is_none() && default_name == "uv" {
+        effective_uv_config_cache(profile, command, home, project_dir)?
     } else {
-        (None, false)
+        (None, false, Vec::new())
     };
-    let project_cache = if command_cache.is_none()
-        && environment_cache.is_none()
-        && config_cache.is_none()
-        && default_name == "uv"
-    {
-        effective_project_uv_cache(project_dir)?
-    } else {
-        None
-    };
-    let project_controlled = config_project_controlled || project_cache.is_some();
+    let project_controlled = config_project_controlled;
     let conventional = conventional_python_caches(home, default_name);
     let default_cache = effective_environment_path(profile, "XDG_CACHE_HOME")
         .map(|directory| directory.join(default_name))
@@ -1432,7 +1433,6 @@ fn effective_python_cache(
     let selected = command_cache
         .or(environment_cache)
         .or(config_cache)
-        .or(project_cache)
         .unwrap_or(default_cache);
     if selected.as_os_str().is_empty() {
         anyhow::bail!("{environment_name} must select a non-empty path");
@@ -1445,6 +1445,7 @@ fn effective_python_cache(
             project_dir.join(selected)
         },
         project_controlled,
+        config_reads,
     }))
 }
 
@@ -1464,6 +1465,56 @@ fn conventional_coursier_caches(home: &Path) -> Vec<PathBuf> {
     #[cfg(not(target_os = "macos"))]
     let paths = vec![xdg];
     paths
+}
+
+fn effective_uv_config_cache(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<(Option<PathBuf>, bool, Vec<PathBuf>)> {
+    let explicit = command_long_path_option(command, "--config-file")?
+        .or_else(|| profile.env.get("UV_CONFIG_FILE").map(PathBuf::from));
+    if let Some(path) = explicit {
+        let path = anchor_project_path(path, project_dir);
+        let Some(contents) = read_bounded_following_metadata_file(&path)? else {
+            anyhow::bail!(
+                "could not inspect explicit uv configuration: {}",
+                path.display()
+            );
+        };
+        let cache = uv_config_cache_path(&contents, &path, false)?;
+        return Ok((cache, false, vec![path]));
+    }
+
+    let no_config = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--")
+        .any(|argument| argument == "--no-config")
+        || profile.env.contains_key("UV_NO_CONFIG")
+        || std::env::var_os("UV_NO_CONFIG").is_some();
+    if no_config {
+        return Ok((None, false, Vec::new()));
+    }
+
+    let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
+        .map(|path| anchor_project_path(path, project_dir))
+        .unwrap_or_else(|| home.join(".config"));
+    let user_config = user_config_root.join("uv/uv.toml");
+    let mut reads = Vec::new();
+    let mut selected = if let Some(contents) = read_bounded_following_metadata_file(&user_config)? {
+        reads.push(user_config.clone());
+        uv_config_cache_path(&contents, &user_config, false)?
+    } else {
+        None
+    };
+
+    if let Some(project_cache) = effective_project_uv_cache(project_dir)? {
+        selected = Some(project_cache);
+        return Ok((selected, true, reads));
+    }
+    Ok((selected, false, reads))
 }
 
 fn effective_project_uv_cache(project_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
@@ -4910,6 +4961,10 @@ mod tests {
                     "https://user:sentinel@example.net/simple".to_owned(),
                 ),
                 (
+                    "UV_INDEX".to_owned(),
+                    "https://user:sentinel@example.edu/simple".to_owned(),
+                ),
+                (
                     "UV_DEFAULT_INDEX".to_owned(),
                     "https://user:sentinel@example.org/simple".to_owned(),
                 ),
@@ -5456,6 +5511,67 @@ mod tests {
             uv_command
                 .allow_write
                 .contains(&SandboxPath::dir(project.join("relative-uv-cache")))
+        );
+
+        let uv_user_config_root = root.path().join("uv-user-config");
+        let uv_user_cache = root.path().join("uv-user-cache");
+        std::fs::create_dir_all(uv_user_config_root.join("uv")).unwrap();
+        std::fs::write(
+            uv_user_config_root.join("uv/uv.toml"),
+            format!("cache-dir = '{}'\n", uv_user_cache.display()),
+        )
+        .unwrap();
+        let mut uv_user_config = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        uv_user_config.env.insert(
+            "XDG_CONFIG_HOME".to_owned(),
+            uv_user_config_root.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut uv_user_config,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            uv_user_config
+                .allow_write
+                .contains(&SandboxPath::dir(uv_user_cache))
+        );
+        assert!(
+            uv_user_config
+                .allow_read
+                .contains(&SandboxPath::file(uv_user_config_root.join("uv/uv.toml")))
+        );
+
+        let explicit_uv_config = root.path().join("explicit-uv.toml");
+        let explicit_uv_cache = root.path().join("explicit-uv-cache");
+        std::fs::write(
+            &explicit_uv_config,
+            format!("cache-dir = '{}'\n", explicit_uv_cache.display()),
+        )
+        .unwrap();
+        let mut uv_explicit = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        uv_explicit.env.insert(
+            "UV_CONFIG_FILE".to_owned(),
+            explicit_uv_config.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut uv_explicit,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            uv_explicit
+                .allow_write
+                .contains(&SandboxPath::dir(explicit_uv_cache))
+        );
+        assert!(
+            uv_explicit
+                .allow_read
+                .contains(&SandboxPath::file(explicit_uv_config))
         );
 
         let project_uv_cache = root.path().join("project-uv-cache");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -639,6 +639,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
             "_CREDENTIALS",
             "_DATABASE_URL",
             "_DATABASE_URI",
+            "_AUTH",
+            "_AUTHTOKEN",
         ]
         .iter()
         .any(|suffix| upper.ends_with(suffix))
@@ -2367,6 +2369,11 @@ mod tests {
                 ("MYSQL_PWD".to_owned(), "sentinel".to_owned()),
                 ("REDISCLI_AUTH".to_owned(), "sentinel".to_owned()),
                 ("MONGODB_URI".to_owned(), "sentinel".to_owned()),
+                ("NPM_CONFIG__AUTH".to_owned(), "sentinel".to_owned()),
+                (
+                    "NPM_CONFIG_//REGISTRY.NPMJS.ORG/:_AUTHTOKEN".to_owned(),
+                    "sentinel".to_owned(),
+                ),
                 (
                     "GOOGLE_APPLICATION_CREDENTIALS".to_owned(),
                     "/tmp/google-credentials.json".to_owned(),

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -32,6 +32,15 @@ use crate::cli::RunArgs;
 /// sbe exit codes for its own errors (matching docker run / env conventions).
 const EXIT_SBE_ERROR: u8 = 125;
 const EXIT_SANDBOX_FAILED: u8 = 126;
+const STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES: &[&str] = &[
+    "caches",
+    "daemon",
+    "jdks",
+    "native",
+    "notifications",
+    "workers",
+    "wrapper",
+];
 #[cfg(target_os = "linux")]
 const MAX_SOURCE_SYMLINK_SCAN_ENTRIES: usize = 100_000;
 #[cfg(target_os = "linux")]
@@ -105,6 +114,10 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         enable_existing_dependency_execution(&mut profile, &args.command);
     } else {
         apply_standard_profile(&mut profile, &args.command, &home, &pwd)?;
+        #[cfg(target_os = "macos")]
+        if !args.dry_run {
+            prepare_standard_gradle_directories(&profile, &args.command, &home, &pwd)?;
+        }
         resolve_standard_path_aliases(&mut profile, &home, &pwd)?;
     }
 
@@ -730,15 +743,18 @@ fn apply_standard_profile(
         );
 
         if let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir) {
-            // Wrapper distributions, dependency caches, and daemon state all
-            // live here. Gradle also executes wrapper/worker code from this
-            // tree, so standard mode needs both halves of its mutable output.
-            insert_builtin_path_grant(
-                profile,
-                GrantKind::AllowWrite,
-                SandboxPath::dir(gradle_home.clone()),
-            );
-            insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(gradle_home));
+            // Keep init.d and root-level initialization scripts immutable.
+            // Standard mode accepts cache poisoning, but should not provide a
+            // direct unsandboxed-startup persistence mechanism.
+            for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+                let path = gradle_home.join(name);
+                insert_builtin_path_grant(
+                    profile,
+                    GrantKind::AllowWrite,
+                    SandboxPath::dir(path.clone()),
+                );
+                insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
+            }
         }
     }
 
@@ -811,6 +827,32 @@ fn effective_gradle_user_home(
     } else {
         project_dir.join(selected)
     })
+}
+
+#[cfg(target_os = "macos")]
+#[allow(
+    clippy::disallowed_methods,
+    reason = "the trusted parent prepares exact Gradle runtime directories before sandboxing"
+)]
+fn prepare_standard_gradle_directories(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<()> {
+    let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir) else {
+        return Ok(());
+    };
+    for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+        let path = gradle_home.join(name);
+        std::fs::create_dir_all(&path).with_context(|| {
+            format!(
+                "could not prepare Gradle runtime directory '{}'",
+                path.display()
+            )
+        })?;
+    }
+    Ok(())
 }
 
 fn remove_builtin_workspace_read_denials(profile: &mut SandboxProfile, project_dir: &Path) {
@@ -2927,16 +2969,41 @@ mod tests {
             &project,
         )
         .unwrap();
+        for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+            let path = inherited_home.join(name);
+            assert!(
+                inherited
+                    .allow_write
+                    .contains(&SandboxPath::dir(path.clone()))
+            );
+            assert!(inherited.allow_exec.contains(&SandboxPath::dir(path)));
+        }
         assert!(
-            inherited
+            !inherited
                 .allow_write
                 .contains(&SandboxPath::dir(inherited_home.clone()))
         );
         assert!(
-            inherited
-                .allow_exec
-                .contains(&SandboxPath::dir(inherited_home))
+            !inherited
+                .allow_write
+                .iter()
+                .any(|grant| grant.path.starts_with(inherited_home.join("init.d")))
         );
+
+        #[cfg(target_os = "macos")]
+        {
+            prepare_standard_gradle_directories(
+                &inherited,
+                &["./gradlew".to_owned(), "build".to_owned()],
+                &home,
+                &project,
+            )
+            .unwrap();
+            for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+                assert!(inherited_home.join(name).is_dir());
+            }
+            assert!(!inherited_home.join("init.d").exists());
+        }
 
         let cli_home = PathBuf::from(".cache/gradle-cli");
         let mut cli = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
@@ -2960,11 +3027,12 @@ mod tests {
         )
         .unwrap();
         let cli_home = project.join(cli_home);
-        assert!(
-            cli.allow_write
-                .contains(&SandboxPath::dir(cli_home.clone()))
-        );
-        assert!(cli.allow_exec.contains(&SandboxPath::dir(cli_home)));
+        for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+            let path = cli_home.join(name);
+            assert!(cli.allow_write.contains(&SandboxPath::dir(path.clone())));
+            assert!(cli.allow_exec.contains(&SandboxPath::dir(path)));
+        }
+        assert!(!cli.allow_write.contains(&SandboxPath::dir(cli_home)));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -758,8 +758,27 @@ fn apply_standard_profile(
         }
     }
 
-    for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
-        if let Some(path) = effective_environment_path(profile, name) {
+    let cargo_cli_target = command_is(command, "cargo")
+        .then(|| command_option_value(command, "--target-dir"))
+        .flatten()
+        .map(PathBuf::from);
+    if let Some(path) = cargo_cli_target {
+        let path = if path.is_absolute() {
+            path
+        } else {
+            project_dir.join(path)
+        };
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowWrite,
+            SandboxPath::dir(path.clone()),
+        );
+        insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
+    } else {
+        for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
+            let Some(path) = effective_environment_path(profile, name) else {
+                continue;
+            };
             let path = if path.is_absolute() {
                 path
             } else {
@@ -773,7 +792,6 @@ fn apply_standard_profile(
             insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
         }
     }
-
     if command_is(command, "cargo") && top_level_subcommand(command).is_command(&["install"]) {
         let cargo_root = command_option_value(command, "--root")
             .map(PathBuf::from)
@@ -819,6 +837,7 @@ fn effective_gradle_user_home(
     let selected = command_option_value(command, "--gradle-user-home")
         .or_else(|| command_option_value(command, "-g"))
         .map(PathBuf::from)
+        .or_else(|| command_system_property(command, "gradle.user.home").map(PathBuf::from))
         .or_else(|| effective_environment_path(profile, "GRADLE_USER_HOME"))
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| home.join(".gradle"));
@@ -1462,6 +1481,30 @@ fn command_option_value<'a>(command: &'a [String], option: &str) -> Option<&'a s
             .strip_prefix(option)
             .and_then(|suffix| suffix.strip_prefix('='))
         {
+            return Some(value);
+        }
+    }
+    None
+}
+
+fn command_system_property<'a>(command: &'a [String], name: &str) -> Option<&'a str> {
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    while let Some(argument) = arguments.next() {
+        let property = if argument == "-D" || argument == "--system-prop" {
+            arguments.next().map(String::as_str)
+        } else {
+            argument
+                .strip_prefix("-D")
+                .or_else(|| argument.strip_prefix("--system-prop="))
+        };
+        if let Some(value) = property.and_then(|property| {
+            property
+                .strip_prefix(name)
+                .and_then(|suffix| suffix.strip_prefix('='))
+        }) {
             return Some(value);
         }
     }
@@ -3035,6 +3078,36 @@ mod tests {
             assert!(cli.allow_exec.contains(&SandboxPath::dir(path)));
         }
         assert!(!cli.allow_write.contains(&SandboxPath::dir(cli_home)));
+
+        let property_home = root.path().join("property-gradle");
+        let mut property = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        property.env.insert(
+            "GRADLE_USER_HOME".to_owned(),
+            root.path()
+                .join("ignored-environment-gradle")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        apply_standard_profile(
+            &mut property,
+            &[
+                "gradle".to_owned(),
+                format!("-Dgradle.user.home={}", property_home.display()),
+                "build".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+            let path = property_home.join(name);
+            assert!(
+                property
+                    .allow_write
+                    .contains(&SandboxPath::dir(path.clone()))
+            );
+            assert!(property.allow_exec.contains(&SandboxPath::dir(path)));
+        }
     }
 
     #[test]
@@ -3400,6 +3473,41 @@ mod tests {
             build_profile
                 .allow_exec
                 .contains(&SandboxPath::dir(target.path().to_path_buf()))
+        );
+
+        let mut cli_build_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        cli_build_profile.env.insert(
+            "CARGO_TARGET_DIR".to_owned(),
+            target.path().to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut cli_build_profile,
+            &[
+                "cargo".to_owned(),
+                "build".to_owned(),
+                "--target-dir=cli-target".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        let cli_target = project.path().join("cli-target");
+        assert!(
+            cli_build_profile
+                .allow_write
+                .contains(&SandboxPath::dir(cli_target.clone()))
+        );
+        assert!(
+            cli_build_profile
+                .allow_exec
+                .contains(&SandboxPath::dir(cli_target))
+        );
+        assert!(
+            !cli_build_profile
+                .allow_write
+                .contains(&SandboxPath::dir(target.path().to_path_buf())),
+            "the CLI target directory must replace the lower-precedence environment path"
         );
 
         let mut install_profile =

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -113,6 +113,7 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         });
     }
     profile.finalize();
+    protect_effective_cargo_credentials(&mut profile, &home, &pwd);
     if args.strict {
         enable_existing_dependency_execution(&mut profile, &args.command);
     } else {
@@ -892,6 +893,36 @@ fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<Pa
         .get(name)
         .map(PathBuf::from)
         .or_else(|| std::env::var_os(name).map(PathBuf::from))
+}
+
+fn protect_effective_cargo_credentials(
+    profile: &mut SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) {
+    let cargo_home =
+        effective_environment_path(profile, "CARGO_HOME").unwrap_or_else(|| home.join(".cargo"));
+    let cargo_home = if cargo_home.is_absolute() {
+        cargo_home
+    } else {
+        project_dir.join(cargo_home)
+    };
+    for name in ["credentials.toml", "credentials"] {
+        insert_builtin_read_denial(profile, SandboxPath::file(cargo_home.join(name)));
+    }
+}
+
+fn insert_builtin_read_denial(profile: &mut SandboxProfile, denial: SandboxPath) {
+    if profile.deny_read.iter().any(|existing| existing == &denial) {
+        return;
+    }
+    let value = denial.path.to_string_lossy().into_owned();
+    profile.deny_read.push(denial);
+    profile.grant_origins.push(GrantRecord {
+        kind: GrantKind::DenyRead,
+        value,
+        origin: GrantOrigin::BuiltIn,
+    });
 }
 
 fn effective_gradle_user_home(
@@ -3490,6 +3521,29 @@ mod tests {
         );
         assert!(strict.contains_key("PATH"));
         assert!(!strict.contains_key("RUSTFLAGS"));
+    }
+
+    #[test]
+    fn custom_cargo_home_credential_files_remain_denied() {
+        let project = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let mut profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        profile
+            .env
+            .insert("CARGO_HOME".to_owned(), "custom-cargo".to_owned());
+
+        protect_effective_cargo_credentials(&mut profile, home.path(), project.path());
+
+        for name in ["credentials.toml", "credentials"] {
+            let denied = SandboxPath::file(project.path().join("custom-cargo").join(name));
+            assert!(profile.deny_read.contains(&denied));
+            assert!(profile.grant_origins.iter().any(|record| {
+                record.kind == GrantKind::DenyRead
+                    && record.origin == GrantOrigin::BuiltIn
+                    && record.value == denied.path.to_string_lossy()
+            }));
+        }
     }
 
     #[tokio::test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -840,13 +840,18 @@ fn effective_gradle_user_home(
         .or_else(|| command_option_value(command, "-g"))
         .map(PathBuf::from)
         .or_else(|| command_system_property(command, "gradle.user.home").map(PathBuf::from));
-    let gradle_opts_home = if command_home.is_none() {
-        gradle_opts_user_home(profile)?
+    let inherited_jvm_home = if command_home.is_none() {
+        let gradle_opts = jvm_options_gradle_user_home(profile, "GRADLE_OPTS")?;
+        if gradle_opts.is_some() {
+            gradle_opts
+        } else {
+            jvm_options_gradle_user_home(profile, "JAVA_OPTS")?
+        }
     } else {
         None
     };
     let selected = command_home
-        .or(gradle_opts_home)
+        .or(inherited_jvm_home)
         .or_else(|| effective_environment_path(profile, "GRADLE_USER_HOME"))
         .filter(|path| !path.as_os_str().is_empty())
         .unwrap_or_else(|| home.join(".gradle"));
@@ -857,12 +862,15 @@ fn effective_gradle_user_home(
     }))
 }
 
-fn gradle_opts_user_home(profile: &SandboxProfile) -> anyhow::Result<Option<PathBuf>> {
+fn jvm_options_gradle_user_home(
+    profile: &SandboxProfile,
+    variable: &str,
+) -> anyhow::Result<Option<PathBuf>> {
     let Some(options) = profile
         .env
-        .get("GRADLE_OPTS")
+        .get(variable)
         .cloned()
-        .or_else(|| std::env::var("GRADLE_OPTS").ok())
+        .or_else(|| std::env::var(variable).ok())
     else {
         return Ok(None);
     };
@@ -877,7 +885,7 @@ fn gradle_opts_user_home(profile: &SandboxProfile) -> anyhow::Result<Option<Path
                 .any(|character| matches!(character, '$' | '`' | '\\' | '\'' | '"'))
         {
             anyhow::bail!(
-                "GRADLE_OPTS selects gradle.user.home with quoting or expansion that sbe cannot \
+                "{variable} selects gradle.user.home with quoting or expansion that sbe cannot \
                  resolve safely; use --gradle-user-home or GRADLE_USER_HOME"
             );
         }
@@ -886,7 +894,7 @@ fn gradle_opts_user_home(profile: &SandboxProfile) -> anyhow::Result<Option<Path
     }
     if selected.is_none() && options.contains("-Dgradle.user.home") {
         anyhow::bail!(
-            "GRADLE_OPTS selects gradle.user.home in an unsupported form; use --gradle-user-home \
+            "{variable} selects gradle.user.home in an unsupported form; use --gradle-user-home \
              or GRADLE_USER_HOME"
         );
     }
@@ -1541,6 +1549,7 @@ fn command_system_property<'a>(command: &'a [String], name: &str) -> Option<&'a 
         .iter()
         .skip(1)
         .take_while(|argument| argument.as_str() != "--");
+    let mut selected = None;
     while let Some(argument) = arguments.next() {
         let property = if argument == "-D" || argument == "--system-prop" {
             arguments.next().map(String::as_str)
@@ -1554,10 +1563,10 @@ fn command_system_property<'a>(command: &'a [String], name: &str) -> Option<&'a 
                 .strip_prefix(name)
                 .and_then(|suffix| suffix.strip_prefix('='))
         }) {
-            return Some(value);
+            selected = Some(value);
         }
     }
-    None
+    selected
 }
 
 #[cfg(target_os = "linux")]
@@ -3149,6 +3158,10 @@ mod tests {
             &mut property,
             &[
                 "gradle".to_owned(),
+                format!(
+                    "-Dgradle.user.home={}",
+                    root.path().join("ignored-first-property").display()
+                ),
                 format!("-Dgradle.user.home={}", property_home.display()),
                 "build".to_owned(),
             ],
@@ -3186,6 +3199,36 @@ mod tests {
             let path = opts_home.join(name);
             assert!(opts.allow_write.contains(&SandboxPath::dir(path.clone())));
             assert!(opts.allow_exec.contains(&SandboxPath::dir(path)));
+        }
+
+        let java_opts_home = root.path().join("java-opts-gradle");
+        let mut java_opts = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        java_opts.env.insert(
+            "JAVA_OPTS".to_owned(),
+            format!("-Dgradle.user.home={}", java_opts_home.display()),
+        );
+        java_opts.env.insert(
+            "GRADLE_USER_HOME".to_owned(),
+            root.path()
+                .join("ignored-environment-home")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        apply_standard_profile(
+            &mut java_opts,
+            &["gradle".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        for name in STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES {
+            let path = java_opts_home.join(name);
+            assert!(
+                java_opts
+                    .allow_write
+                    .contains(&SandboxPath::dir(path.clone()))
+            );
+            assert!(java_opts.allow_exec.contains(&SandboxPath::dir(path)));
         }
 
         let mut ambiguous = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -621,6 +621,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "AWS_ACCESS_KEY_ID",
         "AWS_CONTAINER_CREDENTIALS_FULL_URI",
         "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI",
+        "AWS_CONFIG_FILE",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SHARED_CREDENTIALS_FILE",
         "AWS_SESSION_TOKEN",
@@ -1666,11 +1667,11 @@ fn workspace_read_aliases_with_limits(
 
     let project_referent =
         std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
-    let mut pending = vec![(project_dir.to_path_buf(), 0_usize)];
+    let mut pending = vec![(project_dir.to_path_buf(), 0_usize, false)];
     let mut visited_directories = BTreeSet::new();
     let mut resolved_paths = BTreeSet::new();
     let mut inspected_entries = 0_usize;
-    while let Some((directory, depth)) = pending.pop() {
+    while let Some((directory, depth, symlinks_only)) = pending.pop() {
         if depth > max_depth {
             anyhow::bail!(
                 "source symlink discovery exceeds the maximum depth of {max_depth} below '{}'",
@@ -1684,7 +1685,7 @@ fn workspace_read_aliases_with_limits(
                 continue;
             }
         };
-        if !visited_directories.insert(directory.clone()) {
+        if !visited_directories.insert((directory.clone(), symlinks_only)) {
             continue;
         }
         let entries = match std::fs::read_dir(&directory) {
@@ -1711,13 +1712,10 @@ fn workspace_read_aliases_with_limits(
                 }
             };
             let path = entry.path();
-            if entry
+            let is_derived_directory = entry
                 .file_name()
                 .to_str()
-                .is_some_and(|name| DERIVED_DIRECTORIES.contains(&name))
-            {
-                continue;
-            }
+                .is_some_and(|name| DERIVED_DIRECTORIES.contains(&name));
             let file_type = match entry.file_type() {
                 Ok(file_type) => file_type,
                 Err(error) => {
@@ -1735,13 +1733,12 @@ fn workspace_read_aliases_with_limits(
                 {
                     continue;
                 }
-                if resolved_paths.insert(resolved.clone())
-                    && std::fs::metadata(&resolved).is_ok_and(|metadata| metadata.is_dir())
-                {
-                    pending.push((resolved, depth + 1));
+                resolved_paths.insert(resolved.clone());
+                if std::fs::metadata(&resolved).is_ok_and(|metadata| metadata.is_dir()) {
+                    pending.push((resolved, depth + 1, is_derived_directory));
                 }
-            } else if file_type.is_dir() {
-                pending.push((path, depth + 1));
+            } else if file_type.is_dir() && !symlinks_only {
+                pending.push((path, depth + 1, is_derived_directory));
             }
         }
     }
@@ -3235,6 +3232,7 @@ mod tests {
                     "http://127.0.0.1/credentials".to_owned(),
                 ),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
+                ("AWS_CONFIG_FILE".to_owned(), "/tmp/aws-config".to_owned()),
                 (
                     "AWS_SHARED_CREDENTIALS_FILE".to_owned(),
                     "/tmp/aws-credentials".to_owned(),
@@ -4094,6 +4092,34 @@ mod tests {
         let depth_error =
             workspace_read_aliases_with_limits(&profile, &project, 100, 1).unwrap_err();
         assert!(depth_error.to_string().contains("maximum depth"));
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test builds an isolated linked-dependency fixture"
+    )]
+    fn standard_source_symlink_discovery_reads_linked_generated_dependencies() {
+        let root = tempfile::tempdir().unwrap();
+        let project = root.path().join("project");
+        let dependencies = project.join("node_modules");
+        let ordinary_dependency = dependencies.join("ordinary");
+        let linked = root.path().join("linked");
+        let ignored = root.path().join("ignored");
+        std::fs::create_dir_all(&ordinary_dependency).unwrap();
+        std::fs::create_dir_all(&linked).unwrap();
+        std::fs::create_dir_all(&ignored).unwrap();
+        std::os::unix::fs::symlink("../../linked", dependencies.join("local")).unwrap();
+        std::os::unix::fs::symlink("../../../ignored", ordinary_dependency.join("nested")).unwrap();
+        let profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, root.path(), &project);
+
+        let aliases = workspace_read_aliases_with_limits(&profile, &project, 100, 128).unwrap();
+
+        assert!(aliases.contains(&SandboxPath::dir(std::fs::canonicalize(linked).unwrap())));
+        assert!(
+            !aliases.contains(&SandboxPath::dir(std::fs::canonicalize(ignored).unwrap())),
+            "ordinary generated dependency contents must not be recursively scanned"
+        );
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{BTreeSet, HashMap},
     ffi::CString,
     os::{
         fd::{AsRawFd, FromRawFd},
@@ -171,6 +171,7 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         &mut profile,
         proxy.as_ref().map(|runtime| &runtime.endpoint),
         &runtime_temp_path,
+        &home,
         &pwd,
         &args.command,
         args.strict,
@@ -330,6 +331,7 @@ async fn build_extra_env(
     profile: &mut SandboxProfile,
     proxy_endpoint: Option<&ProxyEndpoint>,
     runtime_temp: &Path,
+    home: &Path,
     project_dir: &Path,
     command: &[String],
     strict: bool,
@@ -438,6 +440,26 @@ async fn build_extra_env(
                     sbt_root.join("global").display(),
                     sbt_root.join("boot").display(),
                     sbt_root.join("ivy2").display(),
+                ),
+            );
+        }
+        (false, "java") => {
+            // Keep ordinary dependency caches persistent, but put sbt's
+            // mutable global base in the private run root. The default global
+            // base also contains settings and plugins, so granting ~/.sbt
+            // broadly would let an untrusted build persist executable code.
+            let inherited = env.get("SBT_OPTS").cloned().unwrap_or_default();
+            let separator = if inherited.is_empty() { "" } else { " " };
+            insert_runtime_environment(
+                profile,
+                &mut env,
+                "SBT_OPTS",
+                format!(
+                    "{inherited}{separator}-Dsbt.global.base={} -Dsbt.boot.directory={} \
+                     -Dsbt.ivy.home={}",
+                    runtime_temp.join("sbt-global").display(),
+                    home.join(".sbt/boot").display(),
+                    home.join(".ivy2").display(),
                 ),
             );
         }
@@ -565,16 +587,24 @@ where
 
 fn is_sensitive_environment_name(name: &str) -> bool {
     const EXACT: &[&str] = &[
+        "API_KEY",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
         "AWS_SESSION_TOKEN",
         "AZURE_CLIENT_SECRET",
+        "CREDENTIAL",
+        "CREDENTIALS",
         "DOCKER_AUTH_CONFIG",
         "GPG_AGENT_INFO",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
+        "PASSWORD",
+        "PASSWD",
+        "PRIVATE_KEY",
+        "SECRET",
         "SSH_AGENT_PID",
         "SSH_AUTH_SOCK",
+        "TOKEN",
     ];
     const RESERVED: &[&str] = &[
         "HTTP_PROXY",
@@ -641,7 +671,7 @@ fn apply_standard_profile(
         // Standard mode uses the package manager's ordinary persistent
         // caches. Strict mode redirects these into the private runtime root.
         for cache in [
-            home.join(".sbt"),
+            home.join(".sbt/boot"),
             home.join(".ivy2/cache"),
             home.join(".cache/coursier"),
         ] {
@@ -672,9 +702,11 @@ fn apply_standard_profile(
     }
 
     if command_is(command, "cargo") && top_level_subcommand(command).is_command(&["install"]) {
-        let cargo_root = std::env::var_os("CARGO_INSTALL_ROOT")
-            .or_else(|| std::env::var_os("CARGO_HOME"))
-            .map_or_else(|| home.join(".cargo"), PathBuf::from);
+        let cargo_root = command_option_value(command, "--root")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("CARGO_INSTALL_ROOT").map(PathBuf::from))
+            .or_else(|| std::env::var_os("CARGO_HOME").map(PathBuf::from))
+            .unwrap_or_else(|| home.join(".cargo"));
         let cargo_root = if cargo_root.is_absolute() {
             cargo_root
         } else {
@@ -828,6 +860,7 @@ fn resolve_standard_path_aliases(profile: &mut SandboxProfile, project_dir: &Pat
         profile.first_user_allow_exec,
         project_dir,
     );
+    let read_aliases = workspace_read_aliases(profile, project_dir);
     for alias in write_aliases {
         if !profile.allow_write.contains(&alias) {
             profile.grant_origins.push(GrantRecord {
@@ -846,6 +879,136 @@ fn resolve_standard_path_aliases(profile: &mut SandboxProfile, project_dir: &Pat
                 origin: GrantOrigin::Runtime,
             });
             profile.allow_exec.push(alias);
+        }
+    }
+    for alias in read_aliases {
+        if !profile.allow_read.contains(&alias) {
+            profile.grant_origins.push(GrantRecord {
+                kind: GrantKind::AllowRead,
+                value: alias.path.to_string_lossy().into_owned(),
+                origin: GrantOrigin::Runtime,
+            });
+            profile.allow_read.push(alias);
+        }
+    }
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode snapshots source symlink referents before launching untrusted code"
+)]
+fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<SandboxPath> {
+    const DERIVED_DIRECTORIES: &[&str] = &[
+        ".git",
+        ".gradle",
+        ".venv",
+        ".yarn",
+        "_build",
+        "build",
+        "deps",
+        "dist",
+        "node_modules",
+        "target",
+        "venv",
+    ];
+    const MAGIC_ROOTS: &[&str] = &["/dev", "/proc", "/sys"];
+
+    let project_referent =
+        std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
+    let mut pending = vec![project_dir.to_path_buf()];
+    let mut resolved_paths = BTreeSet::new();
+    while let Some(directory) = pending.pop() {
+        let entries = match std::fs::read_dir(&directory) {
+            Ok(entries) => entries,
+            Err(error) => {
+                warn!(path = %directory.display(), %error, "could not inspect workspace symlinks");
+                continue;
+            }
+        };
+        for entry in entries {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(error) => {
+                    warn!(path = %directory.display(), %error, "could not inspect workspace entry");
+                    continue;
+                }
+            };
+            let path = entry.path();
+            if entry
+                .file_name()
+                .to_str()
+                .is_some_and(|name| DERIVED_DIRECTORIES.contains(&name))
+            {
+                continue;
+            }
+            let file_type = match entry.file_type() {
+                Ok(file_type) => file_type,
+                Err(error) => {
+                    warn!(path = %path.display(), %error, "could not inspect workspace entry type");
+                    continue;
+                }
+            };
+            if file_type.is_symlink() {
+                let Ok(resolved) = std::fs::canonicalize(&path) else {
+                    continue;
+                };
+                if resolved.starts_with(&project_referent)
+                    || MAGIC_ROOTS.iter().any(|root| resolved.starts_with(root))
+                    || overlaps_denied_read(profile, &resolved)
+                {
+                    continue;
+                }
+                resolved_paths.insert(resolved);
+            } else if file_type.is_dir() {
+                pending.push(path);
+            }
+        }
+    }
+
+    resolved_paths
+        .into_iter()
+        .filter_map(|path| {
+            let metadata = std::fs::metadata(&path).ok()?;
+            Some(if metadata.is_dir() {
+                SandboxPath::dir(path)
+            } else {
+                SandboxPath::file(path)
+            })
+        })
+        .collect()
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode compares source symlink referents with protected paths before launch"
+)]
+fn overlaps_denied_read(profile: &SandboxProfile, candidate: &Path) -> bool {
+    profile.deny_read.iter().any(|denied| {
+        let denied = resolve_existing_ancestor(&denied.path).unwrap_or_else(|| denied.path.clone());
+        candidate.starts_with(&denied) || denied.starts_with(candidate)
+    })
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode resolves a protected path's existing ancestor before comparison"
+)]
+fn resolve_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut existing = path;
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Some(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                missing.push(existing.file_name()?.to_os_string());
+                existing = existing.parent()?;
+            }
+            Err(_) => return None,
         }
     }
 }
@@ -930,6 +1093,25 @@ fn command_has_flag(command: &[String], flags: &[&str]) -> bool {
         .skip(1)
         .take_while(|argument| argument.as_str() != "--")
         .any(|argument| flags.contains(&argument.as_str()))
+}
+
+fn command_option_value<'a>(command: &'a [String], option: &str) -> Option<&'a str> {
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    while let Some(argument) = arguments.next() {
+        if argument == option {
+            return arguments.next().map(String::as_str);
+        }
+        if let Some(value) = argument
+            .strip_prefix(option)
+            .and_then(|suffix| suffix.strip_prefix('='))
+        {
+            return Some(value);
+        }
+    }
+    None
 }
 
 #[cfg(target_os = "linux")]
@@ -2148,6 +2330,14 @@ mod tests {
                 ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
                 ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
                 ("OPENAI_API_KEY".to_owned(), "sentinel".to_owned()),
+                ("TOKEN".to_owned(), "sentinel".to_owned()),
+                ("API_KEY".to_owned(), "sentinel".to_owned()),
+                ("SECRET".to_owned(), "sentinel".to_owned()),
+                ("PASSWORD".to_owned(), "sentinel".to_owned()),
+                ("PASSWD".to_owned(), "sentinel".to_owned()),
+                ("PRIVATE_KEY".to_owned(), "sentinel".to_owned()),
+                ("CREDENTIAL".to_owned(), "sentinel".to_owned()),
+                ("CREDENTIALS".to_owned(), "sentinel".to_owned()),
                 (
                     "GOOGLE_APPLICATION_CREDENTIALS".to_owned(),
                     "/tmp/google-credentials.json".to_owned(),
@@ -2185,6 +2375,7 @@ mod tests {
             &mut profile,
             None,
             runtime.path(),
+            Path::new("/home/test"),
             project.path(),
             &[],
             true,
@@ -2208,6 +2399,7 @@ mod tests {
             &mut profile,
             None,
             runtime.path(),
+            Path::new("/home/test"),
             project.path(),
             &["cargo".to_owned(), "test".to_owned()],
             true,
@@ -2228,6 +2420,7 @@ mod tests {
             &mut profile,
             None,
             runtime.path(),
+            Path::new("/home/test"),
             project.path(),
             &["cargo".to_owned(), "build".to_owned()],
             true,
@@ -2253,6 +2446,7 @@ mod tests {
             &mut profile,
             None,
             runtime.path(),
+            Path::new("/home/test"),
             project.path(),
             &["cargo".to_owned(), "nextest".to_owned(), "run".to_owned()],
             true,
@@ -2316,6 +2510,7 @@ mod tests {
             &mut profile,
             None,
             runtime.path(),
+            Path::new("/Users/test"),
             project.path(),
             &["cargo".to_owned(), "test".to_owned()],
             false,
@@ -2360,6 +2555,53 @@ mod tests {
         assert!(!profile.allow_exec.iter().any(|grant| {
             grant.path == project.path().join("target") || grant.path == external.path()
         }));
+        assert!(
+            !profile
+                .allow_read
+                .iter()
+                .any(|grant| grant.path == external.path()),
+            "generated output symlinks are not inferred as source read grants"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test builds and resolves an isolated temporary symlink fixture"
+    )]
+    fn standard_profile_reads_source_symlink_referents_outside_project() {
+        let root = tempfile::tempdir().unwrap();
+        let project = root.path().join("project");
+        let source = project.join("src");
+        let shared = root.path().join("shared");
+        let protected = root.path().join(".aws");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&shared).unwrap();
+        std::fs::create_dir_all(&protected).unwrap();
+        std::os::unix::fs::symlink("../../shared", source.join("shared")).unwrap();
+        std::os::unix::fs::symlink("../../.aws", source.join("credentials")).unwrap();
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, root.path(), &project);
+
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "build".to_owned()],
+            root.path(),
+            &project,
+        );
+        resolve_standard_path_aliases(&mut profile, &project);
+
+        assert!(
+            profile
+                .allow_read
+                .contains(&SandboxPath::dir(std::fs::canonicalize(shared).unwrap()))
+        );
+        assert!(
+            !profile
+                .allow_read
+                .iter()
+                .any(|grant| { grant.path == std::fs::canonicalize(&protected).unwrap() }),
+            "protected referents must not receive an inferred read grant"
+        );
     }
 
     #[test]
@@ -2387,10 +2629,11 @@ mod tests {
         assert!(profile.deny_read.contains(&SandboxPath::file(denied)));
     }
 
-    #[test]
-    fn standard_java_profile_uses_normal_persistent_caches() {
+    #[tokio::test]
+    async fn standard_java_profile_uses_normal_persistent_caches() {
         let project = tempfile::tempdir().unwrap();
         let home = tempfile::tempdir().unwrap();
+        let runtime = tempfile::tempdir().unwrap();
         let mut profile =
             SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
 
@@ -2401,7 +2644,7 @@ mod tests {
             project.path(),
         );
 
-        for cache in [".sbt", ".ivy2/cache", ".cache/coursier"] {
+        for cache in [".sbt/boot", ".ivy2/cache", ".cache/coursier"] {
             assert!(
                 profile
                     .allow_write
@@ -2409,6 +2652,33 @@ mod tests {
                 "missing standard cache grant for {cache}"
             );
         }
+        assert!(
+            !profile
+                .allow_write
+                .contains(&SandboxPath::dir(home.path().join(".sbt"))),
+            "the sbt global plugin/settings root must remain non-writable"
+        );
+
+        let environment = build_extra_env(
+            &mut profile,
+            None,
+            runtime.path(),
+            home.path(),
+            project.path(),
+            &["sbt".to_owned(), "compile".to_owned()],
+            false,
+        )
+        .await
+        .unwrap();
+        let sbt_options = environment.get("SBT_OPTS").unwrap();
+        assert!(sbt_options.contains(&format!(
+            "-Dsbt.global.base={}",
+            runtime.path().join("sbt-global").display()
+        )));
+        assert!(sbt_options.contains(&format!(
+            "-Dsbt.boot.directory={}",
+            home.path().join(".sbt/boot").display()
+        )));
     }
 
     #[test]
@@ -2446,6 +2716,48 @@ mod tests {
                 .contains(&SandboxPath::dir(cargo_root.join("bin")))
         );
         assert!(!profile.allow_exec.contains(&SandboxPath::dir(cargo_root)));
+    }
+
+    #[test]
+    fn standard_cargo_install_honors_explicit_root() {
+        let project = tempfile::tempdir().unwrap();
+        let install_root = tempfile::tempdir().unwrap();
+        let home = Path::new("/Users/test");
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, home, project.path());
+        apply_standard_profile(
+            &mut profile,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "--root".to_owned(),
+                install_root.path().to_string_lossy().into_owned(),
+                "ripgrep".to_owned(),
+            ],
+            home,
+            project.path(),
+        );
+
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(install_root.path().to_path_buf()))
+        );
+        assert!(
+            profile
+                .allow_exec
+                .contains(&SandboxPath::dir(install_root.path().join("bin")))
+        );
+        assert_eq!(
+            command_option_value(
+                &[
+                    "cargo".to_owned(),
+                    "install".to_owned(),
+                    "--root=relative".to_owned()
+                ],
+                "--root"
+            ),
+            Some("relative")
+        );
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -32,6 +32,8 @@ use crate::cli::RunArgs;
 /// sbe exit codes for its own errors (matching docker run / env conventions).
 const EXIT_SBE_ERROR: u8 = 125;
 const EXIT_SANDBOX_FAILED: u8 = 126;
+const STANDARD_NO_PROXY: &str = "localhost,.localhost,127.0.0.1,::1";
+const STANDARD_JAVA_NON_PROXY_HOSTS: &str = "localhost|*.localhost|127.*|[::1]";
 const STANDARD_GRADLE_MUTABLE_SUBDIRECTORIES: &[&str] = &[
     "caches",
     "daemon",
@@ -500,11 +502,17 @@ async fn build_extra_env(
         insert_runtime_environment(profile, &mut env, "HTTPS_PROXY", proxy_url.clone());
         insert_runtime_environment(profile, &mut env, "http_proxy", proxy_url.clone());
         insert_runtime_environment(profile, &mut env, "https_proxy", proxy_url);
-        insert_runtime_environment(profile, &mut env, "NO_PROXY", String::new());
-        insert_runtime_environment(profile, &mut env, "no_proxy", String::new());
+        let no_proxy = if strict { "" } else { STANDARD_NO_PROXY };
+        insert_runtime_environment(profile, &mut env, "NO_PROXY", no_proxy.to_owned());
+        insert_runtime_environment(profile, &mut env, "no_proxy", no_proxy.to_owned());
         if profile.name == "java" {
             let agent_path = install_java_proxy_agent(runtime_temp).await?;
-            for (name, value) in endpoint.java_environment(&agent_path, &temp) {
+            let non_proxy_hosts = if strict {
+                ""
+            } else {
+                STANDARD_JAVA_NON_PROXY_HOSTS
+            };
+            for (name, value) in endpoint.java_environment(&agent_path, &temp, non_proxy_hosts) {
                 insert_runtime_environment(profile, &mut env, name, value);
             }
         }
@@ -617,6 +625,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "CREDENTIALS",
         "DATABASE_URL",
         "DOCKER_AUTH_CONFIG",
+        "DOCKER_CONFIG",
         "GPG_AGENT_INFO",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
@@ -2815,6 +2824,7 @@ mod tests {
                 ("CREDENTIAL".to_owned(), "sentinel".to_owned()),
                 ("CREDENTIALS".to_owned(), "sentinel".to_owned()),
                 ("DATABASE_URL".to_owned(), "sentinel".to_owned()),
+                ("DOCKER_CONFIG".to_owned(), "/tmp/docker-config".to_owned()),
                 ("TEST_DATABASE_URL".to_owned(), "sentinel".to_owned()),
                 ("PGPASSWORD".to_owned(), "sentinel".to_owned()),
                 ("PGPASSFILE".to_owned(), "sentinel".to_owned()),
@@ -3556,6 +3566,40 @@ mod tests {
             "-Dsbt.boot.directory={}",
             home.path().join(".sbt/boot").display()
         )));
+
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        let proxy = start_proxy_if_needed(&profile, shutdown_rx)
+            .await
+            .unwrap()
+            .unwrap();
+        let proxied = build_extra_env(
+            &mut profile,
+            Some(&proxy.endpoint),
+            runtime.path(),
+            home.path(),
+            project.path(),
+            &["sbt".to_owned(), "compile".to_owned()],
+            false,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            proxied.get("NO_PROXY").map(String::as_str),
+            Some(STANDARD_NO_PROXY)
+        );
+        assert_eq!(
+            proxied.get("no_proxy").map(String::as_str),
+            Some(STANDARD_NO_PROXY)
+        );
+        assert!(
+            proxied
+                .get("JAVA_TOOL_OPTIONS")
+                .is_some_and(|options| options.contains(&format!(
+                    "-Dhttp.nonProxyHosts={STANDARD_JAVA_NON_PROXY_HOSTS}"
+                )))
+        );
+        let _ = shutdown_tx.send(true);
+        await_proxy_shutdown(proxy).await.unwrap();
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -67,9 +67,7 @@ pub async fn execute(args: &RunArgs) -> ExitCode {
 async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
     let pwd = std::env::current_dir().context("failed to get current directory")?;
     let home = dirs::home_dir().context("could not determine home directory")?;
-    if args.strict {
-        reject_project_relocation(&args.command)?;
-    }
+    reject_project_relocation(&args.command)?;
 
     // Determine ecosystem
     let command_name = &args.command[0];
@@ -594,13 +592,20 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "AZURE_CLIENT_SECRET",
         "CREDENTIAL",
         "CREDENTIALS",
+        "DATABASE_URL",
         "DOCKER_AUTH_CONFIG",
         "GPG_AGENT_INFO",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
+        "MONGODB_URI",
+        "MONGO_URL",
+        "MYSQL_PWD",
         "PASSWORD",
         "PASSWD",
+        "PGPASSFILE",
+        "PGPASSWORD",
         "PRIVATE_KEY",
+        "REDISCLI_AUTH",
         "SECRET",
         "SSH_AGENT_PID",
         "SSH_AUTH_SOCK",
@@ -632,6 +637,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
             "_PRIVATE_KEY",
             "_CREDENTIAL",
             "_CREDENTIALS",
+            "_DATABASE_URL",
+            "_DATABASE_URI",
         ]
         .iter()
         .any(|suffix| upper.ends_with(suffix))
@@ -2353,6 +2360,13 @@ mod tests {
                 ("PRIVATE_KEY".to_owned(), "sentinel".to_owned()),
                 ("CREDENTIAL".to_owned(), "sentinel".to_owned()),
                 ("CREDENTIALS".to_owned(), "sentinel".to_owned()),
+                ("DATABASE_URL".to_owned(), "sentinel".to_owned()),
+                ("TEST_DATABASE_URL".to_owned(), "sentinel".to_owned()),
+                ("PGPASSWORD".to_owned(), "sentinel".to_owned()),
+                ("PGPASSFILE".to_owned(), "sentinel".to_owned()),
+                ("MYSQL_PWD".to_owned(), "sentinel".to_owned()),
+                ("REDISCLI_AUTH".to_owned(), "sentinel".to_owned()),
+                ("MONGODB_URI".to_owned(), "sentinel".to_owned()),
                 (
                     "GOOGLE_APPLICATION_CREDENTIALS".to_owned(),
                     "/tmp/google-credentials.json".to_owned(),

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -621,6 +621,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "AWS_SESSION_TOKEN",
         "AWS_WEB_IDENTITY_TOKEN_FILE",
         "AZURE_CLIENT_SECRET",
+        "AZURE_CONFIG_DIR",
+        "CLOUDSDK_CONFIG",
         "CREDENTIAL",
         "CREDENTIALS",
         "DATABASE_URL",
@@ -2810,6 +2812,14 @@ mod tests {
                 (
                     "AZURE_FEDERATED_TOKEN_FILE".to_owned(),
                     "/tmp/azure-oidc-token".to_owned(),
+                ),
+                (
+                    "AZURE_CONFIG_DIR".to_owned(),
+                    "/tmp/azure-config".to_owned(),
+                ),
+                (
+                    "CLOUDSDK_CONFIG".to_owned(),
+                    "/tmp/gcloud-config".to_owned(),
                 ),
                 ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
                 ("SYSTEM_ACCESSTOKEN".to_owned(), "sentinel".to_owned()),

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -916,8 +916,19 @@ fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<S
     let project_referent =
         std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
     let mut pending = vec![project_dir.to_path_buf()];
+    let mut visited_directories = BTreeSet::new();
     let mut resolved_paths = BTreeSet::new();
     while let Some(directory) = pending.pop() {
+        let directory = match std::fs::canonicalize(&directory) {
+            Ok(directory) => directory,
+            Err(error) => {
+                warn!(path = %directory.display(), %error, "could not resolve source directory");
+                continue;
+            }
+        };
+        if !visited_directories.insert(directory.clone()) {
+            continue;
+        }
         let entries = match std::fs::read_dir(&directory) {
             Ok(entries) => entries,
             Err(error) => {
@@ -958,7 +969,11 @@ fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<S
                 {
                     continue;
                 }
-                resolved_paths.insert(resolved);
+                if resolved_paths.insert(resolved.clone())
+                    && std::fs::metadata(&resolved).is_ok_and(|metadata| metadata.is_dir())
+                {
+                    pending.push(resolved);
+                }
             } else if file_type.is_dir() {
                 pending.push(path);
             }
@@ -2574,11 +2589,14 @@ mod tests {
         let project = root.path().join("project");
         let source = project.join("src");
         let shared = root.path().join("shared");
+        let nested = root.path().join("nested");
         let protected = root.path().join(".aws");
         std::fs::create_dir_all(&source).unwrap();
         std::fs::create_dir_all(&shared).unwrap();
+        std::fs::create_dir_all(&nested).unwrap();
         std::fs::create_dir_all(&protected).unwrap();
         std::os::unix::fs::symlink("../../shared", source.join("shared")).unwrap();
+        std::os::unix::fs::symlink("../nested", shared.join("nested")).unwrap();
         std::os::unix::fs::symlink("../../.aws", source.join("credentials")).unwrap();
         let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, root.path(), &project);
 
@@ -2594,6 +2612,11 @@ mod tests {
             profile
                 .allow_read
                 .contains(&SandboxPath::dir(std::fs::canonicalize(shared).unwrap()))
+        );
+        assert!(
+            profile
+                .allow_read
+                .contains(&SandboxPath::dir(std::fs::canonicalize(nested).unwrap()))
         );
         assert!(
             !profile

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -636,6 +636,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "DOCKER_CERT_PATH",
         "DOCKER_CONFIG",
         "GPG_AGENT_INFO",
+        "GH_CONFIG_DIR",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
         "MONGODB_URI",
@@ -803,12 +804,10 @@ fn apply_standard_profile(
             );
             insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
         } else {
-            let mut environment_target = false;
-            for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
-                let Some(path) = effective_environment_path(profile, name) else {
-                    continue;
-                };
-                environment_target = true;
+            let environment_target = effective_environment_path(profile, "CARGO_TARGET_DIR")
+                .or_else(|| effective_environment_path(profile, "CARGO_BUILD_TARGET_DIR"));
+            let has_environment_target = environment_target.is_some();
+            if let Some(path) = environment_target {
                 let path = if path.is_absolute() {
                     path
                 } else {
@@ -821,7 +820,7 @@ fn apply_standard_profile(
                 );
                 insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
             }
-            if !environment_target && let Some(path) = cargo_config_target_dir(command)? {
+            if !has_environment_target && let Some(path) = cargo_config_target_dir(command)? {
                 let path = if path.is_absolute() {
                     path
                 } else {
@@ -3237,6 +3236,7 @@ mod tests {
                     "GOOGLE_APPLICATION_CREDENTIALS".to_owned(),
                     "/tmp/google-credentials.json".to_owned(),
                 ),
+                ("GH_CONFIG_DIR".to_owned(), "/tmp/gh-config".to_owned()),
             ],
             false,
         );
@@ -4445,6 +4445,10 @@ mod tests {
         environment_over_config.env.insert(
             "CARGO_TARGET_DIR".to_owned(),
             target.path().to_string_lossy().into_owned(),
+        );
+        environment_over_config.env.insert(
+            "CARGO_BUILD_TARGET_DIR".to_owned(),
+            config_target.path().to_string_lossy().into_owned(),
         );
         apply_standard_profile(
             &mut environment_over_config,

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -594,6 +594,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "API_KEY",
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
+        "AWS_SHARED_CREDENTIALS_FILE",
         "AWS_SESSION_TOKEN",
         "AWS_WEB_IDENTITY_TOKEN_FILE",
         "AZURE_CLIENT_SECRET",
@@ -647,6 +648,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
             "_PRIVATE_KEY",
             "_CREDENTIAL",
             "_CREDENTIALS",
+            "_CREDENTIALS_FILE",
             "_DATABASE_URL",
             "_DATABASE_URI",
             "_AUTH",
@@ -868,6 +870,17 @@ fn resolves_within(path: &Path, root: &Path) -> bool {
 }
 
 fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, grant: SandboxPath) {
+    // Post-finalization compatibility grants must not undo a higher-precedence
+    // execute denial. Landlock cannot subtract a denied child from an allowed
+    // directory, so any overlap suppresses the complete inferred grant.
+    if kind == GrantKind::AllowExec
+        && profile
+            .deny_exec
+            .iter()
+            .any(|denied| paths_overlap(&grant.path, &denied.path))
+    {
+        return;
+    }
     let paths = match kind {
         GrantKind::AllowWrite => &mut profile.allow_write,
         GrantKind::AllowExec => &mut profile.allow_exec,
@@ -2591,6 +2604,10 @@ mod tests {
                 ("GITHUB_TOKEN".to_owned(), "sentinel".to_owned()),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
                 (
+                    "AWS_SHARED_CREDENTIALS_FILE".to_owned(),
+                    "/tmp/aws-credentials".to_owned(),
+                ),
+                (
                     "AWS_WEB_IDENTITY_TOKEN_FILE".to_owned(),
                     "/tmp/aws-oidc-token".to_owned(),
                 ),
@@ -2812,6 +2829,43 @@ mod tests {
         );
         assert!(!environment.contains_key("SCCACHE_CLIENT_SIDE"));
         assert!(!environment.contains_key("CARGO_BUILD_BUILD_DIR"));
+    }
+
+    #[test]
+    fn standard_profile_preserves_explicit_output_execute_denials() {
+        let project = tempfile::tempdir().unwrap();
+        let output = project.path().join("target");
+        let mut profile = SandboxProfile::for_ecosystem(
+            Ecosystem::Rust,
+            Path::new("/Users/test"),
+            project.path(),
+        );
+        profile.merge_overrides(&ProfileOverrides {
+            deny_exec: vec![SandboxPath::dir(output.clone())],
+            ..ProfileOverrides::default()
+        });
+        profile.finalize();
+
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "test".to_owned()],
+            Path::new("/Users/test"),
+            project.path(),
+        )
+        .unwrap();
+
+        assert!(
+            profile
+                .deny_exec
+                .contains(&SandboxPath::dir(output.clone()))
+        );
+        assert!(
+            !profile
+                .allow_exec
+                .iter()
+                .any(|allowed| paths_overlap(&allowed.path, &output)),
+            "an inferred output grant must not override an explicit execute denial"
+        );
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -489,6 +489,10 @@ async fn build_extra_env(
         && profile_name == "rust"
         && !env.contains_key("CARGO_TARGET_DIR")
         && !env.contains_key("CARGO_BUILD_TARGET_DIR")
+        && !profile.env.contains_key("CARGO_TARGET_DIR")
+        && !profile.env.contains_key("CARGO_BUILD_TARGET_DIR")
+        && command_option_value(command, "--target-dir").is_none()
+        && cargo_config_target_dir(command)?.is_none()
     {
         insert_runtime_environment(
             profile,
@@ -628,6 +632,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "CREDENTIALS",
         "DATABASE_URL",
         "DOCKER_AUTH_CONFIG",
+        "DOCKER_CERT_PATH",
         "DOCKER_CONFIG",
         "GPG_AGENT_INFO",
         "GOOGLE_APPLICATION_CREDENTIALS",
@@ -740,6 +745,13 @@ fn apply_standard_profile(
     }
 
     if profile.name == "java" {
+        if let Some(repository) = effective_maven_local_repository(command, home, project_dir)? {
+            replace_builtin_write_path(
+                profile,
+                &home.join(".m2/repository"),
+                SandboxPath::dir(repository),
+            );
+        }
         // Standard mode uses the package manager's ordinary persistent
         // caches. Strict mode redirects these into the private runtime root.
         for cache in [
@@ -775,12 +787,7 @@ fn apply_standard_profile(
 
     if command_is(command, "cargo") {
         let cargo_cli_target = command_option_value(command, "--target-dir").map(PathBuf::from);
-        let cargo_config_target = if cargo_cli_target.is_none() {
-            cargo_config_target_dir(command)?
-        } else {
-            None
-        };
-        if let Some(path) = cargo_cli_target.or(cargo_config_target) {
+        if let Some(path) = cargo_cli_target {
             let path = if path.is_absolute() {
                 path
             } else {
@@ -793,10 +800,25 @@ fn apply_standard_profile(
             );
             insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
         } else {
+            let mut environment_target = false;
             for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
                 let Some(path) = effective_environment_path(profile, name) else {
                     continue;
                 };
+                environment_target = true;
+                let path = if path.is_absolute() {
+                    path
+                } else {
+                    project_dir.join(path)
+                };
+                insert_builtin_path_grant(
+                    profile,
+                    GrantKind::AllowWrite,
+                    SandboxPath::dir(path.clone()),
+                );
+                insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(path));
+            }
+            if !environment_target && let Some(path) = cargo_config_target_dir(command)? {
                 let path = if path.is_absolute() {
                     path
                 } else {
@@ -876,6 +898,32 @@ fn effective_gradle_user_home(
     } else {
         project_dir.join(selected)
     }))
+}
+
+fn effective_maven_local_repository(
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    if !command_is(command, "mvn") && !command_is(command, "mvnw") {
+        return Ok(None);
+    }
+    let Some(value) = command_maven_property(command, "maven.repo.local") else {
+        return Ok(None);
+    };
+    if value.is_empty() || value.chars().any(char::is_control) {
+        anyhow::bail!("maven.repo.local must be a non-empty path without control characters");
+    }
+    let path = PathBuf::from(value);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        project_dir.join(path)
+    };
+    if path == home.join(".m2/repository") {
+        return Ok(None);
+    }
+    Ok(Some(path))
 }
 
 fn jvm_options_gradle_user_home(
@@ -1072,6 +1120,40 @@ fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, gran
         value,
         origin: GrantOrigin::BuiltIn,
     });
+}
+
+fn replace_builtin_write_path(
+    profile: &mut SandboxProfile,
+    current: &Path,
+    replacement: SandboxPath,
+) {
+    if replacement.path == current {
+        return;
+    }
+    let built_in_boundary = profile
+        .first_user_allow_write
+        .min(profile.allow_write.len());
+    let mut removed = 0_usize;
+    profile.allow_write = profile
+        .allow_write
+        .drain(..)
+        .enumerate()
+        .filter_map(|(index, grant)| {
+            if index < built_in_boundary && grant.path == current {
+                removed += 1;
+                None
+            } else {
+                Some(grant)
+            }
+        })
+        .collect();
+    profile.first_user_allow_write = built_in_boundary.saturating_sub(removed);
+    profile.grant_origins.retain(|record| {
+        record.kind != GrantKind::AllowWrite
+            || record.origin != GrantOrigin::BuiltIn
+            || record.value != current.to_string_lossy()
+    });
+    insert_builtin_path_grant(profile, GrantKind::AllowWrite, replacement);
 }
 
 #[allow(
@@ -1624,6 +1706,9 @@ fn command_aliased_option_value<'a>(
 }
 
 fn cargo_config_target_dir(command: &[String]) -> anyhow::Result<Option<PathBuf>> {
+    if !command_is(command, "cargo") {
+        return Ok(None);
+    }
     let mut arguments = command
         .iter()
         .skip(1)
@@ -1698,6 +1783,31 @@ fn command_system_property<'a>(command: &'a [String], name: &str) -> Option<&'a 
             argument
                 .strip_prefix("-D")
                 .or_else(|| argument.strip_prefix("--system-prop="))
+        };
+        if let Some(value) = property.and_then(|property| {
+            property
+                .strip_prefix(name)
+                .and_then(|suffix| suffix.strip_prefix('='))
+        }) {
+            selected = Some(value);
+        }
+    }
+    selected
+}
+
+fn command_maven_property<'a>(command: &'a [String], name: &str) -> Option<&'a str> {
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    let mut selected = None;
+    while let Some(argument) = arguments.next() {
+        let property = if argument == "-D" || argument == "--define" {
+            arguments.next().map(String::as_str)
+        } else {
+            argument
+                .strip_prefix("-D")
+                .or_else(|| argument.strip_prefix("--define="))
         };
         if let Some(value) = property.and_then(|property| {
             property
@@ -2964,6 +3074,10 @@ mod tests {
                 ("CREDENTIAL".to_owned(), "sentinel".to_owned()),
                 ("CREDENTIALS".to_owned(), "sentinel".to_owned()),
                 ("DATABASE_URL".to_owned(), "sentinel".to_owned()),
+                (
+                    "DOCKER_CERT_PATH".to_owned(),
+                    "/tmp/docker-certs".to_owned(),
+                ),
                 ("DOCKER_CONFIG".to_owned(), "/tmp/docker-config".to_owned()),
                 ("TEST_DATABASE_URL".to_owned(), "sentinel".to_owned()),
                 ("PGPASSWORD".to_owned(), "sentinel".to_owned()),
@@ -3166,6 +3280,27 @@ mod tests {
         );
         assert!(!environment.contains_key("SCCACHE_CLIENT_SIDE"));
         assert!(!environment.contains_key("CARGO_BUILD_BUILD_DIR"));
+
+        let configured_environment = build_extra_env(
+            &mut profile,
+            None,
+            runtime.path(),
+            Path::new("/Users/test"),
+            project.path(),
+            &[
+                "cargo".to_owned(),
+                "build".to_owned(),
+                "--config".to_owned(),
+                "build.target-dir='configured-target'".to_owned(),
+            ],
+            false,
+        )
+        .await
+        .unwrap();
+        assert!(
+            !configured_environment.contains_key("CARGO_TARGET_DIR"),
+            "the standard fallback must not override Cargo command-line configuration"
+        );
     }
 
     #[test]
@@ -3873,6 +4008,31 @@ mod tests {
         );
         let _ = shutdown_tx.send(true);
         await_proxy_shutdown(proxy).await.unwrap();
+
+        let custom_repository = tempfile::tempdir().unwrap();
+        let mut maven = SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        apply_standard_profile(
+            &mut maven,
+            &[
+                "mvn".to_owned(),
+                format!("-Dmaven.repo.local={}", custom_repository.path().display()),
+                "package".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            maven
+                .allow_write
+                .contains(&SandboxPath::dir(custom_repository.path().to_path_buf()))
+        );
+        assert!(
+            !maven
+                .allow_write
+                .contains(&SandboxPath::dir(home.path().join(".m2/repository"))),
+            "the selected Maven repository must replace the default write grant"
+        );
     }
 
     #[test]
@@ -3982,10 +4142,6 @@ mod tests {
 
         let mut config_build_profile =
             SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
-        config_build_profile.env.insert(
-            "CARGO_TARGET_DIR".to_owned(),
-            target.path().to_string_lossy().into_owned(),
-        );
         apply_standard_profile(
             &mut config_build_profile,
             &[
@@ -4008,11 +4164,35 @@ mod tests {
                 .allow_exec
                 .contains(&SandboxPath::dir(config_target.path().to_path_buf()))
         );
+
+        let mut environment_over_config =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        environment_over_config.env.insert(
+            "CARGO_TARGET_DIR".to_owned(),
+            target.path().to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut environment_over_config,
+            &[
+                "cargo".to_owned(),
+                "build".to_owned(),
+                "--config".to_owned(),
+                format!("build.target-dir='{}'", config_target.path().display()),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
         assert!(
-            !config_build_profile
+            environment_over_config
                 .allow_write
-                .contains(&SandboxPath::dir(target.path().to_path_buf())),
-            "a direct Cargo config target must replace the environment path"
+                .contains(&SandboxPath::dir(target.path().to_path_buf()))
+        );
+        assert!(
+            !environment_over_config
+                .allow_write
+                .contains(&SandboxPath::dir(config_target.path().to_path_buf())),
+            "Cargo target environment variables take precedence over --config"
         );
 
         let mut config_file_profile =

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -774,6 +774,18 @@ fn apply_standard_profile(
             SandboxPath::dir(npm_cache.path),
         );
     }
+    if profile.name == "node"
+        && (command_is(command, "npm") || command_is(command, "npx") || command_is(command, "pnpm"))
+    {
+        let user_config = effective_npm_user_config(profile, command, home, project_dir)?;
+        if user_config.explicit {
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowRead,
+                SandboxPath::file(user_config.path),
+            );
+        }
+    }
     if let Some(pnpm_store) = effective_pnpm_store(profile, command, home, project_dir)? {
         let conventional = home.join(".local/share/pnpm");
         if pnpm_store.project_controlled
@@ -1011,7 +1023,8 @@ fn effective_npm_cache(
     };
     let user_cache =
         if command_cache.is_none() && environment_cache.is_none() && project_cache.is_none() {
-            user_npm_config_path(home, "cache")?
+            let user_config = effective_npm_user_config(profile, command, home, project_dir)?;
+            user_npm_config_path(&user_config, home, "cache")?
         } else {
             None
         };
@@ -1042,12 +1055,59 @@ fn project_npm_cache(project_dir: &Path, home: &Path) -> anyhow::Result<Option<P
     npm_config_path_value(&contents, &path, home, "cache", "project .npmrc")
 }
 
-fn user_npm_config_path(home: &Path, key: &str) -> anyhow::Result<Option<PathBuf>> {
-    let path = home.join(".npmrc");
-    let Some(contents) = read_bounded_following_metadata_file(&path)? else {
+struct NpmUserConfigSelection {
+    path: PathBuf,
+    explicit: bool,
+}
+
+fn effective_npm_user_config(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<NpmUserConfigSelection> {
+    let command_config = command_long_path_option(command, "--userconfig")?;
+    let environment_config = if command_config.is_none() {
+        profile
+            .env
+            .get("NPM_CONFIG_USERCONFIG")
+            .or_else(|| profile.env.get("npm_config_userconfig"))
+            .map(PathBuf::from)
+    } else {
+        None
+    };
+    let explicit = command_config.is_some() || environment_config.is_some();
+    let selected = command_config
+        .or(environment_config)
+        .unwrap_or_else(|| home.join(".npmrc"));
+    if selected.as_os_str().is_empty() {
+        anyhow::bail!("npm userconfig must select a non-empty path");
+    }
+    Ok(NpmUserConfigSelection {
+        path: if selected.is_absolute() {
+            selected
+        } else {
+            project_dir.join(selected)
+        },
+        explicit,
+    })
+}
+
+fn user_npm_config_path(
+    selection: &NpmUserConfigSelection,
+    home: &Path,
+    key: &str,
+) -> anyhow::Result<Option<PathBuf>> {
+    let Some(contents) = read_bounded_following_metadata_file(&selection.path)? else {
+        if selection.explicit {
+            anyhow::bail!(
+                "could not inspect explicit npm user configuration: {}",
+                selection.path.display()
+            );
+        }
         return Ok(None);
     };
-    npm_config_path_value(&contents, &path, home, key, "user .npmrc")
+    npm_config_path_value(&contents, &selection.path, home, key, "user .npmrc")
 }
 
 fn npm_config_path_value(
@@ -1170,7 +1230,8 @@ fn effective_pnpm_store(
     };
     let user_store =
         if command_store.is_none() && environment_store.is_none() && project_store.is_none() {
-            user_npm_config_path(home, "store-dir")?
+            let user_config = effective_npm_user_config(profile, command, home, project_dir)?;
+            user_npm_config_path(&user_config, home, "store-dir")?
         } else {
             None
         };
@@ -1224,11 +1285,20 @@ fn effective_python_cache(
     } else {
         None
     };
+    let config_cache =
+        if command_cache.is_none() && environment_cache.is_none() && default_name == "pip" {
+            effective_pip_config_cache(profile, home)?
+        } else {
+            None
+        };
     let conventional = home.join(".cache").join(default_name);
     let default_cache = effective_environment_path(profile, "XDG_CACHE_HOME")
         .map(|directory| directory.join(default_name))
-        .unwrap_or_else(|| conventional.clone());
-    let selected = command_cache.or(environment_cache).unwrap_or(default_cache);
+        .unwrap_or_else(|| platform_python_cache(home, default_name));
+    let selected = command_cache
+        .or(environment_cache)
+        .or(config_cache)
+        .unwrap_or(default_cache);
     if selected.as_os_str().is_empty() {
         anyhow::bail!("{environment_name} must select a non-empty path");
     }
@@ -1240,6 +1310,67 @@ fn effective_python_cache(
             project_dir.join(selected)
         },
     }))
+}
+
+fn effective_pip_config_cache(
+    profile: &SandboxProfile,
+    home: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    let legacy = home.join(".pip/pip.conf");
+    let mut selected = read_pip_config_cache(&legacy, home, false)?;
+
+    let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
+        .unwrap_or_else(|| platform_config_home(home));
+    let user_config = user_config_root.join("pip/pip.conf");
+    if let Some(cache) = read_pip_config_cache(&user_config, home, false)? {
+        selected = Some(cache);
+    }
+
+    // Ambient PIP_CONFIG_FILE is filtered. If it is present in the resolved profile, the user
+    // explicitly restored it and its final config layer should be honored.
+    if let Some(explicit) = profile.env.get("PIP_CONFIG_FILE").map(PathBuf::from)
+        && let Some(cache) = read_pip_config_cache(&explicit, home, true)?
+    {
+        selected = Some(cache);
+    }
+    Ok(selected)
+}
+
+fn read_pip_config_cache(
+    path: &Path,
+    home: &Path,
+    required: bool,
+) -> anyhow::Result<Option<PathBuf>> {
+    let Some(contents) = read_bounded_following_metadata_file(path)? else {
+        if required {
+            anyhow::bail!(
+                "could not inspect explicit pip configuration: {}",
+                path.display()
+            );
+        }
+        return Ok(None);
+    };
+    npm_config_path_value(&contents, path, home, "cache-dir", "pip configuration")
+}
+
+#[cfg(target_os = "macos")]
+fn platform_python_cache(home: &Path, name: &str) -> PathBuf {
+    home.join("Library/Caches").join(name)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_python_cache(home: &Path, name: &str) -> PathBuf {
+    home.join(".cache").join(name)
+}
+
+#[cfg(target_os = "macos")]
+fn platform_config_home(home: &Path) -> PathBuf {
+    home.join("Library/Application Support")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn platform_config_home(home: &Path) -> PathBuf {
+    home.join(".config")
 }
 
 fn command_long_path_option(command: &[String], option: &str) -> anyhow::Result<Option<PathBuf>> {
@@ -4692,6 +4823,34 @@ mod tests {
         std::fs::create_dir_all(&home).unwrap();
         std::fs::create_dir_all(&project).unwrap();
 
+        let mut default_uv = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        apply_standard_profile(
+            &mut default_uv,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            default_uv
+                .allow_write
+                .contains(&SandboxPath::dir(platform_python_cache(&home, "uv")))
+        );
+
+        let mut default_pip = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        apply_standard_profile(
+            &mut default_pip,
+            &["pip".to_owned(), "install".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            default_pip
+                .allow_write
+                .contains(&SandboxPath::dir(platform_python_cache(&home, "pip")))
+        );
+
         let uv_environment_cache = root.path().join("uv-environment-cache");
         let mut uv_environment = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
         uv_environment.env.insert(
@@ -4764,6 +4923,32 @@ mod tests {
         assert!(
             !pip.allow_write
                 .contains(&SandboxPath::dir(home.join(".cache/pip")))
+        );
+
+        let pip_config_home = home.join("custom-config");
+        let pip_config_cache = root.path().join("pip-config-cache");
+        std::fs::create_dir_all(pip_config_home.join("pip")).unwrap();
+        std::fs::write(
+            pip_config_home.join("pip/pip.conf"),
+            format!("[global]\ncache-dir={}\n", pip_config_cache.display()),
+        )
+        .unwrap();
+        let mut pip_config = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        pip_config.env.insert(
+            "XDG_CONFIG_HOME".to_owned(),
+            pip_config_home.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut pip_config,
+            &["pip".to_owned(), "install".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            pip_config
+                .allow_write
+                .contains(&SandboxPath::dir(pip_config_cache))
         );
     }
 
@@ -6950,6 +7135,39 @@ mod tests {
             user_selected
                 .allow_write
                 .contains(&SandboxPath::dir(user_cache))
+        );
+
+        let command_userconfig_root = tempfile::tempdir().unwrap();
+        let command_userconfig = command_userconfig_root.path().join("npmrc");
+        let command_userconfig_cache = root.path().join("command-userconfig-cache");
+        std::fs::write(
+            &command_userconfig,
+            format!("cache={}\n", command_userconfig_cache.display()),
+        )
+        .unwrap();
+        let mut command_userconfig_selected =
+            SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        apply_standard_profile(
+            &mut command_userconfig_selected,
+            &[
+                "npm".to_owned(),
+                "--userconfig".to_owned(),
+                command_userconfig.display().to_string(),
+                "install".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            command_userconfig_selected
+                .allow_write
+                .contains(&SandboxPath::dir(command_userconfig_cache))
+        );
+        assert!(
+            command_userconfig_selected
+                .allow_read
+                .contains(&SandboxPath::file(command_userconfig))
         );
 
         let command_store = root.path().join("command-pnpm-store");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -778,7 +778,9 @@ fn apply_standard_profile(
         && (command_is(command, "npm") || command_is(command, "npx") || command_is(command, "pnpm"))
     {
         let user_config = effective_npm_user_config(profile, command, home, project_dir)?;
-        if user_config.explicit {
+        if user_config.explicit
+            || read_bounded_following_metadata_file(&user_config.path)?.is_some()
+        {
             insert_builtin_path_grant(
                 profile,
                 GrantKind::AllowRead,
@@ -810,6 +812,11 @@ fn apply_standard_profile(
             &cache.conventional,
             SandboxPath::dir(cache.selected),
         );
+    }
+    if profile.name == "python" && command_uses_pip(command) {
+        for config in effective_pip_config_read_paths(profile, home, project_dir)? {
+            insert_builtin_path_grant(profile, GrantKind::AllowRead, SandboxPath::file(config));
+        }
     }
 
     if profile.name == "java" {
@@ -1299,7 +1306,7 @@ fn effective_python_cache(
     };
     let config_cache =
         if command_cache.is_none() && environment_cache.is_none() && default_name == "pip" {
-            effective_pip_config_cache(profile, home)?
+            effective_pip_config_cache(profile, home, project_dir)?
         } else {
             None
         };
@@ -1424,11 +1431,13 @@ fn simple_uv_cache_path(value: &str, source: &Path) -> anyhow::Result<PathBuf> {
 fn effective_pip_config_cache(
     profile: &SandboxProfile,
     home: &Path,
+    project_dir: &Path,
 ) -> anyhow::Result<Option<PathBuf>> {
     let legacy = home.join(".pip/pip.conf");
     let mut selected = read_pip_config_cache(&legacy, home, false)?;
 
     let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
+        .map(|path| anchor_project_path(path, project_dir))
         .unwrap_or_else(|| platform_config_home(home));
     let user_config = user_config_root.join("pip/pip.conf");
     if let Some(cache) = read_pip_config_cache(&user_config, home, false)? {
@@ -1437,12 +1446,64 @@ fn effective_pip_config_cache(
 
     // Ambient PIP_CONFIG_FILE is filtered. If it is present in the resolved profile, the user
     // explicitly restored it and its final config layer should be honored.
-    if let Some(explicit) = profile.env.get("PIP_CONFIG_FILE").map(PathBuf::from)
+    if let Some(explicit) = effective_profile_path(profile, "PIP_CONFIG_FILE", project_dir)
         && let Some(cache) = read_pip_config_cache(&explicit, home, true)?
     {
         selected = Some(cache);
     }
     Ok(selected)
+}
+
+fn effective_pip_config_read_paths(
+    profile: &SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Vec<PathBuf>> {
+    let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
+        .map(|path| anchor_project_path(path, project_dir))
+        .unwrap_or_else(|| platform_config_home(home));
+    let candidates = [
+        home.join(".pip/pip.conf"),
+        user_config_root.join("pip/pip.conf"),
+    ];
+    let mut selected = Vec::new();
+    for path in candidates {
+        if read_bounded_following_metadata_file(&path)?.is_some() {
+            selected.push(path);
+        }
+    }
+    if let Some(path) = effective_profile_path(profile, "PIP_CONFIG_FILE", project_dir) {
+        if read_bounded_following_metadata_file(&path)?.is_none() {
+            anyhow::bail!(
+                "could not inspect explicit pip configuration: {}",
+                path.display()
+            );
+        }
+        if !selected.contains(&path) {
+            selected.push(path);
+        }
+    }
+    Ok(selected)
+}
+
+fn effective_profile_path(
+    profile: &SandboxProfile,
+    name: &str,
+    project_dir: &Path,
+) -> Option<PathBuf> {
+    profile
+        .env
+        .get(name)
+        .map(PathBuf::from)
+        .map(|path| anchor_project_path(path, project_dir))
+}
+
+fn anchor_project_path(path: PathBuf, project_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        project_dir.join(path)
+    }
 }
 
 fn read_pip_config_cache(
@@ -5157,6 +5218,11 @@ mod tests {
                 .allow_write
                 .contains(&SandboxPath::dir(pip_config_cache))
         );
+        assert!(
+            pip_config
+                .allow_read
+                .contains(&SandboxPath::file(pip_config_home.join("pip/pip.conf")))
+        );
     }
 
     #[test]
@@ -7359,6 +7425,11 @@ mod tests {
             user_selected
                 .allow_write
                 .contains(&SandboxPath::dir(user_cache))
+        );
+        assert!(
+            user_selected
+                .allow_read
+                .contains(&SandboxPath::file(home.join(".npmrc")))
         );
 
         let command_userconfig_root = tempfile::tempdir().unwrap();

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -646,6 +646,9 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "GNUPGHOME",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
+        "KRB5CCNAME",
+        "KRB5_CLIENT_KTNAME",
+        "KRB5_KTNAME",
         "MONGODB_URI",
         "MONGO_URL",
         "MYSQL_PWD",
@@ -1073,6 +1076,12 @@ fn effective_maven_local_repository(
     } else {
         None
     };
+    let settings_value =
+        if !has_argument_value && maven_opts_value.is_none() && project_jvm_value.is_none() {
+            effective_maven_settings_repository(profile, command, home, project_dir)?
+        } else {
+            None
+        };
     let selected = command_value
         .map(|path| MavenRepositorySelection {
             path,
@@ -1101,7 +1110,8 @@ fn effective_maven_local_repository(
                 path,
                 project_controlled: true,
             })
-        });
+        })
+        .or(settings_value);
     let Some(mut selected) = selected else {
         return Ok(None);
     };
@@ -1115,6 +1125,185 @@ fn effective_maven_local_repository(
         return Ok(None);
     }
     Ok(Some(selected))
+}
+
+fn effective_maven_settings_repository(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Option<MavenRepositorySelection>> {
+    let command_settings =
+        command_aliased_option_value(command, "--settings", "-s").map(str::to_owned);
+    let maven_args_settings = if command_settings.is_none() {
+        let arguments = profile
+            .env
+            .get("MAVEN_ARGS")
+            .cloned()
+            .or_else(|| std::env::var("MAVEN_ARGS").ok());
+        arguments
+            .as_deref()
+            .and_then(maven_settings_option_value)
+            .map(str::to_owned)
+    } else {
+        None
+    };
+    let project_settings = if command_settings.is_none() && maven_args_settings.is_none() {
+        let config = project_dir.join(".mvn/maven.config");
+        read_bounded_project_file(&config)?
+            .map(|contents| {
+                let contents = std::str::from_utf8(&contents).with_context(|| {
+                    format!("Maven argument config is not UTF-8: {}", config.display())
+                })?;
+                let arguments = contents
+                    .lines()
+                    .map(str::trim)
+                    .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                Ok::<_, anyhow::Error>(maven_settings_option_value(&arguments).map(str::to_owned))
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let project_controlled = project_settings.is_some();
+    let selected = command_settings
+        .or(maven_args_settings)
+        .or(project_settings);
+    if selected.as_deref().is_some_and(|path| {
+        path.is_empty()
+            || path
+                .chars()
+                .any(|character| matches!(character, '$' | '`' | '\'' | '"'))
+    }) {
+        anyhow::bail!(
+            "Maven settings path must be unambiguous; use --settings=/absolute/settings.xml"
+        );
+    }
+    let path = selected
+        .as_deref()
+        .map_or_else(|| home.join(".m2/settings.xml"), PathBuf::from);
+    let path = if path.is_absolute() {
+        path
+    } else {
+        project_dir.join(path)
+    };
+    let Some(contents) = read_bounded_following_metadata_file(&path)? else {
+        if selected.is_some() {
+            anyhow::bail!(
+                "could not inspect explicit Maven settings file: {}",
+                path.display()
+            );
+        }
+        return Ok(None);
+    };
+    let Some(repository) = maven_settings_local_repository(&contents, &path, home)? else {
+        return Ok(None);
+    };
+    Ok(Some(MavenRepositorySelection {
+        path: repository,
+        project_controlled,
+    }))
+}
+
+fn maven_settings_option_value(arguments: &str) -> Option<&str> {
+    let mut selected = None;
+    let mut arguments = arguments.split_whitespace();
+    while let Some(argument) = arguments.next() {
+        if argument == "--settings" || argument == "-s" {
+            selected = arguments.next();
+            continue;
+        }
+        if let Some(value) = argument
+            .strip_prefix("--settings=")
+            .or_else(|| argument.strip_prefix("-s="))
+        {
+            selected = Some(value);
+            continue;
+        }
+        if let Some(value) = argument
+            .strip_prefix("-s")
+            .filter(|value| !value.is_empty())
+        {
+            selected = Some(value);
+        }
+    }
+    selected
+}
+
+fn maven_settings_local_repository(
+    contents: &[u8],
+    path: &Path,
+    home: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    let contents = std::str::from_utf8(contents)
+        .with_context(|| format!("Maven settings are not UTF-8: {}", path.display()))?;
+    let contents = xml_without_comments(contents, path)?;
+    const OPEN: &str = "<localRepository>";
+    const CLOSE: &str = "</localRepository>";
+    let Some(start) = contents.find(OPEN) else {
+        if contents.contains("<localRepository") {
+            anyhow::bail!(
+                "Maven settings '{}' use an unsupported localRepository form; use \
+                 -Dmaven.repo.local=/unambiguous/path",
+                path.display()
+            );
+        }
+        return Ok(None);
+    };
+    if contents[start + OPEN.len()..].contains(OPEN) {
+        anyhow::bail!(
+            "Maven settings '{}' contain multiple localRepository values; use \
+             -Dmaven.repo.local=/unambiguous/path",
+            path.display()
+        );
+    }
+    let value_start = start + OPEN.len();
+    let end = contents[value_start..]
+        .find(CLOSE)
+        .map(|offset| value_start + offset)
+        .with_context(|| {
+            format!(
+                "Maven settings localRepository is not closed: {}",
+                path.display()
+            )
+        })?;
+    let value = contents[value_start..end]
+        .trim()
+        .replace("${user.home}", &home.to_string_lossy())
+        .replace("${env.HOME}", &home.to_string_lossy());
+    if value.is_empty()
+        || value
+            .chars()
+            .any(|character| character.is_control() || matches!(character, '<' | '&' | '$' | '`'))
+    {
+        anyhow::bail!(
+            "Maven settings '{}' select localRepository in a form SBE cannot resolve safely; use \
+             -Dmaven.repo.local=/unambiguous/path",
+            path.display()
+        );
+    }
+    Ok(Some(PathBuf::from(value)))
+}
+
+fn xml_without_comments(contents: &str, path: &Path) -> anyhow::Result<String> {
+    let mut remaining = contents;
+    let mut stripped = String::with_capacity(contents.len());
+    while let Some(start) = remaining.find("<!--") {
+        stripped.push_str(&remaining[..start]);
+        let after_start = &remaining[start + 4..];
+        let end = after_start.find("-->").with_context(|| {
+            format!(
+                "Maven settings contain an unterminated comment: {}",
+                path.display()
+            )
+        })?;
+        remaining = &after_start[end + 3..];
+    }
+    stripped.push_str(remaining);
+    Ok(stripped)
 }
 
 fn project_maven_repository_is_approved(
@@ -2134,7 +2323,7 @@ fn reject_implicit_cargo_install_root(project_dir: &Path, cargo_home: &Path) -> 
 fn reject_cargo_install_root_in_config(config_dir: &Path) -> anyhow::Result<()> {
     for name in ["config", "config.toml"] {
         let path = config_dir.join(name);
-        let Some(contents) = read_bounded_cargo_config(&path)? else {
+        let Some(contents) = read_bounded_following_metadata_file(&path)? else {
             continue;
         };
         let contents = std::str::from_utf8(&contents)
@@ -2154,15 +2343,16 @@ fn reject_cargo_install_root_in_config(config_dir: &Path) -> anyhow::Result<()> 
 
 #[allow(
     clippy::disallowed_methods,
-    reason = "Cargo itself follows config symlinks; policy preparation resolves the selected file \
-              before applying the bounded no-follow reader"
+    reason = "Cargo and Maven follow metadata symlinks; policy preparation resolves the selected \
+              file before applying the bounded no-follow reader"
 )]
-fn read_bounded_cargo_config(path: &Path) -> anyhow::Result<Option<Vec<u8>>> {
+fn read_bounded_following_metadata_file(path: &Path) -> anyhow::Result<Option<Vec<u8>>> {
     let resolved = match std::fs::canonicalize(path) {
         Ok(resolved) => resolved,
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
         Err(error) => {
-            return Err(error).with_context(|| format!("resolve Cargo config: {}", path.display()));
+            return Err(error)
+                .with_context(|| format!("resolve metadata file: {}", path.display()));
         }
     };
     read_bounded_project_file(&resolved)
@@ -3574,6 +3764,15 @@ mod tests {
                     "NPM_CONFIG_USERCONFIG".to_owned(),
                     "/tmp/custom-npmrc".to_owned(),
                 ),
+                ("KRB5CCNAME".to_owned(), "FILE:/tmp/krb5cc".to_owned()),
+                (
+                    "KRB5_CLIENT_KTNAME".to_owned(),
+                    "FILE:/tmp/client.keytab".to_owned(),
+                ),
+                (
+                    "KRB5_KTNAME".to_owned(),
+                    "FILE:/tmp/service.keytab".to_owned(),
+                ),
                 ("OPENAI_API_KEY".to_owned(), "sentinel".to_owned()),
                 ("TOKEN".to_owned(), "sentinel".to_owned()),
                 ("API_KEY".to_owned(), "sentinel".to_owned()),
@@ -4614,8 +4813,79 @@ mod tests {
             "the selected Maven repository must replace the default write grant"
         );
 
-        let jvm_repository = project.path().join("jvm-config-repository");
+        let settings_repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(home.path().join(".m2")).unwrap();
+        std::fs::write(
+            home.path().join(".m2/settings.xml"),
+            format!(
+                "<settings><localRepository>{}</localRepository></settings>",
+                settings_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut user_settings =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        apply_standard_profile(
+            &mut user_settings,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            user_settings
+                .allow_write
+                .contains(&SandboxPath::dir(settings_repository.path().to_path_buf()))
+        );
+
+        let explicit_repository = tempfile::tempdir().unwrap();
+        let explicit_settings = project.path().join("explicit-settings.xml");
+        std::fs::write(
+            &explicit_settings,
+            format!(
+                "<settings><!-- ignored --><localRepository>{}</localRepository></settings>",
+                explicit_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut explicit =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        apply_standard_profile(
+            &mut explicit,
+            &[
+                "mvn".to_owned(),
+                "-s".to_owned(),
+                explicit_settings.display().to_string(),
+                "validate".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            explicit
+                .allow_write
+                .contains(&SandboxPath::dir(explicit_repository.path().to_path_buf()))
+        );
+
         std::fs::create_dir_all(project.path().join(".mvn")).unwrap();
+        std::fs::write(
+            project.path().join(".mvn/maven.config"),
+            format!("--settings={}\n", explicit_settings.display()),
+        )
+        .unwrap();
+        let mut project_selected_settings =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        let error = apply_standard_profile(
+            &mut project_selected_settings,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+
+        let jvm_repository = project.path().join("jvm-config-repository");
         std::fs::write(
             project.path().join(".mvn/jvm.config"),
             format!("-Dmaven.repo.local={}\n", jvm_repository.display()),

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -625,6 +625,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "AWS_SHARED_CREDENTIALS_FILE",
         "AWS_SESSION_TOKEN",
         "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AZURE_CLIENT_CERTIFICATE_PATH",
         "AZURE_CLIENT_SECRET",
         "AZURE_CONFIG_DIR",
         "CLOUDSDK_CONFIG",
@@ -912,7 +913,44 @@ fn effective_maven_local_repository(
         return Ok(None);
     }
     let command_value = command_maven_property(command, "maven.repo.local").map(PathBuf::from);
-    let maven_opts_value = if command_value.is_none() {
+    let maven_args_value = if command_value.is_none() {
+        let arguments = profile
+            .env
+            .get("MAVEN_ARGS")
+            .cloned()
+            .or_else(|| std::env::var("MAVEN_ARGS").ok());
+        arguments
+            .as_deref()
+            .map(|arguments| maven_args_local_repository(arguments, "MAVEN_ARGS"))
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let maven_config_value = if command_value.is_none() && maven_args_value.is_none() {
+        let path = project_dir.join(".mvn/maven.config");
+        read_bounded_project_file(&path)?
+            .map(|contents| {
+                let contents = std::str::from_utf8(&contents).with_context(|| {
+                    format!("Maven argument config is not UTF-8: {}", path.display())
+                })?;
+                let mut arguments = vec!["mvn".to_owned()];
+                arguments.extend(
+                    contents
+                        .lines()
+                        .map(str::trim)
+                        .filter(|line| !line.is_empty() && !line.starts_with('#'))
+                        .map(str::to_owned),
+                );
+                maven_argument_list_local_repository(&arguments, ".mvn/maven.config", true)
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let argument_value = command_value.or(maven_args_value).or(maven_config_value);
+    let maven_opts_value = if argument_value.is_none() {
         let options = profile
             .env
             .get("MAVEN_OPTS")
@@ -926,7 +964,7 @@ fn effective_maven_local_repository(
     } else {
         None
     };
-    let project_value = if command_value.is_none() && maven_opts_value.is_none() {
+    let project_jvm_value = if argument_value.is_none() && maven_opts_value.is_none() {
         let path = project_dir.join(".mvn/jvm.config");
         read_bounded_project_file(&path)?
             .map(|contents| {
@@ -940,7 +978,7 @@ fn effective_maven_local_repository(
     } else {
         None
     };
-    let Some(path) = command_value.or(maven_opts_value).or(project_value) else {
+    let Some(path) = argument_value.or(maven_opts_value).or(project_jvm_value) else {
         return Ok(None);
     };
     if path.as_os_str().is_empty() {
@@ -955,6 +993,45 @@ fn effective_maven_local_repository(
         return Ok(None);
     }
     Ok(Some(path))
+}
+
+fn maven_args_local_repository(arguments: &str, source: &str) -> anyhow::Result<Option<PathBuf>> {
+    let mut command = vec!["mvn".to_owned()];
+    command.extend(arguments.split_whitespace().map(str::to_owned));
+    maven_argument_list_local_repository(&command, source, true)
+}
+
+fn maven_argument_list_local_repository(
+    arguments: &[String],
+    source: &str,
+    reject_shell_syntax: bool,
+) -> anyhow::Result<Option<PathBuf>> {
+    let selected = command_maven_property(arguments, "maven.repo.local");
+    if let Some(value) = selected {
+        if value.is_empty()
+            || value.chars().any(char::is_control)
+            || (reject_shell_syntax
+                && value.chars().any(|character| {
+                    matches!(character, '$' | '`' | '\\' | '\'' | '"' | '*' | '?' | '[')
+                }))
+        {
+            anyhow::bail!(
+                "{source} selects maven.repo.local in a form that sbe cannot resolve safely; use \
+                 -Dmaven.repo.local=/unambiguous/path"
+            );
+        }
+        return Ok(Some(PathBuf::from(value)));
+    }
+    if arguments
+        .iter()
+        .any(|argument| argument.contains("maven.repo.local"))
+    {
+        anyhow::bail!(
+            "{source} selects maven.repo.local in an unsupported form; use \
+             -Dmaven.repo.local=/unambiguous/path"
+        );
+    }
+    Ok(None)
 }
 
 fn maven_options_local_repository(options: &str, source: &str) -> anyhow::Result<Option<PathBuf>> {
@@ -3116,6 +3193,10 @@ mod tests {
                     "/tmp/azure-config".to_owned(),
                 ),
                 (
+                    "AZURE_CLIENT_CERTIFICATE_PATH".to_owned(),
+                    "/tmp/azure-client.pem".to_owned(),
+                ),
+                (
                     "CLOUDSDK_CONFIG".to_owned(),
                     "/tmp/gcloud-config".to_owned(),
                 ),
@@ -4154,6 +4235,79 @@ mod tests {
                 .contains(&SandboxPath::dir(jvm_repository.path().to_path_buf())),
             "MAVEN_OPTS is appended after .mvn/jvm.config and its last property wins"
         );
+
+        let config_repository = tempfile::tempdir().unwrap();
+        std::fs::write(
+            project.path().join(".mvn/maven.config"),
+            format!(
+                "-Dmaven.repo.local={}\n",
+                config_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut maven_config =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        maven_config
+            .env
+            .insert("MAVEN_ARGS".to_owned(), "-B".to_owned());
+        maven_config.env.insert(
+            "MAVEN_OPTS".to_owned(),
+            format!("-Dmaven.repo.local={}", opts_repository.path().display()),
+        );
+        apply_standard_profile(
+            &mut maven_config,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            maven_config
+                .allow_write
+                .contains(&SandboxPath::dir(config_repository.path().to_path_buf())),
+            "project Maven arguments override JVM system-property sources"
+        );
+
+        let args_repository = tempfile::tempdir().unwrap();
+        let mut maven_args =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        maven_args.env.insert(
+            "MAVEN_ARGS".to_owned(),
+            format!("-Dmaven.repo.local={}", args_repository.path().display()),
+        );
+        apply_standard_profile(
+            &mut maven_args,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            maven_args
+                .allow_write
+                .contains(&SandboxPath::dir(args_repository.path().to_path_buf()))
+        );
+        assert!(
+            !maven_args
+                .allow_write
+                .contains(&SandboxPath::dir(config_repository.path().to_path_buf())),
+            "MAVEN_ARGS is passed as CLI input and overrides project Maven arguments"
+        );
+
+        let mut ambiguous_args =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        ambiguous_args.env.insert(
+            "MAVEN_ARGS".to_owned(),
+            "-Dmaven.repo.local='$HOME/maven repository'".to_owned(),
+        );
+        let error = apply_standard_profile(
+            &mut ambiguous_args,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("unambiguous"));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -750,10 +750,22 @@ fn apply_standard_profile(
         if let Some(repository) =
             effective_maven_local_repository(profile, command, home, project_dir)?
         {
+            if repository.project_controlled
+                && !project_maven_repository_is_approved(
+                    profile,
+                    &repository.path,
+                    home,
+                    project_dir,
+                )
+            {
+                let resolved = resolve_existing_ancestor(&repository.path)
+                    .unwrap_or_else(|| repository.path.clone());
+                return Err(external_write_approval_error(&repository.path, &resolved));
+            }
             replace_builtin_write_path(
                 profile,
                 &home.join(".m2/repository"),
-                SandboxPath::dir(repository),
+                SandboxPath::dir(repository.path),
             );
         }
         // Standard mode uses the package manager's ordinary persistent
@@ -902,12 +914,17 @@ fn effective_gradle_user_home(
     }))
 }
 
+struct MavenRepositorySelection {
+    path: PathBuf,
+    project_controlled: bool,
+}
+
 fn effective_maven_local_repository(
     profile: &SandboxProfile,
     command: &[String],
     home: &Path,
     project_dir: &Path,
-) -> anyhow::Result<Option<PathBuf>> {
+) -> anyhow::Result<Option<MavenRepositorySelection>> {
     if !command_is(command, "mvn") && !command_is(command, "mvnw") {
         return Ok(None);
     }
@@ -948,8 +965,9 @@ fn effective_maven_local_repository(
     } else {
         None
     };
-    let argument_value = command_value.or(maven_args_value).or(maven_config_value);
-    let maven_opts_value = if argument_value.is_none() {
+    let has_argument_value =
+        command_value.is_some() || maven_args_value.is_some() || maven_config_value.is_some();
+    let maven_opts_value = if !has_argument_value {
         let options = profile
             .env
             .get("MAVEN_OPTS")
@@ -963,7 +981,7 @@ fn effective_maven_local_repository(
     } else {
         None
     };
-    let project_jvm_value = if argument_value.is_none() && maven_opts_value.is_none() {
+    let project_jvm_value = if !has_argument_value && maven_opts_value.is_none() {
         let path = project_dir.join(".mvn/jvm.config");
         read_bounded_project_file(&path)?
             .map(|contents| {
@@ -977,21 +995,63 @@ fn effective_maven_local_repository(
     } else {
         None
     };
-    let Some(path) = argument_value.or(maven_opts_value).or(project_jvm_value) else {
+    let selected = command_value
+        .map(|path| MavenRepositorySelection {
+            path,
+            project_controlled: false,
+        })
+        .or_else(|| {
+            maven_args_value.map(|path| MavenRepositorySelection {
+                path,
+                project_controlled: false,
+            })
+        })
+        .or_else(|| {
+            maven_config_value.map(|path| MavenRepositorySelection {
+                path,
+                project_controlled: true,
+            })
+        })
+        .or_else(|| {
+            maven_opts_value.map(|path| MavenRepositorySelection {
+                path,
+                project_controlled: false,
+            })
+        })
+        .or_else(|| {
+            project_jvm_value.map(|path| MavenRepositorySelection {
+                path,
+                project_controlled: true,
+            })
+        });
+    let Some(mut selected) = selected else {
         return Ok(None);
     };
-    if path.as_os_str().is_empty() {
+    if selected.path.as_os_str().is_empty() {
         anyhow::bail!("maven.repo.local must be a non-empty path");
     }
-    let path = if path.is_absolute() {
-        path
-    } else {
-        project_dir.join(path)
-    };
-    if path == home.join(".m2/repository") {
+    if !selected.path.is_absolute() {
+        selected.path = project_dir.join(selected.path);
+    }
+    if selected.path == home.join(".m2/repository") {
         return Ok(None);
     }
-    Ok(Some(path))
+    Ok(Some(selected))
+}
+
+fn project_maven_repository_is_approved(
+    profile: &SandboxProfile,
+    repository: &Path,
+    home: &Path,
+    project_dir: &Path,
+) -> bool {
+    let resolved =
+        resolve_existing_ancestor(repository).unwrap_or_else(|| repository.to_path_buf());
+    let project =
+        resolve_existing_ancestor(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+    resolved.starts_with(project)
+        || repository.starts_with(home.join(".m2/repository"))
+        || explicit_write_covers(profile, &resolved)
 }
 
 fn maven_args_local_repository(arguments: &str, source: &str) -> anyhow::Result<Option<PathBuf>> {
@@ -4181,11 +4241,11 @@ mod tests {
             "the selected Maven repository must replace the default write grant"
         );
 
-        let jvm_repository = tempfile::tempdir().unwrap();
+        let jvm_repository = project.path().join("jvm-config-repository");
         std::fs::create_dir_all(project.path().join(".mvn")).unwrap();
         std::fs::write(
             project.path().join(".mvn/jvm.config"),
-            format!("-Dmaven.repo.local={}\n", jvm_repository.path().display()),
+            format!("-Dmaven.repo.local={}\n", jvm_repository.display()),
         )
         .unwrap();
         let mut jvm_config =
@@ -4203,7 +4263,7 @@ mod tests {
         assert!(
             jvm_config
                 .allow_write
-                .contains(&SandboxPath::dir(jvm_repository.path().to_path_buf()))
+                .contains(&SandboxPath::dir(jvm_repository.clone()))
         );
 
         let opts_repository = tempfile::tempdir().unwrap();
@@ -4213,7 +4273,7 @@ mod tests {
             "MAVEN_OPTS".to_owned(),
             format!(
                 "-Dmaven.repo.local={} -Dmaven.repo.local={}",
-                jvm_repository.path().display(),
+                jvm_repository.display(),
                 opts_repository.path().display()
             ),
         );
@@ -4232,17 +4292,14 @@ mod tests {
         assert!(
             !maven_opts
                 .allow_write
-                .contains(&SandboxPath::dir(jvm_repository.path().to_path_buf())),
+                .contains(&SandboxPath::dir(jvm_repository)),
             "MAVEN_OPTS is appended after .mvn/jvm.config and its last property wins"
         );
 
-        let config_repository = tempfile::tempdir().unwrap();
+        let config_repository = project.path().join("maven-config-repository");
         std::fs::write(
             project.path().join(".mvn/maven.config"),
-            format!(
-                "-Dmaven.repo.local={}\n",
-                config_repository.path().display()
-            ),
+            format!("-Dmaven.repo.local={}\n", config_repository.display()),
         )
         .unwrap();
         let mut maven_config =
@@ -4264,9 +4321,54 @@ mod tests {
         assert!(
             maven_config
                 .allow_write
-                .contains(&SandboxPath::dir(config_repository.path().to_path_buf())),
+                .contains(&SandboxPath::dir(config_repository.clone())),
             "project Maven arguments override JVM system-property sources"
         );
+
+        let external_project_repository = tempfile::tempdir().unwrap();
+        std::fs::write(
+            project.path().join(".mvn/maven.config"),
+            format!(
+                "-Dmaven.repo.local={}\n",
+                external_project_repository.path().display()
+            ),
+        )
+        .unwrap();
+        let mut unapproved =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        unapproved
+            .env
+            .insert("MAVEN_ARGS".to_owned(), "-B".to_owned());
+        unapproved
+            .env
+            .insert("MAVEN_OPTS".to_owned(), "-Xmx1g".to_owned());
+        let error = apply_standard_profile(
+            &mut unapproved,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+
+        let mut approved =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        approved
+            .env
+            .insert("MAVEN_ARGS".to_owned(), "-B".to_owned());
+        approved.allow_write.push(SandboxPath::dir(
+            external_project_repository.path().to_path_buf(),
+        ));
+        apply_standard_profile(
+            &mut approved,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(approved.allow_write.contains(&SandboxPath::dir(
+            external_project_repository.path().to_path_buf()
+        )));
 
         let args_repository = tempfile::tempdir().unwrap();
         let mut maven_args =
@@ -4290,7 +4392,7 @@ mod tests {
         assert!(
             !maven_args
                 .allow_write
-                .contains(&SandboxPath::dir(config_repository.path().to_path_buf())),
+                .contains(&SandboxPath::dir(config_repository)),
             "MAVEN_ARGS is passed as CLI input and overrides project Maven arguments"
         );
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -625,7 +625,34 @@ fn apply_standard_profile(
         .into_iter()
         .filter(|output| resolves_within(output, project_dir))
     {
+        // The Linux backend must open an executable directory before it
+        // installs Landlock. Keep the narrower write grant alongside the
+        // workspace grant so a missing output root is created safely before
+        // its execute rule is compiled.
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowWrite,
+            SandboxPath::dir(output.clone()),
+        );
         insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(output));
+    }
+
+    if profile.name == "java" {
+        // Standard mode uses the package manager's ordinary persistent
+        // caches. Strict mode redirects these into the private runtime root.
+        for cache in [
+            home.join(".sbt"),
+            home.join(".ivy2/cache"),
+            home.join(".cache/coursier"),
+        ] {
+            insert_builtin_path_grant(profile, GrantKind::AllowWrite, SandboxPath::dir(cache));
+        }
+        #[cfg(target_os = "macos")]
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowWrite,
+            SandboxPath::dir(home.join("Library/Caches/Coursier")),
+        );
     }
 
     for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
@@ -2271,6 +2298,11 @@ mod tests {
                 .allow_exec
                 .contains(&SandboxPath::dir(project.path().join("target")))
         );
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(project.path().join("target")))
+        );
         assert!(!profile.deny_read.iter().any(|grant| {
             grant.path.parent() == Some(project.path())
                 && grant.path.file_name().is_some_and(|name| name == ".env")
@@ -2353,6 +2385,30 @@ mod tests {
         );
 
         assert!(profile.deny_read.contains(&SandboxPath::file(denied)));
+    }
+
+    #[test]
+    fn standard_java_profile_uses_normal_persistent_caches() {
+        let project = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let mut profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+
+        apply_standard_profile(
+            &mut profile,
+            &["sbt".to_owned(), "compile".to_owned()],
+            home.path(),
+            project.path(),
+        );
+
+        for cache in [".sbt", ".ivy2/cache", ".cache/coursier"] {
+            assert!(
+                profile
+                    .allow_write
+                    .contains(&SandboxPath::dir(home.path().join(cache))),
+                "missing standard cache grant for {cache}"
+            );
+        }
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -632,6 +632,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "CLOUDSDK_CONFIG",
         "CREDENTIAL",
         "CREDENTIALS",
+        "CI_JOB_JWT",
+        "CI_JOB_JWT_V2",
         "DATABASE_URL",
         "DOCKER_AUTH_CONFIG",
         "DOCKER_CERT_PATH",
@@ -849,11 +851,22 @@ fn apply_standard_profile(
         }
     }
     if command_is(command, "cargo") && top_level_subcommand(command).is_command(&["install"]) {
-        let cargo_root = command_option_value(command, "--root")
-            .map(PathBuf::from)
-            .or_else(|| effective_environment_path(profile, "CARGO_INSTALL_ROOT"))
-            .or_else(|| effective_environment_path(profile, "CARGO_HOME"))
+        let explicit_root = command_option_value(command, "--root").map(PathBuf::from);
+        let environment_root = effective_environment_path(profile, "CARGO_INSTALL_ROOT");
+        let config_root = if explicit_root.is_none() && environment_root.is_none() {
+            cargo_config_install_root(command)?
+        } else {
+            None
+        };
+        let cargo_home = effective_environment_path(profile, "CARGO_HOME")
             .unwrap_or_else(|| home.join(".cargo"));
+        if explicit_root.is_none() && environment_root.is_none() && config_root.is_none() {
+            reject_implicit_cargo_install_root(project_dir, &cargo_home)?;
+        }
+        let cargo_root = explicit_root
+            .or(environment_root)
+            .or(config_root)
+            .unwrap_or(cargo_home);
         let cargo_root = if cargo_root.is_absolute() {
             cargo_root
         } else {
@@ -1918,13 +1931,13 @@ fn cargo_config_target_dir(command: &[String]) -> anyhow::Result<Option<PathBuf>
         };
         let Some((key, value)) = config.split_once('=') else {
             anyhow::bail!(
-                "cargo --config file paths cannot be inspected safely for build.target-dir; use \
-                 --target-dir or a direct --config build.target-dir='path' override"
+                "cargo --config file paths cannot be inspected safely for build.target-dir or \
+                 install.root; use --target-dir, --root, or a direct KEY='path' override"
             );
         };
         let key = key.trim();
         if key == "build.target-dir" {
-            selected = Some(parse_cargo_config_path(value)?);
+            selected = Some(parse_cargo_config_path(value, key, "--target-dir")?);
         } else if key == "build" || key.contains("target-dir") {
             anyhow::bail!(
                 "cargo --config target-directory override '{key}' is unsupported; use \
@@ -1935,30 +1948,190 @@ fn cargo_config_target_dir(command: &[String]) -> anyhow::Result<Option<PathBuf>
     Ok(selected)
 }
 
-fn parse_cargo_config_path(value: &str) -> anyhow::Result<PathBuf> {
+fn cargo_config_install_root(command: &[String]) -> anyhow::Result<Option<PathBuf>> {
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    let mut selected = None;
+    while let Some(argument) = arguments.next() {
+        let config = if argument == "--config" {
+            arguments
+                .next()
+                .map(String::as_str)
+                .context("cargo --config requires a value")?
+        } else if let Some(value) = argument.strip_prefix("--config=") {
+            value
+        } else {
+            continue;
+        };
+        let Some((key, value)) = config.split_once('=') else {
+            anyhow::bail!(
+                "cargo --config file paths cannot be inspected safely for install.root; use \
+                 --root or a direct --config install.root='path' override"
+            );
+        };
+        let key = key.trim();
+        if key == "install.root" {
+            selected = Some(parse_cargo_config_path(value, key, "--root")?);
+        } else if key == "include" {
+            anyhow::bail!(
+                "cargo --config include files cannot be inspected safely for install.root; use \
+                 --root to select the install destination explicitly"
+            );
+        } else if key == "install" || key.starts_with("install.root.") {
+            anyhow::bail!(
+                "cargo --config install-root override '{key}' is unsupported; use --root or a \
+                 direct --config install.root='path' override"
+            );
+        }
+    }
+    Ok(selected)
+}
+
+fn parse_cargo_config_path(
+    value: &str,
+    key: &str,
+    preferred_option: &str,
+) -> anyhow::Result<PathBuf> {
     let value = value.trim();
     let path = if value.len() >= 2 && value.starts_with('\'') && value.ends_with('\'') {
         let path = &value[1..value.len() - 1];
         if path.contains('\'') {
-            anyhow::bail!("cargo build.target-dir contains an unsupported quoted path");
+            anyhow::bail!("cargo {key} contains an unsupported quoted path");
         }
         path
     } else if value.len() >= 2 && value.starts_with('"') && value.ends_with('"') {
         let path = &value[1..value.len() - 1];
         if path.contains('\\') || path.contains('"') {
-            anyhow::bail!("cargo build.target-dir contains unsupported TOML escapes");
+            anyhow::bail!("cargo {key} contains unsupported TOML escapes");
         }
         path
     } else {
         anyhow::bail!(
-            "cargo build.target-dir must be a simple quoted path; use --target-dir for complex \
-             values"
+            "cargo {key} must be a simple quoted path; use {preferred_option} for complex values"
         );
     };
     if path.is_empty() || path.chars().any(char::is_control) {
-        anyhow::bail!("cargo build.target-dir must be a non-empty path without control characters");
+        anyhow::bail!("cargo {key} must be a non-empty path without control characters");
     }
     Ok(PathBuf::from(path))
+}
+
+fn reject_implicit_cargo_install_root(project_dir: &Path, cargo_home: &Path) -> anyhow::Result<()> {
+    for directory in project_dir.ancestors() {
+        reject_cargo_install_root_in_config(&directory.join(".cargo"))?;
+    }
+    reject_cargo_install_root_in_config(cargo_home)
+}
+
+fn reject_cargo_install_root_in_config(config_dir: &Path) -> anyhow::Result<()> {
+    for name in ["config", "config.toml"] {
+        let path = config_dir.join(name);
+        let Some(contents) = read_bounded_cargo_config(&path)? else {
+            continue;
+        };
+        let contents = std::str::from_utf8(&contents)
+            .with_context(|| format!("Cargo config is not UTF-8: {}", path.display()))?;
+        if cargo_config_may_define_install_root(contents) {
+            anyhow::bail!(
+                "Cargo config '{}' selects or may include install.root, which SBE cannot safely \
+                 reproduce; use an explicit cargo install --root path",
+                path.display()
+            );
+        }
+        // Cargo gives the legacy extensionless spelling precedence when both exist.
+        break;
+    }
+    Ok(())
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "Cargo itself follows config symlinks; policy preparation resolves the selected file \
+              before applying the bounded no-follow reader"
+)]
+fn read_bounded_cargo_config(path: &Path) -> anyhow::Result<Option<Vec<u8>>> {
+    let resolved = match std::fs::canonicalize(path) {
+        Ok(resolved) => resolved,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(error).with_context(|| format!("resolve Cargo config: {}", path.display()));
+        }
+    };
+    read_bounded_project_file(&resolved)
+}
+
+fn cargo_config_may_define_install_root(contents: &str) -> bool {
+    let mut in_install_table = false;
+    let mut at_root = true;
+    for line in contents.lines() {
+        let line = strip_toml_comment(line).trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with('[') && line.ends_with(']') {
+            let table = line.trim_matches(['[', ']']).trim();
+            in_install_table = simple_toml_key_path(table).is_some_and(|path| path == ["install"]);
+            at_root = false;
+            continue;
+        }
+        let Some((key, _value)) = line.split_once('=') else {
+            continue;
+        };
+        let Some(key) = simple_toml_key_path(key.trim()) else {
+            continue;
+        };
+        if key == ["install", "root"]
+            || (in_install_table && key == ["root"])
+            || (!in_install_table && key == ["install"])
+            || (at_root && key == ["include"])
+        {
+            return true;
+        }
+    }
+    false
+}
+
+fn simple_toml_key_path(key: &str) -> Option<Vec<&str>> {
+    key.split('.')
+        .map(|component| {
+            let component = component.trim();
+            if component.len() >= 2
+                && ((component.starts_with('\'') && component.ends_with('\''))
+                    || (component.starts_with('"') && component.ends_with('"')))
+            {
+                Some(&component[1..component.len() - 1])
+            } else if !component.is_empty()
+                && component
+                    .chars()
+                    .all(|character| character.is_ascii_alphanumeric() || "_-".contains(character))
+            {
+                Some(component)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn strip_toml_comment(line: &str) -> &str {
+    let mut quote = None;
+    let mut escaped = false;
+    for (index, character) in line.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match (quote, character) {
+            (Some('"'), '\\') => escaped = true,
+            (Some(active), current) if active == current => quote = None,
+            (None, '\'' | '"') => quote = Some(character),
+            (None, '#') => return &line[..index],
+            _ => {}
+        }
+    }
+    line
 }
 
 fn command_system_property<'a>(command: &'a [String], name: &str) -> Option<&'a str> {
@@ -3233,6 +3406,8 @@ mod tests {
                 ),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
                 ("AWS_CONFIG_FILE".to_owned(), "/tmp/aws-config".to_owned()),
+                ("CI_JOB_JWT".to_owned(), "sentinel".to_owned()),
+                ("CI_JOB_JWT_V2".to_owned(), "sentinel".to_owned()),
                 (
                     "AWS_SHARED_CREDENTIALS_FILE".to_owned(),
                     "/tmp/aws-credentials".to_owned(),
@@ -4717,6 +4892,131 @@ mod tests {
             ),
             Some("relative")
         );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test writes isolated Cargo configuration fixtures"
+    )]
+    fn standard_cargo_install_handles_configured_roots_before_launch() {
+        let project = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let direct_root = tempfile::tempdir().unwrap();
+        let configured_root = tempfile::tempdir().unwrap();
+        let mut direct =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        apply_standard_profile(
+            &mut direct,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "--config".to_owned(),
+                format!("install.root='{}'", direct_root.path().display()),
+                "ripgrep".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            direct
+                .allow_write
+                .contains(&SandboxPath::dir(direct_root.path().to_path_buf()))
+        );
+        assert!(
+            direct
+                .allow_exec
+                .contains(&SandboxPath::dir(direct_root.path().join("bin")))
+        );
+
+        let mut environment =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        environment.env.insert(
+            "CARGO_INSTALL_ROOT".to_owned(),
+            configured_root.path().display().to_string(),
+        );
+        apply_standard_profile(
+            &mut environment,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "--config".to_owned(),
+                format!("install.root='{}'", direct_root.path().display()),
+                "ripgrep".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            environment
+                .allow_write
+                .contains(&SandboxPath::dir(configured_root.path().to_path_buf())),
+            "CARGO_INSTALL_ROOT takes precedence over the Cargo config value"
+        );
+        assert!(
+            !environment
+                .allow_write
+                .contains(&SandboxPath::dir(direct_root.path().to_path_buf()))
+        );
+
+        let cargo_config = project.path().join(".cargo/config.toml");
+        std::fs::create_dir_all(cargo_config.parent().unwrap()).unwrap();
+        std::fs::write(
+            &cargo_config,
+            format!("[install]\nroot = '{}'\n", configured_root.path().display()),
+        )
+        .unwrap();
+        let mut implicit =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        let error = apply_standard_profile(
+            &mut implicit,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "ripgrep".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("cargo install --root"));
+
+        let mut explicit =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        apply_standard_profile(
+            &mut explicit,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "--root".to_owned(),
+                direct_root.path().display().to_string(),
+                "ripgrep".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            explicit
+                .allow_write
+                .contains(&SandboxPath::dir(direct_root.path().to_path_buf())),
+            "an explicit root must override an implicit Cargo config"
+        );
+
+        assert!(cargo_config_may_define_install_root(
+            "[\"install\"]\n\"root\" = '/tmp/cargo' # selected root"
+        ));
+        assert!(cargo_config_may_define_install_root(
+            "'install'.'root' = '/tmp/cargo'"
+        ));
+        assert!(cargo_config_may_define_install_root(
+            "include = ['shared.toml']"
+        ));
+        assert!(!cargo_config_may_define_install_root(
+            "[build]\ntarget-dir = 'install/root' # not an install setting"
+        ));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -758,7 +758,18 @@ fn apply_standard_profile(
     }
 
     if let Some(npm_cache) = effective_npm_cache(profile, command, home, project_dir)? {
-        replace_builtin_write_path(profile, &home.join(".npm"), SandboxPath::dir(npm_cache));
+        if npm_cache.project_controlled
+            && !project_npm_cache_is_approved(profile, &npm_cache.path, home, project_dir)
+        {
+            let resolved = resolve_existing_ancestor(&npm_cache.path)
+                .unwrap_or_else(|| npm_cache.path.clone());
+            return Err(external_write_approval_error(&npm_cache.path, &resolved));
+        }
+        replace_builtin_write_path(
+            profile,
+            &home.join(".npm"),
+            SandboxPath::dir(npm_cache.path),
+        );
     }
 
     if profile.name == "java" {
@@ -924,12 +935,17 @@ fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<Pa
         .or_else(|| std::env::var_os(name).map(PathBuf::from))
 }
 
+struct NpmCacheSelection {
+    path: PathBuf,
+    project_controlled: bool,
+}
+
 fn effective_npm_cache(
     profile: &SandboxProfile,
     command: &[String],
     home: &Path,
     project_dir: &Path,
-) -> anyhow::Result<Option<PathBuf>> {
+) -> anyhow::Result<Option<NpmCacheSelection>> {
     if profile.name != "node" || (!command_is(command, "npm") && !command_is(command, "npx")) {
         return Ok(None);
     }
@@ -956,17 +972,113 @@ fn effective_npm_cache(
             command_cache = Some(PathBuf::from(value));
         }
     }
+    let environment_cache = if command_cache.is_none() {
+        effective_environment_path(profile, "NPM_CONFIG_CACHE").or_else(|| {
+            profile
+                .env
+                .get("npm_config_cache")
+                .map(PathBuf::from)
+                .or_else(|| std::env::var_os("npm_config_cache").map(PathBuf::from))
+        })
+    } else {
+        None
+    };
+    let project_cache = if command_cache.is_none() && environment_cache.is_none() {
+        project_npm_cache(project_dir, home)?
+    } else {
+        None
+    };
+    let project_controlled = project_cache.is_some();
     let selected = command_cache
-        .or_else(|| effective_environment_path(profile, "NPM_CONFIG_CACHE"))
+        .or(environment_cache)
+        .or(project_cache)
         .unwrap_or_else(|| home.join(".npm"));
     if selected.as_os_str().is_empty() {
         anyhow::bail!("NPM_CONFIG_CACHE must select a non-empty path");
     }
-    Ok(Some(if selected.is_absolute() {
-        selected
-    } else {
-        project_dir.join(selected)
+    Ok(Some(NpmCacheSelection {
+        path: if selected.is_absolute() {
+            selected
+        } else {
+            project_dir.join(selected)
+        },
+        project_controlled,
     }))
+}
+
+fn project_npm_cache(project_dir: &Path, home: &Path) -> anyhow::Result<Option<PathBuf>> {
+    let path = project_dir.join(".npmrc");
+    let Some(contents) = read_bounded_project_file(&path)? else {
+        return Ok(None);
+    };
+    let contents = std::str::from_utf8(&contents)
+        .with_context(|| format!("project npm configuration is not UTF-8: {}", path.display()))?;
+    let mut selected = None;
+    for line in contents.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            if line
+                .split_whitespace()
+                .next()
+                .is_some_and(|key| key.eq_ignore_ascii_case("cache"))
+            {
+                anyhow::bail!(
+                    "project .npmrc selects cache in an unsupported form; use npm \
+                     --cache=/unambiguous/path"
+                );
+            }
+            continue;
+        };
+        if !key.trim().eq_ignore_ascii_case("cache") {
+            continue;
+        }
+        let mut value = value.trim();
+        if value.len() >= 2
+            && ((value.starts_with('"') && value.ends_with('"'))
+                || (value.starts_with('\'') && value.ends_with('\'')))
+        {
+            value = &value[1..value.len() - 1];
+        }
+        let value = value
+            .replace("${HOME}", &home.to_string_lossy())
+            .replace("${home}", &home.to_string_lossy());
+        let value = value
+            .strip_prefix("~/")
+            .map_or_else(|| PathBuf::from(&value), |suffix| home.join(suffix));
+        let value_text = value.to_string_lossy();
+        if value.as_os_str().is_empty()
+            || value_text
+                .chars()
+                .any(|character| character.is_control() || matches!(character, '$' | '`'))
+            || value_text.starts_with('"')
+            || value_text.starts_with('\'')
+            || value_text.ends_with('"')
+            || value_text.ends_with('\'')
+        {
+            anyhow::bail!(
+                "project .npmrc selects cache in a form sbe cannot resolve safely; use npm \
+                 --cache=/unambiguous/path"
+            );
+        }
+        selected = Some(value);
+    }
+    Ok(selected)
+}
+
+fn project_npm_cache_is_approved(
+    profile: &SandboxProfile,
+    cache: &Path,
+    home: &Path,
+    project_dir: &Path,
+) -> bool {
+    let resolved = resolve_existing_ancestor(cache).unwrap_or_else(|| cache.to_path_buf());
+    let project =
+        resolve_existing_ancestor(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+    resolved.starts_with(project)
+        || cache.starts_with(home.join(".npm"))
+        || explicit_write_covers(profile, &resolved)
 }
 
 fn effective_cargo_home(profile: &SandboxProfile, home: &Path, project_dir: &Path) -> PathBuf {
@@ -1089,6 +1201,15 @@ fn effective_maven_settings_read_paths(
     .into_iter()
     .flatten()
     {
+        if settings.project_controlled {
+            let resolved =
+                resolve_existing_ancestor(&settings.path).unwrap_or_else(|| settings.path.clone());
+            let project =
+                resolve_existing_ancestor(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
+            if !resolved.starts_with(project) && !explicit_read_covers(profile, &resolved) {
+                return Err(external_read_approval_error(&settings.path, &resolved));
+            }
+        }
         paths.push(SandboxPath::file(settings.path));
     }
     Ok(paths)
@@ -2117,6 +2238,24 @@ fn explicit_write_covers(profile: &SandboxProfile, target: &Path) -> bool {
         .iter()
         .filter_map(resolve_explicit_grant)
         .any(|explicit| grant_covers(&explicit, target))
+}
+
+fn explicit_read_covers(profile: &SandboxProfile, target: &Path) -> bool {
+    let built_in_boundary = profile.first_user_allow_read.min(profile.allow_read.len());
+    profile.allow_read[built_in_boundary..]
+        .iter()
+        .filter_map(resolve_explicit_grant)
+        .any(|explicit| grant_covers(&explicit, target))
+}
+
+fn external_read_approval_error(lexical: &Path, resolved: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "project-selected readable path '{}' resolves outside the workspace to '{}'; approve that \
+         target explicitly with --allow-read '{}'",
+        lexical.display(),
+        resolved.display(),
+        resolved.display()
+    )
 }
 
 fn external_write_approval_error(lexical: &Path, resolved: &Path) -> anyhow::Error {
@@ -3841,12 +3980,16 @@ fn build_overrides(args: &RunArgs, home: &Path, pwd: &Path) -> anyhow::Result<Pr
             .iter()
             .map(|path| expand_cli_path(path, home, pwd))
             .collect::<anyhow::Result<_>>()?,
+        allow_read: args
+            .allow_read
+            .iter()
+            .map(|path| expand_cli_path(path, home, pwd))
+            .collect::<anyhow::Result<_>>()?,
         deny_read: args
             .deny_read
             .iter()
             .map(|path| expand_cli_path(path, home, pwd))
             .collect::<anyhow::Result<_>>()?,
-        allow_read: Vec::new(),
         allow_domains: args
             .allow_domain
             .iter()
@@ -5204,7 +5347,42 @@ mod tests {
             project.path(),
         )
         .unwrap_err();
+        assert!(error.to_string().contains("--allow-read"));
+
+        let mut settings_read_approved =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        settings_read_approved
+            .allow_read
+            .push(SandboxPath::file(explicit_settings.clone()));
+        let error = apply_standard_profile(
+            &mut settings_read_approved,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap_err();
         assert!(error.to_string().contains("--allow-write"));
+
+        let mut project_settings_approved =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        project_settings_approved
+            .allow_read
+            .push(SandboxPath::file(explicit_settings.clone()));
+        project_settings_approved
+            .allow_write
+            .push(SandboxPath::dir(explicit_repository.path().to_path_buf()));
+        apply_standard_profile(
+            &mut project_settings_approved,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            project_settings_approved
+                .allow_read
+                .contains(&SandboxPath::file(explicit_settings.clone()))
+        );
 
         std::fs::write(
             project.path().join(".mvn/maven.config"),
@@ -6407,6 +6585,40 @@ mod tests {
             environment_selected
                 .allow_write
                 .contains(&SandboxPath::dir(project.join("relative-npm-cache")))
+        );
+
+        let external_project_cache = root.path().join("project-selected-cache");
+        std::fs::create_dir_all(&external_project_cache).unwrap();
+        std::fs::write(
+            project.join(".npmrc"),
+            format!("cache={}\n", external_project_cache.display()),
+        )
+        .unwrap();
+        let mut unapproved = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        let error = apply_standard_profile(
+            &mut unapproved,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+
+        let mut approved = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        approved
+            .allow_write
+            .push(SandboxPath::dir(external_project_cache.clone()));
+        apply_standard_profile(
+            &mut approved,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            approved
+                .allow_write
+                .contains(&SandboxPath::dir(external_project_cache))
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1079,8 +1079,8 @@ fn resolve_standard_path_aliases(
     project_dir: &Path,
 ) -> anyhow::Result<()> {
     snapshot_standard_write_aliases(profile, home, project_dir)?;
-    snapshot_standard_exec_aliases(profile);
-    snapshot_standard_read_aliases(profile);
+    snapshot_standard_exec_aliases(profile)?;
+    snapshot_standard_read_aliases(profile)?;
     #[cfg(target_os = "linux")]
     append_standard_workspace_read_aliases(profile, project_dir)?;
     Ok(())
@@ -1109,60 +1109,95 @@ fn append_standard_workspace_read_aliases(
     clippy::disallowed_methods,
     reason = "standard mode snapshots executable symlink referents before launching untrusted code"
 )]
-fn snapshot_standard_exec_aliases(profile: &mut SandboxProfile) {
+fn snapshot_standard_exec_aliases(profile: &mut SandboxProfile) -> anyhow::Result<()> {
+    let built_in_boundary = profile.first_user_allow_exec.min(profile.allow_exec.len());
+    let original = profile.allow_exec.clone();
+    let mut snapped = Vec::with_capacity(original.len());
     let mut records = Vec::new();
-    profile.allow_exec = profile
-        .allow_exec
-        .drain(..)
-        .map(|grant| {
-            let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
-                return grant;
-            };
-            if resolved == grant.path {
-                return grant;
-            }
+    for (index, grant) in original.into_iter().enumerate() {
+        let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+            snapped.push(grant);
+            continue;
+        };
+        if resolved != grant.path
+            && index < built_in_boundary
+            && overlaps_denied_read(profile, &resolved)
+        {
+            return Err(protected_builtin_alias_error(
+                "executable",
+                &grant.path,
+                &resolved,
+            ));
+        }
+        if resolved != grant.path {
             records.push(GrantRecord {
                 kind: GrantKind::AllowExec,
                 value: resolved.to_string_lossy().into_owned(),
                 origin: GrantOrigin::Runtime,
             });
-            SandboxPath {
+            snapped.push(SandboxPath {
                 path: resolved,
                 kind: grant.kind,
-            }
-        })
-        .collect();
+            });
+        } else {
+            snapped.push(grant);
+        }
+    }
+    profile.allow_exec = snapped;
     profile.grant_origins.extend(records);
+    Ok(())
 }
 
 #[allow(
     clippy::disallowed_methods,
     reason = "standard mode snapshots readable symlink referents before launching untrusted code"
 )]
-fn snapshot_standard_read_aliases(profile: &mut SandboxProfile) {
+fn snapshot_standard_read_aliases(profile: &mut SandboxProfile) -> anyhow::Result<()> {
+    let built_in_boundary = profile.first_user_allow_read.min(profile.allow_read.len());
+    let original = profile.allow_read.clone();
+    let mut snapped = Vec::with_capacity(original.len());
     let mut records = Vec::new();
-    profile.allow_read = profile
-        .allow_read
-        .drain(..)
-        .map(|grant| {
-            let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
-                return grant;
-            };
-            if resolved == grant.path {
-                return grant;
-            }
+    for (index, grant) in original.into_iter().enumerate() {
+        let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+            snapped.push(grant);
+            continue;
+        };
+        if resolved != grant.path
+            && index < built_in_boundary
+            && overlaps_denied_read(profile, &resolved)
+        {
+            return Err(protected_builtin_alias_error(
+                "readable",
+                &grant.path,
+                &resolved,
+            ));
+        }
+        if resolved != grant.path {
             records.push(GrantRecord {
                 kind: GrantKind::AllowRead,
                 value: resolved.to_string_lossy().into_owned(),
                 origin: GrantOrigin::Runtime,
             });
-            SandboxPath {
+            snapped.push(SandboxPath {
                 path: resolved,
                 kind: grant.kind,
-            }
-        })
-        .collect();
+            });
+        } else {
+            snapped.push(grant);
+        }
+    }
+    profile.allow_read = snapped;
     profile.grant_origins.extend(records);
+    Ok(())
+}
+
+fn protected_builtin_alias_error(kind: &str, lexical: &Path, resolved: &Path) -> anyhow::Error {
+    anyhow::anyhow!(
+        "built-in {kind} path '{}' resolves into protected read path '{}'; protected referents \
+         cannot be inferred from a built-in grant",
+        lexical.display(),
+        resolved.display()
+    )
 }
 
 #[allow(
@@ -1447,7 +1482,6 @@ fn workspace_read_aliases_with_limits(
     clippy::disallowed_methods,
     reason = "standard mode compares source symlink referents with protected paths before launch"
 )]
-#[cfg(any(target_os = "linux", test))]
 fn overlaps_denied_read(profile: &SandboxProfile, candidate: &Path) -> bool {
     profile.deny_read.iter().any(|denied| {
         let denied = resolve_existing_ancestor(&denied.path).unwrap_or_else(|| denied.path.clone());
@@ -3423,6 +3457,45 @@ mod tests {
                 .any(|grant| grant.path == home.join(".npm")),
             "the launcher must not reopen the mutable lexical symlink"
         );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test resolves isolated malicious wrapper and read symlinks"
+    )]
+    fn standard_profile_rejects_protected_builtin_aliases() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let ssh = home.join(".ssh");
+        let private_key = ssh.join("id_rsa");
+        std::fs::create_dir_all(&ssh).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::write(&private_key, "sentinel").unwrap();
+        std::os::unix::fs::symlink(&private_key, project.join("gradlew")).unwrap();
+
+        let mut executable = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        apply_standard_profile(
+            &mut executable,
+            &["./gradlew".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        let error = resolve_standard_path_aliases(&mut executable, &home, &project).unwrap_err();
+        assert!(error.to_string().contains("built-in executable"));
+        assert!(error.to_string().contains("gradlew"));
+        assert!(error.to_string().contains("id_rsa"));
+
+        let read_alias = home.join("read-alias");
+        std::os::unix::fs::symlink(&ssh, &read_alias).unwrap();
+        let mut readable = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        readable.allow_read = vec![SandboxPath::dir(read_alias)];
+        readable.first_user_allow_read = 1;
+        let error = snapshot_standard_read_aliases(&mut readable).unwrap_err();
+        assert!(error.to_string().contains("built-in readable"));
+        assert!(error.to_string().contains(".ssh"));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -745,7 +745,9 @@ fn apply_standard_profile(
     }
 
     if profile.name == "java" {
-        if let Some(repository) = effective_maven_local_repository(command, home, project_dir)? {
+        if let Some(repository) =
+            effective_maven_local_repository(profile, command, home, project_dir)?
+        {
             replace_builtin_write_path(
                 profile,
                 &home.join(".m2/repository"),
@@ -901,6 +903,7 @@ fn effective_gradle_user_home(
 }
 
 fn effective_maven_local_repository(
+    profile: &SandboxProfile,
     command: &[String],
     home: &Path,
     project_dir: &Path,
@@ -908,13 +911,41 @@ fn effective_maven_local_repository(
     if !command_is(command, "mvn") && !command_is(command, "mvnw") {
         return Ok(None);
     }
-    let Some(value) = command_maven_property(command, "maven.repo.local") else {
+    let command_value = command_maven_property(command, "maven.repo.local").map(PathBuf::from);
+    let maven_opts_value = if command_value.is_none() {
+        let options = profile
+            .env
+            .get("MAVEN_OPTS")
+            .cloned()
+            .or_else(|| std::env::var("MAVEN_OPTS").ok());
+        options
+            .as_deref()
+            .map(|options| maven_options_local_repository(options, "MAVEN_OPTS"))
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let project_value = if command_value.is_none() && maven_opts_value.is_none() {
+        let path = project_dir.join(".mvn/jvm.config");
+        read_bounded_project_file(&path)?
+            .map(|contents| {
+                let contents = std::str::from_utf8(&contents).with_context(|| {
+                    format!("Maven JVM config is not UTF-8: {}", path.display())
+                })?;
+                maven_options_local_repository(contents, ".mvn/jvm.config")
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let Some(path) = command_value.or(maven_opts_value).or(project_value) else {
         return Ok(None);
     };
-    if value.is_empty() || value.chars().any(char::is_control) {
-        anyhow::bail!("maven.repo.local must be a non-empty path without control characters");
+    if path.as_os_str().is_empty() {
+        anyhow::bail!("maven.repo.local must be a non-empty path");
     }
-    let path = PathBuf::from(value);
     let path = if path.is_absolute() {
         path
     } else {
@@ -924,6 +955,33 @@ fn effective_maven_local_repository(
         return Ok(None);
     }
     Ok(Some(path))
+}
+
+fn maven_options_local_repository(options: &str, source: &str) -> anyhow::Result<Option<PathBuf>> {
+    let mut selected = None;
+    for token in options.split_whitespace() {
+        let Some(value) = token.strip_prefix("-Dmaven.repo.local=") else {
+            continue;
+        };
+        if value.is_empty()
+            || value.chars().any(|character| {
+                matches!(character, '$' | '`' | '\\' | '\'' | '"' | '*' | '?' | '[')
+            })
+        {
+            anyhow::bail!(
+                "{source} selects maven.repo.local in a form that sbe cannot resolve safely; use \
+                 -Dmaven.repo.local=/unambiguous/path"
+            );
+        }
+        selected = Some(PathBuf::from(value));
+    }
+    if selected.is_none() && options.contains("-Dmaven.repo.local") {
+        anyhow::bail!(
+            "{source} selects maven.repo.local in an unsupported form; use \
+             -Dmaven.repo.local=/unambiguous/path"
+        );
+    }
+    Ok(selected)
 }
 
 fn jvm_options_gradle_user_home(
@@ -3924,6 +3982,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the test creates an isolated Maven JVM configuration fixture"
+    )]
     async fn standard_java_profile_uses_normal_persistent_caches() {
         let project = tempfile::tempdir().unwrap();
         let home = tempfile::tempdir().unwrap();
@@ -4011,6 +4073,10 @@ mod tests {
 
         let custom_repository = tempfile::tempdir().unwrap();
         let mut maven = SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        maven.env.insert(
+            "MAVEN_OPTS".to_owned(),
+            "-Dmaven.repo.local=/ignored-lower-precedence-repository".to_owned(),
+        );
         apply_standard_profile(
             &mut maven,
             &[
@@ -4032,6 +4098,61 @@ mod tests {
                 .allow_write
                 .contains(&SandboxPath::dir(home.path().join(".m2/repository"))),
             "the selected Maven repository must replace the default write grant"
+        );
+
+        let jvm_repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(project.path().join(".mvn")).unwrap();
+        std::fs::write(
+            project.path().join(".mvn/jvm.config"),
+            format!("-Dmaven.repo.local={}\n", jvm_repository.path().display()),
+        )
+        .unwrap();
+        let mut jvm_config =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        jvm_config
+            .env
+            .insert("MAVEN_OPTS".to_owned(), "-Xmx1g".to_owned());
+        apply_standard_profile(
+            &mut jvm_config,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            jvm_config
+                .allow_write
+                .contains(&SandboxPath::dir(jvm_repository.path().to_path_buf()))
+        );
+
+        let opts_repository = tempfile::tempdir().unwrap();
+        let mut maven_opts =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        maven_opts.env.insert(
+            "MAVEN_OPTS".to_owned(),
+            format!(
+                "-Dmaven.repo.local={} -Dmaven.repo.local={}",
+                jvm_repository.path().display(),
+                opts_repository.path().display()
+            ),
+        );
+        apply_standard_profile(
+            &mut maven_opts,
+            &["mvn".to_owned(), "validate".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            maven_opts
+                .allow_write
+                .contains(&SandboxPath::dir(opts_repository.path().to_path_buf()))
+        );
+        assert!(
+            !maven_opts
+                .allow_write
+                .contains(&SandboxPath::dir(jvm_repository.path().to_path_buf())),
+            "MAVEN_OPTS is appended after .mvn/jvm.config and its last property wins"
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1450,6 +1450,10 @@ fn project_relocation_option(command: &[String]) -> Option<&str> {
         .iter()
         .skip(1)
         .take_while(|argument| argument.as_str() != "--")
+        .filter(|argument| {
+            !matches!(program, "mvn" | "mvnw")
+                || !["-fae", "-ff", "-fn"].contains(&argument.as_str())
+        })
         .find_map(|argument| {
             options.iter().copied().find(|option| {
                 argument == *option
@@ -3834,6 +3838,13 @@ mod tests {
             ])
             .is_ok()
         );
+        for flag in ["-fae", "-ff", "-fn"] {
+            assert!(
+                reject_project_relocation(&["mvn".to_owned(), flag.to_owned(), "test".to_owned(),])
+                    .is_ok(),
+                "Maven failure-mode flag was treated as a project path: {flag}"
+            );
+        }
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -652,6 +652,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "MONGODB_URI",
         "MONGO_URL",
         "MYSQL_PWD",
+        "NETRC",
         "NPM_CONFIG_USERCONFIG",
         "PASSWORD",
         "PASSWD",
@@ -759,7 +760,7 @@ fn apply_standard_profile(
 
     if let Some(npm_cache) = effective_npm_cache(profile, command, home, project_dir)? {
         if npm_cache.project_controlled
-            && !project_npm_cache_is_approved(profile, &npm_cache.path, home, project_dir)
+            && !project_cache_is_approved(profile, &npm_cache.path, &home.join(".npm"), project_dir)
         {
             let resolved = resolve_existing_ancestor(&npm_cache.path)
                 .unwrap_or_else(|| npm_cache.path.clone());
@@ -770,6 +771,17 @@ fn apply_standard_profile(
             &home.join(".npm"),
             SandboxPath::dir(npm_cache.path),
         );
+    }
+    if let Some(pnpm_store) = effective_pnpm_store(profile, command, home, project_dir)? {
+        let conventional = home.join(".local/share/pnpm");
+        if pnpm_store.project_controlled
+            && !project_cache_is_approved(profile, &pnpm_store.path, &conventional, project_dir)
+        {
+            let resolved = resolve_existing_ancestor(&pnpm_store.path)
+                .unwrap_or_else(|| pnpm_store.path.clone());
+            return Err(external_write_approval_error(&pnpm_store.path, &resolved));
+        }
+        replace_builtin_write_path(profile, &conventional, SandboxPath::dir(pnpm_store.path));
     }
 
     if profile.name == "java" {
@@ -988,10 +1000,17 @@ fn effective_npm_cache(
     } else {
         None
     };
+    let user_cache =
+        if command_cache.is_none() && environment_cache.is_none() && project_cache.is_none() {
+            user_npm_config_path(home, "cache")?
+        } else {
+            None
+        };
     let project_controlled = project_cache.is_some();
     let selected = command_cache
         .or(environment_cache)
         .or(project_cache)
+        .or(user_cache)
         .unwrap_or_else(|| home.join(".npm"));
     if selected.as_os_str().is_empty() {
         anyhow::bail!("NPM_CONFIG_CACHE must select a non-empty path");
@@ -1011,8 +1030,26 @@ fn project_npm_cache(project_dir: &Path, home: &Path) -> anyhow::Result<Option<P
     let Some(contents) = read_bounded_project_file(&path)? else {
         return Ok(None);
     };
-    let contents = std::str::from_utf8(&contents)
-        .with_context(|| format!("project npm configuration is not UTF-8: {}", path.display()))?;
+    npm_config_path_value(&contents, &path, home, "cache", "project .npmrc")
+}
+
+fn user_npm_config_path(home: &Path, key: &str) -> anyhow::Result<Option<PathBuf>> {
+    let path = home.join(".npmrc");
+    let Some(contents) = read_bounded_following_metadata_file(&path)? else {
+        return Ok(None);
+    };
+    npm_config_path_value(&contents, &path, home, key, "user .npmrc")
+}
+
+fn npm_config_path_value(
+    contents: &[u8],
+    path: &Path,
+    home: &Path,
+    selected_key: &str,
+    source: &str,
+) -> anyhow::Result<Option<PathBuf>> {
+    let contents = std::str::from_utf8(contents)
+        .with_context(|| format!("{source} is not UTF-8: {}", path.display()))?;
     let mut selected = None;
     for line in contents.lines().map(str::trim) {
         if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
@@ -1022,16 +1059,16 @@ fn project_npm_cache(project_dir: &Path, home: &Path) -> anyhow::Result<Option<P
             if line
                 .split_whitespace()
                 .next()
-                .is_some_and(|key| key.eq_ignore_ascii_case("cache"))
+                .is_some_and(|key| key.eq_ignore_ascii_case(selected_key))
             {
                 anyhow::bail!(
-                    "project .npmrc selects cache in an unsupported form; use npm \
-                     --cache=/unambiguous/path"
+                    "{source} selects {selected_key} in an unsupported form; use an explicit \
+                     unambiguous command option"
                 );
             }
             continue;
         };
-        if !key.trim().eq_ignore_ascii_case("cache") {
+        if !key.trim().eq_ignore_ascii_case(selected_key) {
             continue;
         }
         let mut value = value.trim();
@@ -1058,8 +1095,8 @@ fn project_npm_cache(project_dir: &Path, home: &Path) -> anyhow::Result<Option<P
             || value_text.ends_with('\'')
         {
             anyhow::bail!(
-                "project .npmrc selects cache in a form sbe cannot resolve safely; use npm \
-                 --cache=/unambiguous/path"
+                "{source} selects {selected_key} in a form sbe cannot resolve safely; use an \
+                 explicit unambiguous command option"
             );
         }
         selected = Some(value);
@@ -1067,17 +1104,100 @@ fn project_npm_cache(project_dir: &Path, home: &Path) -> anyhow::Result<Option<P
     Ok(selected)
 }
 
-fn project_npm_cache_is_approved(
+fn effective_pnpm_store(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Option<NpmCacheSelection>> {
+    if profile.name != "node" || !command_is(command, "pnpm") {
+        return Ok(None);
+    }
+    let mut command_store = None;
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    while let Some(argument) = arguments.next() {
+        let value = if argument == "--store-dir" {
+            Some(
+                arguments
+                    .next()
+                    .map(String::as_str)
+                    .context("pnpm --store-dir requires a value")?,
+            )
+        } else {
+            argument.strip_prefix("--store-dir=")
+        };
+        if let Some(value) = value {
+            if value.is_empty() || value.chars().any(char::is_control) {
+                anyhow::bail!("pnpm --store-dir must select a non-empty unambiguous path");
+            }
+            command_store = Some(PathBuf::from(value));
+        }
+    }
+    let environment_store = if command_store.is_none() {
+        [
+            "PNPM_STORE_DIR",
+            "NPM_CONFIG_STORE_DIR",
+            "pnpm_config_store_dir",
+            "npm_config_store_dir",
+        ]
+        .iter()
+        .find_map(|name| effective_environment_path(profile, name))
+    } else {
+        None
+    };
+    let project_store = if command_store.is_none() && environment_store.is_none() {
+        let path = project_dir.join(".npmrc");
+        read_bounded_project_file(&path)?
+            .map(|contents| {
+                npm_config_path_value(&contents, &path, home, "store-dir", "project .npmrc")
+            })
+            .transpose()?
+            .flatten()
+    } else {
+        None
+    };
+    let user_store =
+        if command_store.is_none() && environment_store.is_none() && project_store.is_none() {
+            user_npm_config_path(home, "store-dir")?
+        } else {
+            None
+        };
+    let project_controlled = project_store.is_some();
+    let default_store = effective_environment_path(profile, "XDG_DATA_HOME")
+        .map(|directory| directory.join("pnpm"))
+        .unwrap_or_else(|| home.join(".local/share/pnpm"));
+    let selected = command_store
+        .or(environment_store)
+        .or(project_store)
+        .or(user_store)
+        .unwrap_or(default_store);
+    if selected.as_os_str().is_empty() {
+        anyhow::bail!("pnpm store directory must be a non-empty path");
+    }
+    Ok(Some(NpmCacheSelection {
+        path: if selected.is_absolute() {
+            selected
+        } else {
+            project_dir.join(selected)
+        },
+        project_controlled,
+    }))
+}
+
+fn project_cache_is_approved(
     profile: &SandboxProfile,
     cache: &Path,
-    home: &Path,
+    conventional: &Path,
     project_dir: &Path,
 ) -> bool {
     let resolved = resolve_existing_ancestor(cache).unwrap_or_else(|| cache.to_path_buf());
     let project =
         resolve_existing_ancestor(project_dir).unwrap_or_else(|| project_dir.to_path_buf());
     resolved.starts_with(project)
-        || cache.starts_with(home.join(".npm"))
+        || cache.starts_with(conventional)
         || explicit_write_covers(profile, &resolved)
 }
 
@@ -4139,6 +4259,7 @@ mod tests {
                     "NPM_CONFIG_USERCONFIG".to_owned(),
                     "/tmp/custom-npmrc".to_owned(),
                 ),
+                ("NETRC".to_owned(), "/tmp/custom-netrc".to_owned()),
                 ("KRB5CCNAME".to_owned(), "FILE:/tmp/krb5cc".to_owned()),
                 (
                     "KRB5_CLIENT_KTNAME".to_owned(),
@@ -6619,6 +6740,87 @@ mod tests {
             approved
                 .allow_write
                 .contains(&SandboxPath::dir(external_project_cache))
+        );
+
+        std::fs::write(project.join(".npmrc"), "# no project cache\n").unwrap();
+        let user_cache = root.path().join("user-selected-cache");
+        std::fs::create_dir_all(&user_cache).unwrap();
+        std::fs::write(
+            home.join(".npmrc"),
+            format!("cache={}\n", user_cache.display()),
+        )
+        .unwrap();
+        let mut user_selected = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        apply_standard_profile(
+            &mut user_selected,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            user_selected
+                .allow_write
+                .contains(&SandboxPath::dir(user_cache))
+        );
+
+        let command_store = root.path().join("command-pnpm-store");
+        let mut pnpm_command = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        apply_standard_profile(
+            &mut pnpm_command,
+            &[
+                "pnpm".to_owned(),
+                "install".to_owned(),
+                "--store-dir".to_owned(),
+                command_store.display().to_string(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            pnpm_command
+                .allow_write
+                .contains(&SandboxPath::dir(command_store))
+        );
+        assert!(
+            !pnpm_command
+                .allow_write
+                .contains(&SandboxPath::dir(home.join(".local/share/pnpm")))
+        );
+
+        let project_store = root.path().join("project-pnpm-store");
+        std::fs::create_dir_all(&project_store).unwrap();
+        std::fs::write(
+            project.join(".npmrc"),
+            format!("store-dir={}\n", project_store.display()),
+        )
+        .unwrap();
+        let mut pnpm_unapproved = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        let error = apply_standard_profile(
+            &mut pnpm_unapproved,
+            &["pnpm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+
+        let mut pnpm_approved = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        pnpm_approved
+            .allow_write
+            .push(SandboxPath::dir(project_store.clone()));
+        apply_standard_profile(
+            &mut pnpm_approved,
+            &["pnpm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            pnpm_approved
+                .allow_write
+                .contains(&SandboxPath::dir(project_store))
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -788,6 +788,11 @@ fn apply_standard_profile(
             SandboxPath::dir(npm_cache.path),
         );
     }
+    if let Some(bun_cache) = effective_bun_cache(profile, command, project_dir)? {
+        for conventional in [home.join(".bun"), home.join(".cache/bun")] {
+            replace_builtin_write_path(profile, &conventional, SandboxPath::dir(bun_cache.clone()));
+        }
+    }
     if profile.name == "node"
         && (command_is(command, "npm") || command_is(command, "npx") || command_is(command, "pnpm"))
     {
@@ -801,11 +806,14 @@ fn apply_standard_profile(
                 SandboxPath::file(user_config.path),
             );
         }
-        if let Some(global_config) = effective_npm_global_config(profile, command, project_dir)? {
+        if let Some(global_config) = effective_npm_global_config(profile, command, project_dir)?
+            && (global_config.explicit
+                || read_bounded_following_metadata_file(&global_config.path)?.is_some())
+        {
             insert_builtin_path_grant(
                 profile,
                 GrantKind::AllowRead,
-                SandboxPath::file(global_config),
+                SandboxPath::file(global_config.path),
             );
         }
     }
@@ -840,7 +848,7 @@ fn apply_standard_profile(
         }
     }
     if profile.name == "python" && command_uses_pip(command) {
-        for config in effective_pip_config_read_paths(profile, home, project_dir)? {
+        for config in effective_pip_config_read_paths(profile, command, home, project_dir)? {
             insert_builtin_path_grant(profile, GrantKind::AllowRead, SandboxPath::file(config));
         }
     }
@@ -1033,6 +1041,18 @@ struct NpmCacheSelection {
     project_controlled: bool,
 }
 
+fn effective_bun_cache(
+    profile: &SandboxProfile,
+    command: &[String],
+    project_dir: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    if profile.name != "node" || !command_is(command, "bun") {
+        return Ok(None);
+    }
+    Ok(command_long_path_option(command, "--cache-dir")?
+        .map(|path| anchor_project_path(path, project_dir)))
+}
+
 fn effective_npm_cache(
     profile: &SandboxProfile,
     command: &[String],
@@ -1163,19 +1183,38 @@ fn effective_npm_user_config(
     })
 }
 
+struct NpmGlobalConfigSelection {
+    path: PathBuf,
+    explicit: bool,
+}
+
 fn effective_npm_global_config(
     profile: &SandboxProfile,
     command: &[String],
     project_dir: &Path,
-) -> anyhow::Result<Option<PathBuf>> {
-    let selected = command_long_path_option(command, "--globalconfig")?.or_else(|| {
+) -> anyhow::Result<Option<NpmGlobalConfigSelection>> {
+    let command_config = command_long_path_option(command, "--globalconfig")?;
+    let environment_config = if command_config.is_none() {
         profile
             .env
             .get("NPM_CONFIG_GLOBALCONFIG")
             .or_else(|| profile.env.get("npm_config_globalconfig"))
             .map(PathBuf::from)
+    } else {
+        None
+    };
+    let explicit = command_config.is_some() || environment_config.is_some();
+    let selected = command_config.or(environment_config).or_else(|| {
+        ["NPM_CONFIG_PREFIX", "npm_config_prefix"]
+            .iter()
+            .find_map(|name| effective_environment_path(profile, name))
+            .filter(|prefix| !prefix.as_os_str().is_empty())
+            .map(|prefix| prefix.join("etc/npmrc"))
     });
-    Ok(selected.map(|path| anchor_project_path(path, project_dir)))
+    Ok(selected.map(|path| NpmGlobalConfigSelection {
+        path: anchor_project_path(path, project_dir),
+        explicit,
+    }))
 }
 
 fn selected_global_npm_config_path(
@@ -1185,16 +1224,19 @@ fn selected_global_npm_config_path(
     project_dir: &Path,
     key: &str,
 ) -> anyhow::Result<Option<PathBuf>> {
-    let Some(path) = effective_npm_global_config(profile, command, project_dir)? else {
+    let Some(selection) = effective_npm_global_config(profile, command, project_dir)? else {
         return Ok(None);
     };
-    let Some(contents) = read_bounded_following_metadata_file(&path)? else {
-        anyhow::bail!(
-            "could not inspect explicit npm global configuration: {}",
-            path.display()
-        );
+    let Some(contents) = read_bounded_following_metadata_file(&selection.path)? else {
+        if selection.explicit {
+            anyhow::bail!(
+                "could not inspect explicit npm global configuration: {}",
+                selection.path.display()
+            );
+        }
+        return Ok(None);
     };
-    npm_config_path_value(&contents, &path, home, key, "global npmrc")
+    npm_config_path_value(&contents, &selection.path, home, key, "global npmrc")
 }
 
 fn user_npm_config_path(
@@ -1411,11 +1453,9 @@ fn effective_python_cache(
         && environment_cache.is_none()
         && default_name == "pip"
     {
-        (
-            effective_pip_config_cache(profile, home, project_dir)?,
-            false,
-            Vec::new(),
-        )
+        let (cache, project_controlled) =
+            effective_pip_config_cache(profile, command, home, project_dir)?;
+        (cache, project_controlled, Vec::new())
     } else if command_cache.is_none() && environment_cache.is_none() && default_name == "pypoetry" {
         let (cache, project_controlled) =
             effective_poetry_config_cache(profile, home, project_dir)?;
@@ -1604,28 +1644,19 @@ fn simple_uv_cache_path(value: &str, source: &Path) -> anyhow::Result<PathBuf> {
 
 fn effective_pip_config_cache(
     profile: &SandboxProfile,
+    command: &[String],
     home: &Path,
     project_dir: &Path,
-) -> anyhow::Result<Option<PathBuf>> {
-    let legacy = home.join(".pip/pip.conf");
-    let mut selected = read_pip_config_cache(&legacy, home, false)?;
-
-    let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
-        .map(|path| anchor_project_path(path, project_dir))
-        .unwrap_or_else(|| platform_config_home(home));
-    let user_config = user_config_root.join("pip/pip.conf");
-    if let Some(cache) = read_pip_config_cache(&user_config, home, false)? {
-        selected = Some(cache);
+) -> anyhow::Result<(Option<PathBuf>, bool)> {
+    let mut selected = None;
+    let mut project_controlled = false;
+    for candidate in effective_pip_config_candidates(profile, command, home, project_dir)? {
+        if let Some(cache) = read_pip_config_cache(&candidate.path, home, candidate.required)? {
+            selected = Some(cache);
+            project_controlled = candidate.project_controlled;
+        }
     }
-
-    // Ambient PIP_CONFIG_FILE is filtered. If it is present in the resolved profile, the user
-    // explicitly restored it and its final config layer should be honored.
-    if let Some(explicit) = effective_profile_path(profile, "PIP_CONFIG_FILE", project_dir)
-        && let Some(cache) = read_pip_config_cache(&explicit, home, true)?
-    {
-        selected = Some(cache);
-    }
-    Ok(selected)
+    Ok((selected, project_controlled))
 }
 
 fn effective_poetry_config_cache(
@@ -1690,34 +1721,147 @@ fn effective_poetry_config_read_paths(
 
 fn effective_pip_config_read_paths(
     profile: &SandboxProfile,
+    command: &[String],
     home: &Path,
     project_dir: &Path,
 ) -> anyhow::Result<Vec<PathBuf>> {
-    let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
-        .map(|path| anchor_project_path(path, project_dir))
-        .unwrap_or_else(|| platform_config_home(home));
-    let candidates = [
-        home.join(".pip/pip.conf"),
-        user_config_root.join("pip/pip.conf"),
-    ];
     let mut selected = Vec::new();
-    for path in candidates {
-        if read_bounded_following_metadata_file(&path)?.is_some() {
-            selected.push(path);
+    for candidate in effective_pip_config_candidates(profile, command, home, project_dir)? {
+        if read_bounded_following_metadata_file(&candidate.path)?.is_some() {
+            if !selected.contains(&candidate.path) {
+                selected.push(candidate.path);
+            }
+        } else if candidate.required {
+            anyhow::bail!(
+                "could not inspect explicit pip configuration: {}",
+                candidate.path.display()
+            );
         }
     }
-    if let Some(path) = effective_profile_path(profile, "PIP_CONFIG_FILE", project_dir) {
-        if read_bounded_following_metadata_file(&path)?.is_none() {
+    Ok(selected)
+}
+
+struct PipConfigCandidate {
+    path: PathBuf,
+    required: bool,
+    project_controlled: bool,
+}
+
+fn effective_pip_config_candidates(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Vec<PipConfigCandidate>> {
+    // Ambient PIP_CONFIG_FILE is filtered. A value here was explicitly restored and pip loads it
+    // after global, user, and site configuration. An existing explicit file suppresses the user
+    // layer; /dev/null suppresses every file layer.
+    if profile
+        .env
+        .get("PIP_CONFIG_FILE")
+        .is_some_and(String::is_empty)
+    {
+        anyhow::bail!("PIP_CONFIG_FILE must select a non-empty path");
+    }
+    let explicit = effective_profile_path(profile, "PIP_CONFIG_FILE", project_dir);
+    if let Some(path) = &explicit {
+        if path.as_os_str().is_empty() {
+            anyhow::bail!("PIP_CONFIG_FILE must select a non-empty path");
+        }
+        if path == Path::new("/dev/null") {
+            return Ok(Vec::new());
+        }
+        if read_bounded_following_metadata_file(path)?.is_none() {
             anyhow::bail!(
                 "could not inspect explicit pip configuration: {}",
                 path.display()
             );
         }
-        if !selected.contains(&path) {
-            selected.push(path);
-        }
     }
-    Ok(selected)
+
+    let mut candidates = global_pip_config_paths(profile, project_dir)
+        .into_iter()
+        .map(|path| PipConfigCandidate {
+            path,
+            required: false,
+            project_controlled: false,
+        })
+        .collect::<Vec<_>>();
+
+    if explicit.is_none() {
+        let user_config_root = effective_environment_path(profile, "XDG_CONFIG_HOME")
+            .map(|path| anchor_project_path(path, project_dir))
+            .unwrap_or_else(|| platform_config_home(home));
+        candidates.extend(
+            [
+                home.join(".pip/pip.conf"),
+                user_config_root.join("pip/pip.conf"),
+            ]
+            .into_iter()
+            .map(|path| PipConfigCandidate {
+                path,
+                required: false,
+                project_controlled: false,
+            }),
+        );
+    }
+
+    if let Some(path) = effective_pip_site_config(profile, command, project_dir) {
+        candidates.push(PipConfigCandidate {
+            project_controlled: resolves_within(&path, project_dir),
+            path,
+            required: false,
+        });
+    }
+    if let Some(path) = explicit {
+        candidates.push(PipConfigCandidate {
+            path,
+            required: true,
+            project_controlled: false,
+        });
+    }
+    Ok(candidates)
+}
+
+#[cfg(target_os = "macos")]
+fn global_pip_config_paths(_profile: &SandboxProfile, _project_dir: &Path) -> Vec<PathBuf> {
+    vec![PathBuf::from("/Library/Application Support/pip/pip.conf")]
+}
+
+#[cfg(not(target_os = "macos"))]
+fn global_pip_config_paths(profile: &SandboxProfile, project_dir: &Path) -> Vec<PathBuf> {
+    let directories = profile
+        .env
+        .get("XDG_CONFIG_DIRS")
+        .cloned()
+        .or_else(|| std::env::var("XDG_CONFIG_DIRS").ok())
+        .unwrap_or_else(|| "/etc/xdg".to_owned());
+    let mut paths = std::env::split_paths(&directories)
+        .map(|directory| anchor_project_path(directory, project_dir).join("pip/pip.conf"))
+        .collect::<Vec<_>>();
+    paths.push(PathBuf::from("/etc/pip.conf"));
+    paths
+}
+
+fn effective_pip_site_config(
+    profile: &SandboxProfile,
+    command: &[String],
+    project_dir: &Path,
+) -> Option<PathBuf> {
+    let executable = command.first().map(PathBuf::from)?;
+    let executable = anchor_project_path(executable, project_dir);
+    let executable_environment = executable
+        .parent()
+        .filter(|parent| {
+            parent.file_name().is_some_and(|name| {
+                name == std::ffi::OsStr::new("bin") || name == std::ffi::OsStr::new("Scripts")
+            })
+        })
+        .and_then(Path::parent)
+        .map(Path::to_path_buf);
+    executable_environment
+        .or_else(|| effective_environment_path(profile, "VIRTUAL_ENV"))
+        .map(|path| anchor_project_path(path, project_dir).join("pip.conf"))
 }
 
 fn effective_profile_path(
@@ -5698,12 +5842,53 @@ mod tests {
         assert!(
             pip_config
                 .allow_write
-                .contains(&SandboxPath::dir(pip_config_cache))
+                .contains(&SandboxPath::dir(pip_config_cache.clone()))
         );
         assert!(
             pip_config
                 .allow_read
                 .contains(&SandboxPath::file(pip_config_home.join("pip/pip.conf")))
+        );
+
+        let virtual_environment = root.path().join("external-venv");
+        let site_config = virtual_environment.join("pip.conf");
+        let site_cache = root.path().join("pip-site-cache");
+        std::fs::create_dir_all(virtual_environment.join("bin")).unwrap();
+        std::fs::write(
+            &site_config,
+            format!("[global]\ncache-dir={}\n", site_cache.display()),
+        )
+        .unwrap();
+        let mut pip_site = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        pip_site.env.insert(
+            "XDG_CONFIG_HOME".to_owned(),
+            pip_config_home.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut pip_site,
+            &[
+                virtual_environment
+                    .join("bin/pip")
+                    .to_string_lossy()
+                    .into_owned(),
+                "install".to_owned(),
+                "build".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(pip_site.allow_write.contains(&SandboxPath::dir(site_cache)));
+        assert!(
+            !pip_site
+                .allow_write
+                .contains(&SandboxPath::dir(pip_config_cache)),
+            "virtual-environment site configuration must override user configuration"
+        );
+        assert!(
+            pip_site
+                .allow_read
+                .contains(&SandboxPath::file(site_config))
         );
     }
 
@@ -8027,6 +8212,68 @@ mod tests {
             global_config_selected
                 .allow_write
                 .contains(&SandboxPath::dir(global_config_cache))
+        );
+
+        let prefix = root.path().join("npm-prefix");
+        let prefix_config = prefix.join("etc/npmrc");
+        let prefix_cache = root.path().join("prefix-config-cache");
+        std::fs::create_dir_all(prefix.join("etc")).unwrap();
+        std::fs::write(
+            &prefix_config,
+            format!("cache={}\n", prefix_cache.display()),
+        )
+        .unwrap();
+        let mut prefix_selected = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        prefix_selected.env.insert(
+            "NPM_CONFIG_PREFIX".to_owned(),
+            prefix.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut prefix_selected,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            prefix_selected
+                .allow_read
+                .contains(&SandboxPath::file(prefix_config))
+        );
+        assert!(
+            prefix_selected
+                .allow_write
+                .contains(&SandboxPath::dir(prefix_cache))
+        );
+
+        let bun_cache = root.path().join("bun-command-cache");
+        let mut bun_selected = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        apply_standard_profile(
+            &mut bun_selected,
+            &[
+                "bun".to_owned(),
+                "install".to_owned(),
+                "--cache-dir".to_owned(),
+                bun_cache.to_string_lossy().into_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            bun_selected
+                .allow_write
+                .contains(&SandboxPath::dir(bun_cache))
+        );
+        assert!(
+            !bun_selected
+                .allow_write
+                .contains(&SandboxPath::dir(home.join(".bun")))
+        );
+        assert!(
+            !bun_selected
+                .allow_write
+                .contains(&SandboxPath::dir(home.join(".cache/bun")))
         );
 
         let pnpm_home = root.path().join("custom-pnpm-home");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -643,6 +643,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "DOCKER_CONFIG",
         "GPG_AGENT_INFO",
         "GH_CONFIG_DIR",
+        "GIT_CONFIG_COUNT",
+        "GIT_CONFIG_PARAMETERS",
         "GNUPGHOME",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
@@ -685,6 +687,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
     EXACT.contains(&upper.as_str())
         || RESERVED.contains(&upper.as_str())
         || upper.starts_with("DYLD_")
+        || upper.starts_with("GIT_CONFIG_KEY_")
+        || upper.starts_with("GIT_CONFIG_VALUE_")
         || upper.starts_with("TF_TOKEN_")
         || upper == "LD_PRELOAD"
         || upper == "LD_LIBRARY_PATH"
@@ -862,19 +866,25 @@ fn apply_standard_profile(
         }
         // Standard mode uses the package manager's ordinary persistent
         // caches. Strict mode redirects these into the private runtime root.
-        for cache in [
-            home.join(".sbt/boot"),
-            home.join(".ivy2/cache"),
-            home.join(".cache/coursier"),
-        ] {
+        for cache in [home.join(".sbt/boot"), home.join(".ivy2/cache")] {
             insert_builtin_path_grant(profile, GrantKind::AllowWrite, SandboxPath::dir(cache));
         }
-        #[cfg(target_os = "macos")]
-        insert_builtin_path_grant(
-            profile,
-            GrantKind::AllowWrite,
-            SandboxPath::dir(home.join("Library/Caches/Coursier")),
-        );
+        let selected_coursier = effective_environment_path(profile, "COURSIER_CACHE")
+            .map(|path| anchor_project_path(path, project_dir));
+        for conventional in conventional_coursier_caches(home) {
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowWrite,
+                SandboxPath::dir(conventional.clone()),
+            );
+            if let Some(selected) = &selected_coursier {
+                replace_builtin_write_path(
+                    profile,
+                    &conventional,
+                    SandboxPath::dir(selected.clone()),
+                );
+            }
+        }
 
         if let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir)?
         {
@@ -1438,6 +1448,15 @@ fn conventional_python_caches(home: &Path, name: &str) -> Vec<PathBuf> {
         return vec![xdg, home.join("Library/Caches/pypoetry")];
     }
     vec![xdg]
+}
+
+fn conventional_coursier_caches(home: &Path) -> Vec<PathBuf> {
+    let xdg = home.join(".cache/coursier");
+    #[cfg(target_os = "macos")]
+    let paths = vec![xdg, home.join("Library/Caches/Coursier")];
+    #[cfg(not(target_os = "macos"))]
+    let paths = vec![xdg];
+    paths
 }
 
 fn effective_project_uv_cache(project_dir: &Path) -> anyhow::Result<Option<PathBuf>> {
@@ -4801,6 +4820,16 @@ mod tests {
                 ),
                 ("CI_JOB_JWT".to_owned(), "sentinel".to_owned()),
                 ("CI_JOB_JWT_V2".to_owned(), "sentinel".to_owned()),
+                ("GIT_CONFIG_COUNT".to_owned(), "1".to_owned()),
+                (
+                    "GIT_CONFIG_KEY_0".to_owned(),
+                    "http.https://example.com.extraHeader".to_owned(),
+                ),
+                ("GIT_CONFIG_VALUE_0".to_owned(), "sentinel".to_owned()),
+                (
+                    "GIT_CONFIG_PARAMETERS".to_owned(),
+                    "'http.extraHeader=Authorization: sentinel'".to_owned(),
+                ),
                 (
                     "AWS_SHARED_CREDENTIALS_FILE".to_owned(),
                     "/tmp/aws-credentials".to_owned(),
@@ -6203,6 +6232,33 @@ mod tests {
                 .contains(&SandboxPath::dir(home.path().join(".sbt"))),
             "the sbt global plugin/settings root must remain non-writable"
         );
+
+        let selected_coursier = runtime.path().join("selected-coursier");
+        let mut coursier_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Java, home.path(), project.path());
+        coursier_profile.env.insert(
+            "COURSIER_CACHE".to_owned(),
+            selected_coursier.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut coursier_profile,
+            &["sbt".to_owned(), "compile".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            coursier_profile
+                .allow_write
+                .contains(&SandboxPath::dir(selected_coursier))
+        );
+        for conventional in conventional_coursier_caches(home.path()) {
+            assert!(
+                !coursier_profile
+                    .allow_write
+                    .contains(&SandboxPath::dir(conventional))
+            );
+        }
 
         let environment = build_extra_env(
             &mut profile,

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -658,6 +658,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "PASSWD",
         "PGPASSFILE",
         "PGPASSWORD",
+        "PIP_CONFIG_FILE",
         "PRIVATE_KEY",
         "REDISCLI_AUTH",
         "SECRET",
@@ -665,6 +666,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "SSH_AUTH_SOCK",
         "SYSTEM_ACCESSTOKEN",
         "TOKEN",
+        "UV_CONFIG_FILE",
     ];
     const RESERVED: &[&str] = &[
         "HTTP_PROXY",
@@ -782,6 +784,13 @@ fn apply_standard_profile(
             return Err(external_write_approval_error(&pnpm_store.path, &resolved));
         }
         replace_builtin_write_path(profile, &conventional, SandboxPath::dir(pnpm_store.path));
+    }
+    if let Some(cache) = effective_python_cache(profile, command, home, project_dir)? {
+        replace_builtin_write_path(
+            profile,
+            &cache.conventional,
+            SandboxPath::dir(cache.selected),
+        );
     }
 
     if profile.name == "java" {
@@ -1185,6 +1194,90 @@ fn effective_pnpm_store(
         },
         project_controlled,
     }))
+}
+
+struct CacheReplacement {
+    conventional: PathBuf,
+    selected: PathBuf,
+}
+
+fn effective_python_cache(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Option<CacheReplacement>> {
+    if profile.name != "python" {
+        return Ok(None);
+    }
+    let (environment_name, default_name) =
+        if command_is(command, "uv") || command_is(command, "uvx") {
+            ("UV_CACHE_DIR", "uv")
+        } else if command_uses_pip(command) {
+            ("PIP_CACHE_DIR", "pip")
+        } else {
+            return Ok(None);
+        };
+    let command_cache = command_long_path_option(command, "--cache-dir")?;
+    let environment_cache = if command_cache.is_none() {
+        effective_environment_path(profile, environment_name)
+    } else {
+        None
+    };
+    let conventional = home.join(".cache").join(default_name);
+    let default_cache = effective_environment_path(profile, "XDG_CACHE_HOME")
+        .map(|directory| directory.join(default_name))
+        .unwrap_or_else(|| conventional.clone());
+    let selected = command_cache.or(environment_cache).unwrap_or(default_cache);
+    if selected.as_os_str().is_empty() {
+        anyhow::bail!("{environment_name} must select a non-empty path");
+    }
+    Ok(Some(CacheReplacement {
+        conventional,
+        selected: if selected.is_absolute() {
+            selected
+        } else {
+            project_dir.join(selected)
+        },
+    }))
+}
+
+fn command_long_path_option(command: &[String], option: &str) -> anyhow::Result<Option<PathBuf>> {
+    let mut selected = None;
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    while let Some(argument) = arguments.next() {
+        let value = if argument == option {
+            Some(
+                arguments
+                    .next()
+                    .map(String::as_str)
+                    .with_context(|| format!("{option} requires a value"))?,
+            )
+        } else {
+            argument
+                .strip_prefix(option)
+                .and_then(|suffix| suffix.strip_prefix('='))
+        };
+        if let Some(value) = value {
+            if value.is_empty() || value.chars().any(char::is_control) {
+                anyhow::bail!("{option} must select a non-empty unambiguous path");
+            }
+            selected = Some(PathBuf::from(value));
+        }
+    }
+    Ok(selected)
+}
+
+fn command_uses_pip(command: &[String]) -> bool {
+    command_is(command, "pip")
+        || command_is(command, "pip3")
+        || ((command_is(command, "python") || command_is(command, "python3"))
+            && command
+                .windows(2)
+                .any(|arguments| arguments[0] == "-m" && arguments[1] == "pip"))
 }
 
 fn project_cache_is_approved(
@@ -4260,6 +4353,14 @@ mod tests {
                     "/tmp/custom-npmrc".to_owned(),
                 ),
                 ("NETRC".to_owned(), "/tmp/custom-netrc".to_owned()),
+                (
+                    "PIP_CONFIG_FILE".to_owned(),
+                    "/tmp/custom-pip.conf".to_owned(),
+                ),
+                (
+                    "UV_CONFIG_FILE".to_owned(),
+                    "/tmp/custom-uv.toml".to_owned(),
+                ),
                 ("KRB5CCNAME".to_owned(), "FILE:/tmp/krb5cc".to_owned()),
                 (
                     "KRB5_CLIENT_KTNAME".to_owned(),
@@ -4576,6 +4677,93 @@ mod tests {
                 .iter()
                 .any(|allowed| paths_overlap(&allowed.path, &output)),
             "an inferred output grant must not override an explicit execute denial"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test creates isolated Python home and project fixtures"
+    )]
+    fn standard_python_profile_uses_the_effective_cache() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+
+        let uv_environment_cache = root.path().join("uv-environment-cache");
+        let mut uv_environment = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        uv_environment.env.insert(
+            "UV_CACHE_DIR".to_owned(),
+            uv_environment_cache.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut uv_environment,
+            &["uv".to_owned(), "sync".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            uv_environment
+                .allow_write
+                .contains(&SandboxPath::dir(uv_environment_cache))
+        );
+        assert!(
+            !uv_environment
+                .allow_write
+                .contains(&SandboxPath::dir(home.join(".cache/uv")))
+        );
+
+        let mut uv_command = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        uv_command.env.insert(
+            "UV_CACHE_DIR".to_owned(),
+            root.path()
+                .join("ignored-uv-cache")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        apply_standard_profile(
+            &mut uv_command,
+            &[
+                "uv".to_owned(),
+                "sync".to_owned(),
+                "--cache-dir=relative-uv-cache".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            uv_command
+                .allow_write
+                .contains(&SandboxPath::dir(project.join("relative-uv-cache")))
+        );
+
+        let pip_cache = root.path().join("pip-environment-cache");
+        let mut pip = SandboxProfile::for_ecosystem(Ecosystem::Python, &home, &project);
+        pip.env.insert(
+            "PIP_CACHE_DIR".to_owned(),
+            pip_cache.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut pip,
+            &[
+                "python".to_owned(),
+                "-m".to_owned(),
+                "pip".to_owned(),
+                "install".to_owned(),
+                "build".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(pip.allow_write.contains(&SandboxPath::dir(pip_cache)));
+        assert!(
+            !pip.allow_write
+                .contains(&SandboxPath::dir(home.join(".cache/pip")))
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1067,11 +1067,21 @@ fn effective_npm_cache(
         } else {
             None
         };
+    let global_cache = if command_cache.is_none()
+        && environment_cache.is_none()
+        && project_cache.is_none()
+        && user_cache.is_none()
+    {
+        selected_global_npm_config_path(profile, command, home, project_dir, "cache")?
+    } else {
+        None
+    };
     let project_controlled = project_cache.is_some();
     let selected = command_cache
         .or(environment_cache)
         .or(project_cache)
         .or(user_cache)
+        .or(global_cache)
         .unwrap_or_else(|| home.join(".npm"));
     if selected.as_os_str().is_empty() {
         anyhow::bail!("NPM_CONFIG_CACHE must select a non-empty path");
@@ -1141,9 +1151,29 @@ fn effective_npm_global_config(
         profile
             .env
             .get("NPM_CONFIG_GLOBALCONFIG")
+            .or_else(|| profile.env.get("npm_config_globalconfig"))
             .map(PathBuf::from)
     });
     Ok(selected.map(|path| anchor_project_path(path, project_dir)))
+}
+
+fn selected_global_npm_config_path(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+    key: &str,
+) -> anyhow::Result<Option<PathBuf>> {
+    let Some(path) = effective_npm_global_config(profile, command, project_dir)? else {
+        return Ok(None);
+    };
+    let Some(contents) = read_bounded_following_metadata_file(&path)? else {
+        anyhow::bail!(
+            "could not inspect explicit npm global configuration: {}",
+            path.display()
+        );
+    };
+    npm_config_path_value(&contents, &path, home, key, "global npmrc")
 }
 
 fn user_npm_config_path(
@@ -1288,6 +1318,15 @@ fn effective_pnpm_store(
         } else {
             None
         };
+    let global_store = if command_store.is_none()
+        && environment_store.is_none()
+        && project_store.is_none()
+        && user_store.is_none()
+    {
+        selected_global_npm_config_path(profile, command, home, project_dir, "store-dir")?
+    } else {
+        None
+    };
     let project_controlled = project_store.is_some();
     let default_store = effective_environment_path(profile, "PNPM_HOME")
         .map(|directory| directory.join("store"))
@@ -1300,6 +1339,7 @@ fn effective_pnpm_store(
         .or(environment_store)
         .or(project_store)
         .or(user_store)
+        .or(global_store)
         .unwrap_or(default_store);
     if selected.as_os_str().is_empty() {
         anyhow::bail!("pnpm store directory must be a non-empty path");
@@ -7747,12 +7787,21 @@ mod tests {
                 .contains(&SandboxPath::file(command_userconfig))
         );
 
+        std::fs::write(home.join(".npmrc"), "# no user cache\n").unwrap();
         let global_config = root.path().join("global-npmrc");
-        std::fs::write(&global_config, "registry=https://registry.npmjs.org/\n").unwrap();
+        let global_config_cache = root.path().join("global-config-cache");
+        std::fs::write(
+            &global_config,
+            format!(
+                "registry=https://registry.npmjs.org/\ncache={}\n",
+                global_config_cache.display()
+            ),
+        )
+        .unwrap();
         let mut global_config_selected =
             SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
         global_config_selected.env.insert(
-            "NPM_CONFIG_GLOBALCONFIG".to_owned(),
+            "npm_config_globalconfig".to_owned(),
             global_config.to_string_lossy().into_owned(),
         );
         apply_standard_profile(
@@ -7766,6 +7815,11 @@ mod tests {
             global_config_selected
                 .allow_read
                 .contains(&SandboxPath::file(global_config))
+        );
+        assert!(
+            global_config_selected
+                .allow_write
+                .contains(&SandboxPath::dir(global_config_cache))
         );
 
         let pnpm_home = root.path().join("custom-pnpm-home");

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -30,6 +30,8 @@ use crate::cli::RunArgs;
 /// sbe exit codes for its own errors (matching docker run / env conventions).
 const EXIT_SBE_ERROR: u8 = 125;
 const EXIT_SANDBOX_FAILED: u8 = 126;
+const MAX_SOURCE_SYMLINK_SCAN_ENTRIES: usize = 100_000;
+const MAX_SOURCE_SYMLINK_SCAN_DEPTH: usize = 128;
 
 const SAFE_PARENT_ENV: &[&str] = &[
     "PATH",
@@ -609,6 +611,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "SECRET",
         "SSH_AGENT_PID",
         "SSH_AUTH_SOCK",
+        "SYSTEM_ACCESSTOKEN",
         "TOKEN",
     ];
     const RESERVED: &[&str] = &[
@@ -899,7 +902,8 @@ fn resolve_standard_path_aliases(
 ) -> anyhow::Result<()> {
     snapshot_standard_write_aliases(profile, home, project_dir)?;
     snapshot_standard_exec_aliases(profile);
-    let read_aliases = workspace_read_aliases(profile, project_dir);
+    snapshot_standard_read_aliases(profile);
+    let read_aliases = workspace_read_aliases(profile, project_dir)?;
     for alias in read_aliases {
         if !profile.allow_read.contains(&alias) {
             profile.grant_origins.push(GrantRecord {
@@ -931,6 +935,36 @@ fn snapshot_standard_exec_aliases(profile: &mut SandboxProfile) {
             }
             records.push(GrantRecord {
                 kind: GrantKind::AllowExec,
+                value: resolved.to_string_lossy().into_owned(),
+                origin: GrantOrigin::Runtime,
+            });
+            SandboxPath {
+                path: resolved,
+                kind: grant.kind,
+            }
+        })
+        .collect();
+    profile.grant_origins.extend(records);
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode snapshots readable symlink referents before launching untrusted code"
+)]
+fn snapshot_standard_read_aliases(profile: &mut SandboxProfile) {
+    let mut records = Vec::new();
+    profile.allow_read = profile
+        .allow_read
+        .drain(..)
+        .map(|grant| {
+            let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+                return grant;
+            };
+            if resolved == grant.path {
+                return grant;
+            }
+            records.push(GrantRecord {
+                kind: GrantKind::AllowRead,
                 value: resolved.to_string_lossy().into_owned(),
                 origin: GrantOrigin::Runtime,
             });
@@ -1087,11 +1121,28 @@ fn grant_covers(grant: &SandboxPath, target: &Path) -> bool {
     }
 }
 
+fn workspace_read_aliases(
+    profile: &SandboxProfile,
+    project_dir: &Path,
+) -> anyhow::Result<Vec<SandboxPath>> {
+    workspace_read_aliases_with_limits(
+        profile,
+        project_dir,
+        MAX_SOURCE_SYMLINK_SCAN_ENTRIES,
+        MAX_SOURCE_SYMLINK_SCAN_DEPTH,
+    )
+}
+
 #[allow(
     clippy::disallowed_methods,
     reason = "standard mode snapshots source symlink referents before launching untrusted code"
 )]
-fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<SandboxPath> {
+fn workspace_read_aliases_with_limits(
+    profile: &SandboxProfile,
+    project_dir: &Path,
+    max_entries: usize,
+    max_depth: usize,
+) -> anyhow::Result<Vec<SandboxPath>> {
     const DERIVED_DIRECTORIES: &[&str] = &[
         ".git",
         ".gradle",
@@ -1109,10 +1160,17 @@ fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<S
 
     let project_referent =
         std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
-    let mut pending = vec![project_dir.to_path_buf()];
+    let mut pending = vec![(project_dir.to_path_buf(), 0_usize)];
     let mut visited_directories = BTreeSet::new();
     let mut resolved_paths = BTreeSet::new();
-    while let Some(directory) = pending.pop() {
+    let mut inspected_entries = 0_usize;
+    while let Some((directory, depth)) = pending.pop() {
+        if depth > max_depth {
+            anyhow::bail!(
+                "source symlink discovery exceeds the maximum depth of {max_depth} below '{}'",
+                project_dir.display()
+            );
+        }
         let directory = match std::fs::canonicalize(&directory) {
             Ok(directory) => directory,
             Err(error) => {
@@ -1131,6 +1189,14 @@ fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<S
             }
         };
         for entry in entries {
+            inspected_entries = inspected_entries.saturating_add(1);
+            if inspected_entries > max_entries {
+                anyhow::bail!(
+                    "source symlink discovery exceeds the {max_entries}-entry scan budget below \
+                     '{}'",
+                    project_dir.display()
+                );
+            }
             let entry = match entry {
                 Ok(entry) => entry,
                 Err(error) => {
@@ -1166,15 +1232,15 @@ fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<S
                 if resolved_paths.insert(resolved.clone())
                     && std::fs::metadata(&resolved).is_ok_and(|metadata| metadata.is_dir())
                 {
-                    pending.push(resolved);
+                    pending.push((resolved, depth + 1));
                 }
             } else if file_type.is_dir() {
-                pending.push(path);
+                pending.push((path, depth + 1));
             }
         }
     }
 
-    resolved_paths
+    Ok(resolved_paths
         .into_iter()
         .filter_map(|path| {
             let metadata = std::fs::metadata(&path).ok()?;
@@ -1184,7 +1250,7 @@ fn workspace_read_aliases(profile: &SandboxProfile, project_dir: &Path) -> Vec<S
                 SandboxPath::file(path)
             })
         })
-        .collect()
+        .collect())
 }
 
 #[allow(
@@ -2506,6 +2572,7 @@ mod tests {
                 ("GITHUB_TOKEN".to_owned(), "sentinel".to_owned()),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
                 ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
+                ("SYSTEM_ACCESSTOKEN".to_owned(), "sentinel".to_owned()),
                 ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
                 ("OPENAI_API_KEY".to_owned(), "sentinel".to_owned()),
                 ("TOKEN".to_owned(), "sentinel".to_owned()),
@@ -2910,6 +2977,30 @@ mod tests {
                 .any(|grant| { grant.path == std::fs::canonicalize(&protected).unwrap() }),
             "protected referents must not receive an inferred read grant"
         );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test builds an isolated bounded source traversal fixture"
+    )]
+    fn standard_source_symlink_discovery_is_bounded() {
+        let root = tempfile::tempdir().unwrap();
+        let project = root.path().join("project");
+        let source = project.join("src");
+        let external = root.path().join("external");
+        std::fs::create_dir_all(&source).unwrap();
+        std::fs::create_dir_all(&external).unwrap();
+        std::os::unix::fs::symlink(&external, source.join("external")).unwrap();
+        let profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, root.path(), &project);
+
+        let entry_error =
+            workspace_read_aliases_with_limits(&profile, &project, 1, 128).unwrap_err();
+        assert!(entry_error.to_string().contains("entry scan budget"));
+
+        let depth_error =
+            workspace_read_aliases_with_limits(&profile, &project, 100, 1).unwrap_err();
+        assert!(depth_error.to_string().contains("maximum depth"));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -897,38 +897,9 @@ fn resolve_standard_path_aliases(
     home: &Path,
     project_dir: &Path,
 ) -> anyhow::Result<()> {
-    validate_standard_write_aliases(profile, home, project_dir)?;
-    let write_aliases = resolved_aliases(
-        &profile.allow_write,
-        profile.first_user_allow_write,
-        project_dir,
-    );
-    let exec_aliases = resolved_aliases(
-        &profile.allow_exec,
-        profile.first_user_allow_exec,
-        project_dir,
-    );
+    snapshot_standard_write_aliases(profile, home, project_dir)?;
+    snapshot_standard_exec_aliases(profile);
     let read_aliases = workspace_read_aliases(profile, project_dir);
-    for alias in write_aliases {
-        if !profile.allow_write.contains(&alias) {
-            profile.grant_origins.push(GrantRecord {
-                kind: GrantKind::AllowWrite,
-                value: alias.path.to_string_lossy().into_owned(),
-                origin: GrantOrigin::Runtime,
-            });
-            profile.allow_write.push(alias);
-        }
-    }
-    for alias in exec_aliases {
-        if !profile.allow_exec.contains(&alias) {
-            profile.grant_origins.push(GrantRecord {
-                kind: GrantKind::AllowExec,
-                value: alias.path.to_string_lossy().into_owned(),
-                origin: GrantOrigin::Runtime,
-            });
-            profile.allow_exec.push(alias);
-        }
-    }
     for alias in read_aliases {
         if !profile.allow_read.contains(&alias) {
             profile.grant_origins.push(GrantRecord {
@@ -944,11 +915,41 @@ fn resolve_standard_path_aliases(
 
 #[allow(
     clippy::disallowed_methods,
+    reason = "standard mode snapshots executable symlink referents before launching untrusted code"
+)]
+fn snapshot_standard_exec_aliases(profile: &mut SandboxProfile) {
+    let mut records = Vec::new();
+    profile.allow_exec = profile
+        .allow_exec
+        .drain(..)
+        .map(|grant| {
+            let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+                return grant;
+            };
+            if resolved == grant.path {
+                return grant;
+            }
+            records.push(GrantRecord {
+                kind: GrantKind::AllowExec,
+                value: resolved.to_string_lossy().into_owned(),
+                origin: GrantOrigin::Runtime,
+            });
+            SandboxPath {
+                path: resolved,
+                kind: grant.kind,
+            }
+        })
+        .collect();
+    profile.grant_origins.extend(records);
+}
+
+#[allow(
+    clippy::disallowed_methods,
     reason = "standard mode validates built-in write symlinks against the approved authority \
               envelope"
 )]
-fn validate_standard_write_aliases(
-    profile: &SandboxProfile,
+fn snapshot_standard_write_aliases(
+    profile: &mut SandboxProfile,
     home: &Path,
     project_dir: &Path,
 ) -> anyhow::Result<()> {
@@ -962,7 +963,8 @@ fn validate_standard_write_aliases(
         home_referent.join(".cache"),
         home_referent.join("Library/Caches"),
     ];
-    let built_in_envelopes: Vec<SandboxPath> = profile.allow_write[..built_in_boundary]
+    let original = profile.allow_write.clone();
+    let built_in_envelopes: Vec<SandboxPath> = original[..built_in_boundary]
         .iter()
         .map(|grant| SandboxPath {
             path: remap_to_referent(
@@ -975,9 +977,16 @@ fn validate_standard_write_aliases(
             kind: grant.kind,
         })
         .collect();
+    let explicit_envelopes: Vec<SandboxPath> = original[built_in_boundary..]
+        .iter()
+        .filter_map(resolve_explicit_grant)
+        .collect();
+    let mut snapped = Vec::with_capacity(original.len());
+    let mut records = Vec::new();
 
-    for grant in &profile.allow_write[..built_in_boundary] {
+    for (index, grant) in original.into_iter().enumerate() {
         let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+            snapped.push(grant);
             continue;
         };
         let expected = remap_to_referent(
@@ -987,7 +996,7 @@ fn validate_standard_write_aliases(
             project_dir,
             &project_referent,
         );
-        if resolved == expected
+        let approved = resolved == expected
             || resolved.starts_with(&project_referent)
             || cache_envelopes
                 .iter()
@@ -995,13 +1004,31 @@ fn validate_standard_write_aliases(
             || built_in_envelopes
                 .iter()
                 .any(|envelope| grant_covers(envelope, &resolved))
-            || explicit_write_covers(profile, &resolved)
-        {
-            continue;
+            || explicit_envelopes
+                .iter()
+                .any(|explicit| grant_covers(explicit, &resolved));
+        if index < built_in_boundary && !approved {
+            return Err(external_write_approval_error(&grant.path, &resolved));
         }
 
-        return Err(external_write_approval_error(&grant.path, &resolved));
+        if resolved != grant.path {
+            records.push(GrantRecord {
+                kind: GrantKind::AllowWrite,
+                value: resolved.to_string_lossy().into_owned(),
+                origin: GrantOrigin::Runtime,
+            });
+            snapped.push(SandboxPath {
+                path: resolved,
+                kind: grant.kind,
+            });
+        } else {
+            snapped.push(grant);
+        }
     }
+    // The launcher opens only these canonical snapshots, never the mutable
+    // lexical symlink that was validated above.
+    profile.allow_write = snapped;
+    profile.grant_origins.extend(records);
     Ok(())
 }
 
@@ -1193,37 +1220,6 @@ fn resolve_existing_ancestor(path: &Path) -> Option<PathBuf> {
             Err(_) => return None,
         }
     }
-}
-
-#[allow(
-    clippy::disallowed_methods,
-    reason = "standard mode snapshots pre-existing user tool and cache symlinks before launch"
-)]
-fn resolved_aliases(
-    paths: &[SandboxPath],
-    built_in_boundary: usize,
-    project_dir: &Path,
-) -> Vec<SandboxPath> {
-    paths
-        .iter()
-        .enumerate()
-        .filter_map(|(index, grant)| {
-            let resolved = std::fs::canonicalize(&grant.path).ok()?;
-            if resolved == grant.path {
-                return None;
-            }
-            let built_in_project_path = index < built_in_boundary
-                && grant.path.starts_with(project_dir)
-                && !resolved.starts_with(project_dir);
-            if built_in_project_path {
-                return None;
-            }
-            Some(SandboxPath {
-                path: resolved,
-                kind: grant.kind,
-            })
-        })
-        .collect()
 }
 
 fn command_is(command: &[String], expected: &str) -> bool {
@@ -2771,16 +2767,12 @@ mod tests {
         resolve_standard_path_aliases(&mut approved, Path::new("/Users/test"), project.path())
             .unwrap();
 
-        assert!(
-            approved
-                .allow_write
-                .contains(&SandboxPath::dir(project.path().to_path_buf()))
-        );
-        assert!(
-            approved
-                .allow_write
-                .contains(&SandboxPath::dir(external.path().to_path_buf()))
-        );
+        assert!(approved.allow_write.contains(&SandboxPath::dir(
+            std::fs::canonicalize(project.path()).unwrap()
+        )));
+        assert!(approved.allow_write.contains(&SandboxPath::dir(
+            std::fs::canonicalize(external.path()).unwrap()
+        )));
         assert!(approved.allow_exec.contains(&SandboxPath::dir(
             std::fs::canonicalize(external.path()).unwrap()
         )));
@@ -2828,11 +2820,9 @@ mod tests {
         )
         .unwrap();
         resolve_standard_path_aliases(&mut approved, &home, &project).unwrap();
-        assert!(
-            approved
-                .allow_write
-                .contains(&SandboxPath::dir(persistence))
-        );
+        assert!(approved.allow_write.contains(&SandboxPath::dir(
+            std::fs::canonicalize(persistence).unwrap()
+        )));
     }
 
     #[test]
@@ -2863,6 +2853,13 @@ mod tests {
             profile
                 .allow_write
                 .contains(&SandboxPath::dir(std::fs::canonicalize(cache).unwrap()))
+        );
+        assert!(
+            !profile
+                .allow_write
+                .iter()
+                .any(|grant| grant.path == home.join(".npm")),
+            "the launcher must not reopen the mutable lexical symlink"
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -1423,6 +1423,8 @@ fn project_relocation_option(command: &[String]) -> Option<&str> {
         "pnpm" => &["--dir", "-C"],
         "uv" => &["--directory", "--project"],
         "poetry" | "pdm" => &["--directory", "--project", "-C", "-P", "-p"],
+        "gradle" | "gradlew" => &["--project-dir", "-p"],
+        "mvn" | "mvnw" => &["--file", "-f"],
         _ => return None,
     };
     command
@@ -3703,6 +3705,10 @@ mod tests {
             vec!["uv", "--project", "subproject", "sync"],
             vec!["poetry", "-P", "subproject", "install"],
             vec!["cargo", "-Csubproject", "build"],
+            vec!["./gradlew", "--project-dir", "subproject", "build"],
+            vec!["gradle", "-psubproject", "build"],
+            vec!["./mvnw", "--file=subproject/pom.xml", "package"],
+            vec!["mvn", "-fsubproject/pom.xml", "package"],
         ] {
             let command: Vec<String> = command.into_iter().map(str::to_owned).collect();
             assert!(

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use sbe_core::{
     BackendOptions, Sandbox, SandboxBackend, SecurityMode,
-    config::{SandboxPath, expand_path, load_configs, resolve_profile},
+    config::{PathKind, SandboxPath, expand_path, load_configs, resolve_profile},
     detect::{self, Ecosystem},
     error::CoreError,
     profile::{
@@ -99,7 +99,7 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         enable_existing_dependency_execution(&mut profile, &args.command);
     } else {
         apply_standard_profile(&mut profile, &args.command, &home, &pwd);
-        resolve_standard_path_aliases(&mut profile, &pwd);
+        resolve_standard_path_aliases(&mut profile, &home, &pwd)?;
     }
 
     if args.strict && !args.dry_run {
@@ -626,6 +626,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
     EXACT.contains(&upper.as_str())
         || RESERVED.contains(&upper.as_str())
         || upper.starts_with("DYLD_")
+        || upper.starts_with("TF_TOKEN_")
         || upper == "LD_PRELOAD"
         || upper == "LD_LIBRARY_PATH"
         || [
@@ -858,7 +859,12 @@ fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, gran
     clippy::disallowed_methods,
     reason = "standard mode snapshots pre-existing user tool and cache symlinks before launch"
 )]
-fn resolve_standard_path_aliases(profile: &mut SandboxProfile, project_dir: &Path) {
+fn resolve_standard_path_aliases(
+    profile: &mut SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<()> {
+    validate_standard_write_aliases(profile, home, project_dir)?;
     let write_aliases = resolved_aliases(
         &profile.allow_write,
         profile.first_user_allow_write,
@@ -899,6 +905,110 @@ fn resolve_standard_path_aliases(profile: &mut SandboxProfile, project_dir: &Pat
             });
             profile.allow_read.push(alias);
         }
+    }
+    Ok(())
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode validates built-in write symlinks against the approved authority \
+              envelope"
+)]
+fn validate_standard_write_aliases(
+    profile: &SandboxProfile,
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<()> {
+    let built_in_boundary = profile
+        .first_user_allow_write
+        .min(profile.allow_write.len());
+    let home_referent = std::fs::canonicalize(home).unwrap_or_else(|_| home.to_path_buf());
+    let project_referent =
+        std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
+    let cache_envelopes = [
+        home_referent.join(".cache"),
+        home_referent.join("Library/Caches"),
+    ];
+    let built_in_envelopes: Vec<SandboxPath> = profile.allow_write[..built_in_boundary]
+        .iter()
+        .map(|grant| SandboxPath {
+            path: remap_to_referent(
+                &grant.path,
+                home,
+                &home_referent,
+                project_dir,
+                &project_referent,
+            ),
+            kind: grant.kind,
+        })
+        .collect();
+
+    for grant in &profile.allow_write[..built_in_boundary] {
+        let Ok(resolved) = std::fs::canonicalize(&grant.path) else {
+            continue;
+        };
+        let expected = remap_to_referent(
+            &grant.path,
+            home,
+            &home_referent,
+            project_dir,
+            &project_referent,
+        );
+        if resolved == expected
+            || resolved.starts_with(&project_referent)
+            || cache_envelopes
+                .iter()
+                .any(|envelope| resolved.starts_with(envelope))
+            || built_in_envelopes
+                .iter()
+                .any(|envelope| grant_covers(envelope, &resolved))
+            || profile.allow_write[built_in_boundary..]
+                .iter()
+                .filter_map(resolve_explicit_grant)
+                .any(|explicit| grant_covers(&explicit, &resolved))
+        {
+            continue;
+        }
+
+        anyhow::bail!(
+            "built-in writable path '{}' resolves outside the standard writable envelope to '{}'; \
+             approve that target explicitly with --allow-write '{}'",
+            grant.path.display(),
+            resolved.display(),
+            resolved.display()
+        );
+    }
+    Ok(())
+}
+
+fn remap_to_referent(
+    path: &Path,
+    home: &Path,
+    home_referent: &Path,
+    project_dir: &Path,
+    project_referent: &Path,
+) -> PathBuf {
+    if let Ok(relative) = path.strip_prefix(project_dir) {
+        project_referent.join(relative)
+    } else if let Ok(relative) = path.strip_prefix(home) {
+        home_referent.join(relative)
+    } else {
+        path.to_path_buf()
+    }
+}
+
+fn resolve_explicit_grant(grant: &SandboxPath) -> Option<SandboxPath> {
+    Some(SandboxPath {
+        path: resolve_existing_ancestor(&grant.path)?,
+        kind: grant.kind,
+    })
+}
+
+fn grant_covers(grant: &SandboxPath, target: &Path) -> bool {
+    match grant.kind {
+        PathKind::Subpath => target.starts_with(&grant.path),
+        PathKind::Literal => target == grant.path,
+        PathKind::Regex => false,
     }
 }
 
@@ -2375,6 +2485,10 @@ mod tests {
                     "sentinel".to_owned(),
                 ),
                 (
+                    "TF_TOKEN_APP_TERRAFORM_IO".to_owned(),
+                    "sentinel".to_owned(),
+                ),
+                (
                     "GOOGLE_APPLICATION_CREDENTIALS".to_owned(),
                     "/tmp/google-credentials.json".to_owned(),
                 ),
@@ -2578,7 +2692,8 @@ mod tests {
             Path::new("/Users/test"),
             project.path(),
         );
-        resolve_standard_path_aliases(&mut profile, project.path());
+        resolve_standard_path_aliases(&mut profile, Path::new("/Users/test"), project.path())
+            .unwrap();
 
         assert!(
             profile
@@ -2597,6 +2712,83 @@ mod tests {
                 .iter()
                 .any(|grant| grant.path == external.path()),
             "generated output symlinks are not inferred as source read grants"
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test builds and resolves isolated cache symlink fixtures"
+    )]
+    fn standard_profile_requires_approval_for_cache_symlinks_outside_the_envelope() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let persistence = home.join(".config/autostart");
+        std::fs::create_dir_all(&persistence).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::os::unix::fs::symlink(&persistence, home.join(".npm")).unwrap();
+
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        apply_standard_profile(
+            &mut profile,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        );
+        let error = resolve_standard_path_aliases(&mut profile, &home, &project).unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+        assert!(
+            error
+                .to_string()
+                .contains(&persistence.display().to_string())
+        );
+
+        let mut approved = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        approved
+            .allow_write
+            .push(SandboxPath::dir(persistence.clone()));
+        apply_standard_profile(
+            &mut approved,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        );
+        resolve_standard_path_aliases(&mut approved, &home, &project).unwrap();
+        assert!(
+            approved
+                .allow_write
+                .contains(&SandboxPath::dir(persistence))
+        );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test builds and resolves an isolated cache symlink fixture"
+    )]
+    fn standard_profile_follows_cache_symlinks_within_the_cache_envelope() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let cache = home.join(".cache/npm");
+        std::fs::create_dir_all(&cache).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::os::unix::fs::symlink(&cache, home.join(".npm")).unwrap();
+
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        apply_standard_profile(
+            &mut profile,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        );
+        resolve_standard_path_aliases(&mut profile, &home, &project).unwrap();
+
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(std::fs::canonicalize(cache).unwrap()))
         );
     }
 
@@ -2627,7 +2819,7 @@ mod tests {
             root.path(),
             &project,
         );
-        resolve_standard_path_aliases(&mut profile, &project);
+        resolve_standard_path_aliases(&mut profile, root.path(), &project).unwrap();
 
         assert!(
             profile

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -757,7 +757,14 @@ fn apply_standard_profile(
         insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(resolved));
     }
 
+    if let Some(npm_cache) = effective_npm_cache(profile, command, home, project_dir)? {
+        replace_builtin_write_path(profile, &home.join(".npm"), SandboxPath::dir(npm_cache));
+    }
+
     if profile.name == "java" {
+        for settings in effective_maven_settings_read_paths(profile, command, home, project_dir)? {
+            insert_builtin_path_grant(profile, GrantKind::AllowRead, settings);
+        }
         if let Some(repository) =
             effective_maven_local_repository(profile, command, home, project_dir)?
         {
@@ -797,6 +804,11 @@ fn apply_standard_profile(
 
         if let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir)?
         {
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowRead,
+                SandboxPath::dir(gradle_home.clone()),
+            );
             // Keep init.d and root-level initialization scripts immutable.
             // Standard mode accepts cache poisoning, but should not provide a
             // direct unsandboxed-startup persistence mechanism.
@@ -912,6 +924,51 @@ fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<Pa
         .or_else(|| std::env::var_os(name).map(PathBuf::from))
 }
 
+fn effective_npm_cache(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    if profile.name != "node" || (!command_is(command, "npm") && !command_is(command, "npx")) {
+        return Ok(None);
+    }
+    let mut command_cache = None;
+    let mut arguments = command
+        .iter()
+        .skip(1)
+        .take_while(|argument| argument.as_str() != "--");
+    while let Some(argument) = arguments.next() {
+        let value = if argument == "--cache" {
+            Some(
+                arguments
+                    .next()
+                    .map(String::as_str)
+                    .context("npm --cache requires a value")?,
+            )
+        } else {
+            argument.strip_prefix("--cache=")
+        };
+        if let Some(value) = value {
+            if value.is_empty() || value.chars().any(char::is_control) {
+                anyhow::bail!("npm --cache must select a non-empty unambiguous path");
+            }
+            command_cache = Some(PathBuf::from(value));
+        }
+    }
+    let selected = command_cache
+        .or_else(|| effective_environment_path(profile, "NPM_CONFIG_CACHE"))
+        .unwrap_or_else(|| home.join(".npm"));
+    if selected.as_os_str().is_empty() {
+        anyhow::bail!("NPM_CONFIG_CACHE must select a non-empty path");
+    }
+    Ok(Some(if selected.is_absolute() {
+        selected
+    } else {
+        project_dir.join(selected)
+    }))
+}
+
 fn effective_cargo_home(profile: &SandboxProfile, home: &Path, project_dir: &Path) -> PathBuf {
     let cargo_home =
         effective_environment_path(profile, "CARGO_HOME").unwrap_or_else(|| home.join(".cargo"));
@@ -1009,6 +1066,32 @@ struct MavenSettingsSelection {
 struct MavenSettingsRepository {
     path: PathBuf,
     user_home_dependent: bool,
+}
+
+fn effective_maven_settings_read_paths(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> anyhow::Result<Vec<SandboxPath>> {
+    if !command_is(command, "mvn") && !command_is(command, "mvnw") {
+        return Ok(Vec::new());
+    }
+    let (user_home, _) = effective_maven_user_home(profile, home, project_dir)?;
+    let mut paths = Vec::new();
+    if user_home != home {
+        paths.push(SandboxPath::dir(user_home.join(".m2")));
+    }
+    for settings in [
+        selected_maven_settings(profile, command, project_dir, "--global-settings", "-gs")?,
+        selected_maven_settings(profile, command, project_dir, "--settings", "-s")?,
+    ]
+    .into_iter()
+    .flatten()
+    {
+        paths.push(SandboxPath::file(settings.path));
+    }
+    Ok(paths)
 }
 
 fn effective_maven_local_repository(
@@ -4267,6 +4350,11 @@ mod tests {
             assert!(inherited.allow_exec.contains(&SandboxPath::dir(path)));
         }
         assert!(
+            inherited
+                .allow_read
+                .contains(&SandboxPath::dir(inherited_home.clone()))
+        );
+        assert!(
             !inherited
                 .allow_write
                 .contains(&SandboxPath::dir(inherited_home.clone()))
@@ -4320,6 +4408,7 @@ mod tests {
             assert!(cli.allow_write.contains(&SandboxPath::dir(path.clone())));
             assert!(cli.allow_exec.contains(&SandboxPath::dir(path)));
         }
+        assert!(cli.allow_read.contains(&SandboxPath::dir(cli_home.clone())));
         assert!(!cli.allow_write.contains(&SandboxPath::dir(cli_home)));
 
         let attached_home = root.path().join("attached-gradle");
@@ -4351,6 +4440,11 @@ mod tests {
             );
             assert!(attached.allow_exec.contains(&SandboxPath::dir(path)));
         }
+        assert!(
+            attached
+                .allow_read
+                .contains(&SandboxPath::dir(attached_home))
+        );
 
         let property_home = root.path().join("property-gradle");
         let mut property = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
@@ -4988,7 +5082,8 @@ mod tests {
         );
 
         let explicit_repository = tempfile::tempdir().unwrap();
-        let explicit_settings = project.path().join("explicit-settings.xml");
+        let explicit_settings_root = tempfile::tempdir().unwrap();
+        let explicit_settings = explicit_settings_root.path().join("settings.xml");
         std::fs::write(
             &explicit_settings,
             format!(
@@ -5016,10 +5111,16 @@ mod tests {
                 .allow_write
                 .contains(&SandboxPath::dir(explicit_repository.path().to_path_buf()))
         );
+        assert!(
+            explicit
+                .allow_read
+                .contains(&SandboxPath::file(explicit_settings.clone()))
+        );
 
         std::fs::write(home.path().join(".m2/settings.xml"), "<settings/>").unwrap();
         let global_repository = tempfile::tempdir().unwrap();
-        let global_settings = project.path().join("global-settings.xml");
+        let global_settings_root = tempfile::tempdir().unwrap();
+        let global_settings = global_settings_root.path().join("settings.xml");
         std::fs::write(
             &global_settings,
             format!(
@@ -5046,6 +5147,11 @@ mod tests {
             explicit_global
                 .allow_write
                 .contains(&SandboxPath::dir(global_repository.path().to_path_buf()))
+        );
+        assert!(
+            explicit_global
+                .allow_read
+                .contains(&SandboxPath::file(global_settings.clone()))
         );
 
         std::fs::write(
@@ -5132,6 +5238,11 @@ mod tests {
         assert!(alternate_user_home.allow_write.contains(&SandboxPath::dir(
             alternate_home_repository.path().to_path_buf()
         )));
+        assert!(
+            alternate_user_home
+                .allow_read
+                .contains(&SandboxPath::dir(alternate_home.path().join(".m2")))
+        );
 
         let alternate_default_home = tempfile::tempdir().unwrap();
         let mut alternate_default =
@@ -6229,6 +6340,74 @@ mod tests {
             .is_err()
         );
         assert!(!relocated_project.path().join("package-lock.json").exists());
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test creates isolated npm home and project fixtures"
+    )]
+    fn standard_npm_profile_uses_the_effective_cache() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let environment_cache = root.path().join("environment-cache");
+        let command_cache = root.path().join("command-cache");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+
+        let mut command_selected = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        command_selected.env.insert(
+            "NPM_CONFIG_CACHE".to_owned(),
+            environment_cache.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut command_selected,
+            &[
+                "npm".to_owned(),
+                "install".to_owned(),
+                format!("--cache={}", command_cache.display()),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            command_selected
+                .allow_write
+                .contains(&SandboxPath::dir(command_cache.clone()))
+        );
+        assert!(
+            !command_selected
+                .allow_write
+                .contains(&SandboxPath::dir(environment_cache.clone())),
+            "the npm command option must override NPM_CONFIG_CACHE"
+        );
+        assert!(
+            !command_selected
+                .allow_write
+                .contains(&SandboxPath::dir(home.join(".npm"))),
+            "the effective npm cache must replace the default grant"
+        );
+
+        let mut environment_selected =
+            SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &project);
+        environment_selected.env.insert(
+            "NPM_CONFIG_CACHE".to_owned(),
+            "relative-npm-cache".to_owned(),
+        );
+        apply_standard_profile(
+            &mut environment_selected,
+            &["npm".to_owned(), "install".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            environment_selected
+                .allow_write
+                .contains(&SandboxPath::dir(project.join("relative-npm-cache")))
+        );
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -613,6 +613,7 @@ fn apply_standard_profile(
     home: &Path,
     project_dir: &Path,
 ) {
+    remove_builtin_workspace_read_denials(profile, project_dir);
     let project_outputs = replace_builtin_project_writes(profile, project_dir);
 
     insert_builtin_path_grant(
@@ -663,6 +664,40 @@ fn apply_standard_profile(
             SandboxPath::dir(cargo_root.join("bin")),
         );
     }
+}
+
+fn remove_builtin_workspace_read_denials(profile: &mut SandboxProfile, project_dir: &Path) {
+    let removed: Vec<PathBuf> = profile
+        .deny_read
+        .iter()
+        .filter(|grant| grant.path.parent() == Some(project_dir))
+        .filter(|grant| {
+            grant.path.file_name().is_some_and(|name| {
+                matches!(
+                    name.to_str(),
+                    Some(".env" | ".env.local" | ".env.production")
+                )
+            })
+        })
+        .filter(|grant| {
+            !profile.grant_origins.iter().any(|record| {
+                record.kind == GrantKind::DenyRead
+                    && record.origin != GrantOrigin::BuiltIn
+                    && record.value == grant.path.to_string_lossy()
+            })
+        })
+        .map(|grant| grant.path.clone())
+        .collect();
+    profile
+        .deny_read
+        .retain(|grant| !removed.contains(&grant.path));
+    profile.grant_origins.retain(|record| {
+        record.kind != GrantKind::DenyRead
+            || record.origin != GrantOrigin::BuiltIn
+            || !removed
+                .iter()
+                .any(|path| record.value == path.to_string_lossy())
+    });
 }
 
 fn replace_builtin_project_writes(
@@ -2236,6 +2271,10 @@ mod tests {
                 .allow_exec
                 .contains(&SandboxPath::dir(project.path().join("target")))
         );
+        assert!(!profile.deny_read.iter().any(|grant| {
+            grant.path.parent() == Some(project.path())
+                && grant.path.file_name().is_some_and(|name| name == ".env")
+        }));
         assert!(
             profile.validate_structural_security_invariants().is_err(),
             "standard mode deliberately permits mutable executable build output"
@@ -2289,6 +2328,31 @@ mod tests {
         assert!(!profile.allow_exec.iter().any(|grant| {
             grant.path == project.path().join("target") || grant.path == external.path()
         }));
+    }
+
+    #[test]
+    fn standard_profile_preserves_explicit_workspace_read_denials() {
+        let project = tempfile::tempdir().unwrap();
+        let denied = project.path().join(".env");
+        let mut profile = SandboxProfile::for_ecosystem(
+            Ecosystem::Rust,
+            Path::new("/Users/test"),
+            project.path(),
+        );
+        profile.grant_origins.push(GrantRecord {
+            kind: GrantKind::DenyRead,
+            value: denied.to_string_lossy().into_owned(),
+            origin: GrantOrigin::Project(project.path().join(".sbe.yaml")),
+        });
+
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "build".to_owned()],
+            Path::new("/Users/test"),
+            project.path(),
+        );
+
+        assert!(profile.deny_read.contains(&SandboxPath::file(denied)));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -728,6 +728,18 @@ fn apply_standard_profile(
             GrantKind::AllowWrite,
             SandboxPath::dir(home.join("Library/Caches/Coursier")),
         );
+
+        if let Some(gradle_home) = effective_gradle_user_home(profile, command, home, project_dir) {
+            // Wrapper distributions, dependency caches, and daemon state all
+            // live here. Gradle also executes wrapper/worker code from this
+            // tree, so standard mode needs both halves of its mutable output.
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowWrite,
+                SandboxPath::dir(gradle_home.clone()),
+            );
+            insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(gradle_home));
+        }
     }
 
     for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
@@ -777,6 +789,28 @@ fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<Pa
         .get(name)
         .map(PathBuf::from)
         .or_else(|| std::env::var_os(name).map(PathBuf::from))
+}
+
+fn effective_gradle_user_home(
+    profile: &SandboxProfile,
+    command: &[String],
+    home: &Path,
+    project_dir: &Path,
+) -> Option<PathBuf> {
+    if !command_is(command, "gradle") && !command_is(command, "gradlew") {
+        return None;
+    }
+    let selected = command_option_value(command, "--gradle-user-home")
+        .or_else(|| command_option_value(command, "-g"))
+        .map(PathBuf::from)
+        .or_else(|| effective_environment_path(profile, "GRADLE_USER_HOME"))
+        .filter(|path| !path.as_os_str().is_empty())
+        .unwrap_or_else(|| home.join(".gradle"));
+    Some(if selected.is_absolute() {
+        selected
+    } else {
+        project_dir.join(selected)
+    })
 }
 
 fn remove_builtin_workspace_read_denials(profile: &mut SandboxProfile, project_dir: &Path) {
@@ -2866,6 +2900,71 @@ mod tests {
                 .any(|allowed| paths_overlap(&allowed.path, &output)),
             "an inferred output grant must not override an explicit execute denial"
         );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test creates an isolated Gradle home and project fixture"
+    )]
+    fn standard_gradle_profile_grants_the_effective_user_home() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let inherited_home = root.path().join("inherited-gradle");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+
+        let mut inherited = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        inherited.env.insert(
+            "GRADLE_USER_HOME".to_owned(),
+            inherited_home.to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut inherited,
+            &["./gradlew".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            inherited
+                .allow_write
+                .contains(&SandboxPath::dir(inherited_home.clone()))
+        );
+        assert!(
+            inherited
+                .allow_exec
+                .contains(&SandboxPath::dir(inherited_home))
+        );
+
+        let cli_home = PathBuf::from(".cache/gradle-cli");
+        let mut cli = SandboxProfile::for_ecosystem(Ecosystem::Java, &home, &project);
+        cli.env.insert(
+            "GRADLE_USER_HOME".to_owned(),
+            root.path()
+                .join("ignored-gradle")
+                .to_string_lossy()
+                .into_owned(),
+        );
+        apply_standard_profile(
+            &mut cli,
+            &[
+                "gradle".to_owned(),
+                "--gradle-user-home".to_owned(),
+                cli_home.to_string_lossy().into_owned(),
+                "build".to_owned(),
+            ],
+            &home,
+            &project,
+        )
+        .unwrap();
+        let cli_home = project.join(cli_home);
+        assert!(
+            cli.allow_write
+                .contains(&SandboxPath::dir(cli_home.clone()))
+        );
+        assert!(cli.allow_exec.contains(&SandboxPath::dir(cli_home)));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -95,8 +95,8 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
 
     // Build and resolve profile
     let mut profile = SandboxProfile::for_ecosystem(ecosystem, &home, &pwd);
-    if args.strict && ecosystem == Ecosystem::Node {
-        configure_node_workspace(&mut profile, &args.command, &pwd)?;
+    if ecosystem == Ecosystem::Node {
+        configure_node_workspace(&mut profile, &args.command, &pwd, !args.strict)?;
     }
     let configs = load_configs(&pwd, args.config.as_deref(), args.trust_project_config).await?;
     resolve_profile(&mut profile, &configs, &home, &pwd)?;
@@ -627,6 +627,8 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "AWS_SHARED_CREDENTIALS_FILE",
         "AWS_SESSION_TOKEN",
         "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "ARM_CLIENT_CERTIFICATE_PATH",
+        "ARM_OIDC_TOKEN_FILE_PATH",
         "AZURE_CLIENT_CERTIFICATE_PATH",
         "AZURE_CLIENT_SECRET",
         "AZURE_CONFIG_DIR",
@@ -1337,9 +1339,9 @@ fn resolves_within(path: &Path, root: &Path) -> bool {
 }
 
 fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, grant: SandboxPath) {
-    // Post-finalization compatibility grants must not undo a higher-precedence
-    // execute denial. Landlock cannot subtract a denied child from an allowed
-    // directory, so any overlap suppresses the complete inferred grant.
+    // Inferred compatibility grants must not undo a higher-precedence execute
+    // denial. Landlock cannot subtract a denied child from an allowed directory,
+    // so any overlap suppresses the complete inferred grant.
     if kind == GrantKind::AllowExec
         && profile
             .deny_exec
@@ -1351,6 +1353,7 @@ fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, gran
     let paths = match kind {
         GrantKind::AllowWrite => &mut profile.allow_write,
         GrantKind::AllowExec => &mut profile.allow_exec,
+        GrantKind::AllowRead => &mut profile.allow_read,
         _ => return,
     };
     if paths.iter().any(|existing| existing == &grant) {
@@ -1367,6 +1370,11 @@ fn insert_builtin_path_grant(profile: &mut SandboxProfile, kind: GrantKind, gran
             let index = profile.first_user_allow_exec.min(paths.len());
             paths.insert(index, grant);
             profile.first_user_allow_exec = index + 1;
+        }
+        GrantKind::AllowRead => {
+            let index = profile.first_user_allow_read.min(paths.len());
+            paths.insert(index, grant);
+            profile.first_user_allow_read = index + 1;
         }
         _ => return,
     }
@@ -2286,6 +2294,7 @@ fn configure_node_workspace(
     profile: &mut SandboxProfile,
     command: &[String],
     project_dir: &Path,
+    standard: bool,
 ) -> anyhow::Result<()> {
     let program = command
         .first()
@@ -2302,6 +2311,26 @@ fn configure_node_workspace(
     let workspace_root = discover_node_workspace_root(project_dir, manager)?;
     if workspace_root == project_dir {
         return Ok(());
+    }
+
+    if standard {
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowRead,
+            SandboxPath::dir(workspace_root.clone()),
+        );
+        insert_builtin_path_grant(
+            profile,
+            GrantKind::AllowExec,
+            SandboxPath::dir(workspace_root.join("node_modules")),
+        );
+        if manager == "yarn" {
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowExec,
+                SandboxPath::dir(workspace_root.join(".yarn")),
+            );
+        }
     }
 
     let mut grants = vec![SandboxPath::dir(workspace_root.join("node_modules"))];
@@ -3478,6 +3507,14 @@ mod tests {
                 ),
                 ("AWS_SECRET_ACCESS_KEY".to_owned(), "sentinel".to_owned()),
                 ("AWS_CONFIG_FILE".to_owned(), "/tmp/aws-config".to_owned()),
+                (
+                    "ARM_CLIENT_CERTIFICATE_PATH".to_owned(),
+                    "/tmp/arm-client.pem".to_owned(),
+                ),
+                (
+                    "ARM_OIDC_TOKEN_FILE_PATH".to_owned(),
+                    "/tmp/arm-oidc-token".to_owned(),
+                ),
                 ("CI_JOB_JWT".to_owned(), "sentinel".to_owned()),
                 ("CI_JOB_JWT_V2".to_owned(), "sentinel".to_owned()),
                 (
@@ -5585,6 +5622,59 @@ mod tests {
         assert!(!relocated_project.path().join("package-lock.json").exists());
     }
 
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test writes isolated Node workspace metadata"
+    )]
+    fn standard_node_workspace_grants_root_input_and_generated_outputs() {
+        let repository = tempfile::tempdir().unwrap();
+        std::fs::create_dir(repository.path().join(".git")).unwrap();
+        std::fs::write(
+            repository.path().join("package.json"),
+            r#"{"name":"workspace","workspaces":["packages/*"]}"#,
+        )
+        .unwrap();
+        let member = repository.path().join("packages/app");
+        std::fs::create_dir_all(&member).unwrap();
+        std::fs::write(member.join("package.json"), r#"{"name":"app"}"#).unwrap();
+        let mut profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Node, Path::new("/home/test"), &member);
+
+        configure_node_workspace(
+            &mut profile,
+            &["npm".to_owned(), "install".to_owned()],
+            &member,
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            profile
+                .allow_read
+                .contains(&SandboxPath::dir(repository.path().to_path_buf()))
+        );
+        assert!(profile.allow_write.contains(&SandboxPath::file(
+            repository.path().join("package-lock.json")
+        )));
+        assert!(
+            profile
+                .allow_write
+                .contains(&SandboxPath::dir(repository.path().join("node_modules")))
+        );
+        assert!(
+            profile
+                .allow_exec
+                .contains(&SandboxPath::dir(repository.path().join("node_modules")))
+        );
+        assert!(
+            !profile
+                .allow_write
+                .contains(&SandboxPath::dir(repository.path().to_path_buf())),
+            "standard mode keeps root writes scoped to generated workspace outputs"
+        );
+    }
+
     #[cfg(target_os = "linux")]
     #[test]
     #[allow(
@@ -5610,6 +5700,7 @@ mod tests {
             &mut profile,
             &["npm".to_owned(), "install".to_owned()],
             &member,
+            false,
         )
         .unwrap();
         ensure_literal_write_targets(&profile, &["npm".to_owned(), "install".to_owned()], &member)
@@ -5649,6 +5740,7 @@ mod tests {
             &mut standalone_profile,
             &["npm".to_owned(), "install".to_owned()],
             &standalone,
+            false,
         )
         .unwrap();
         ensure_literal_write_targets(

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -98,7 +98,7 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
     if args.strict {
         enable_existing_dependency_execution(&mut profile, &args.command);
     } else {
-        apply_standard_profile(&mut profile, &args.command, &home, &pwd);
+        apply_standard_profile(&mut profile, &args.command, &home, &pwd)?;
         resolve_standard_path_aliases(&mut profile, &home, &pwd)?;
     }
 
@@ -647,12 +647,17 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         .any(|suffix| upper.ends_with(suffix))
 }
 
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode resolves conventional outputs before granting their canonical \
+              referents"
+)]
 fn apply_standard_profile(
     profile: &mut SandboxProfile,
     command: &[String],
     home: &Path,
     project_dir: &Path,
-) {
+) -> anyhow::Result<()> {
     remove_builtin_workspace_read_denials(profile, project_dir);
     let project_outputs = replace_builtin_project_writes(profile, project_dir);
 
@@ -661,20 +666,39 @@ fn apply_standard_profile(
         GrantKind::AllowWrite,
         SandboxPath::dir(project_dir.to_path_buf()),
     );
-    for output in project_outputs
-        .into_iter()
-        .filter(|output| resolves_within(output, project_dir))
-    {
-        // The Linux backend must open an executable directory before it
-        // installs Landlock. Keep the narrower write grant alongside the
-        // workspace grant so a missing output root is created safely before
-        // its execute rule is compiled.
-        insert_builtin_path_grant(
-            profile,
-            GrantKind::AllowWrite,
-            SandboxPath::dir(output.clone()),
-        );
-        insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(output));
+    for output in project_outputs {
+        if resolves_within(&output, project_dir) {
+            // The Linux backend must open an executable directory before it
+            // installs Landlock. Keep the narrower write grant alongside the
+            // workspace grant so a missing output root is created safely
+            // before its execute rule is compiled.
+            insert_builtin_path_grant(
+                profile,
+                GrantKind::AllowWrite,
+                SandboxPath::dir(output.clone()),
+            );
+            insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(output));
+            continue;
+        }
+
+        let resolved = std::fs::canonicalize(&output).with_context(|| {
+            format!(
+                "could not resolve conventional output path '{}'",
+                output.display()
+            )
+        })?;
+        if !resolved.is_dir() {
+            anyhow::bail!(
+                "conventional output path '{}' must resolve to a directory",
+                output.display()
+            );
+        }
+        if !explicit_write_covers(profile, &resolved) {
+            return Err(external_write_approval_error(&output, &resolved));
+        }
+        // The explicit grant supplies write authority. Output intent also
+        // authorizes execution, but only for the approved canonical subtree.
+        insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(resolved));
     }
 
     if profile.name == "java" {
@@ -696,7 +720,7 @@ fn apply_standard_profile(
     }
 
     for name in ["CARGO_TARGET_DIR", "CARGO_BUILD_TARGET_DIR"] {
-        if let Some(path) = std::env::var_os(name).map(PathBuf::from) {
+        if let Some(path) = effective_environment_path(profile, name) {
             let path = if path.is_absolute() {
                 path
             } else {
@@ -714,8 +738,8 @@ fn apply_standard_profile(
     if command_is(command, "cargo") && top_level_subcommand(command).is_command(&["install"]) {
         let cargo_root = command_option_value(command, "--root")
             .map(PathBuf::from)
-            .or_else(|| std::env::var_os("CARGO_INSTALL_ROOT").map(PathBuf::from))
-            .or_else(|| std::env::var_os("CARGO_HOME").map(PathBuf::from))
+            .or_else(|| effective_environment_path(profile, "CARGO_INSTALL_ROOT"))
+            .or_else(|| effective_environment_path(profile, "CARGO_HOME"))
             .unwrap_or_else(|| home.join(".cargo"));
         let cargo_root = if cargo_root.is_absolute() {
             cargo_root
@@ -733,6 +757,15 @@ fn apply_standard_profile(
             SandboxPath::dir(cargo_root.join("bin")),
         );
     }
+    Ok(())
+}
+
+fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<PathBuf> {
+    profile
+        .env
+        .get(name)
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os(name).map(PathBuf::from))
 }
 
 fn remove_builtin_workspace_read_denials(profile: &mut SandboxProfile, project_dir: &Path) {
@@ -962,21 +995,12 @@ fn validate_standard_write_aliases(
             || built_in_envelopes
                 .iter()
                 .any(|envelope| grant_covers(envelope, &resolved))
-            || profile.allow_write[built_in_boundary..]
-                .iter()
-                .filter_map(resolve_explicit_grant)
-                .any(|explicit| grant_covers(&explicit, &resolved))
+            || explicit_write_covers(profile, &resolved)
         {
             continue;
         }
 
-        anyhow::bail!(
-            "built-in writable path '{}' resolves outside the standard writable envelope to '{}'; \
-             approve that target explicitly with --allow-write '{}'",
-            grant.path.display(),
-            resolved.display(),
-            resolved.display()
-        );
+        return Err(external_write_approval_error(&grant.path, &resolved));
     }
     Ok(())
 }
@@ -1004,10 +1028,34 @@ fn resolve_explicit_grant(grant: &SandboxPath) -> Option<SandboxPath> {
     })
 }
 
+fn explicit_write_covers(profile: &SandboxProfile, target: &Path) -> bool {
+    let built_in_boundary = profile
+        .first_user_allow_write
+        .min(profile.allow_write.len());
+    profile.allow_write[built_in_boundary..]
+        .iter()
+        .filter_map(resolve_explicit_grant)
+        .any(|explicit| grant_covers(&explicit, target))
+}
+
+fn external_write_approval_error(lexical: &Path, resolved: &Path) -> anyhow::Error {
+    let mut approval = resolved.display().to_string();
+    if resolved.is_dir() && !approval.ends_with(std::path::MAIN_SEPARATOR) {
+        approval.push(std::path::MAIN_SEPARATOR);
+    }
+    anyhow::anyhow!(
+        "built-in writable path '{}' resolves outside the standard writable envelope to '{}'; \
+         approve that target explicitly with --allow-write '{}'",
+        lexical.display(),
+        resolved.display(),
+        approval
+    )
+}
+
 fn grant_covers(grant: &SandboxPath, target: &Path) -> bool {
     match grant.kind {
         PathKind::Subpath => target.starts_with(&grant.path),
-        PathKind::Literal => target == grant.path,
+        PathKind::Literal => target == grant.path && !target.is_dir(),
         PathKind::Regex => false,
     }
 }
@@ -2630,7 +2678,8 @@ mod tests {
             &["cargo".to_owned(), "test".to_owned()],
             Path::new("/Users/test"),
             project.path(),
-        );
+        )
+        .unwrap();
 
         assert!(
             profile
@@ -2676,7 +2725,11 @@ mod tests {
     }
 
     #[test]
-    fn standard_profile_does_not_follow_project_output_symlinks_outside_project() {
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test builds and resolves an isolated external output symlink"
+    )]
+    fn standard_profile_requires_approval_for_external_project_outputs() {
         let project = tempfile::tempdir().unwrap();
         let external = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink(external.path(), project.path().join("target")).unwrap();
@@ -2686,33 +2739,51 @@ mod tests {
             project.path(),
         );
 
-        apply_standard_profile(
+        let error = apply_standard_profile(
             &mut profile,
             &["cargo".to_owned(), "build".to_owned()],
             Path::new("/Users/test"),
             project.path(),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("--allow-write"));
+        assert!(error.to_string().contains(&format!(
+            "{}{sep}",
+            external.path().display(),
+            sep = std::path::MAIN_SEPARATOR
+        )));
+
+        let mut approved = SandboxProfile::for_ecosystem(
+            Ecosystem::Rust,
+            Path::new("/Users/test"),
+            project.path(),
         );
-        resolve_standard_path_aliases(&mut profile, Path::new("/Users/test"), project.path())
+        approved
+            .allow_write
+            .push(SandboxPath::dir(external.path().to_path_buf()));
+        apply_standard_profile(
+            &mut approved,
+            &["cargo".to_owned(), "build".to_owned()],
+            Path::new("/Users/test"),
+            project.path(),
+        )
+        .unwrap();
+        resolve_standard_path_aliases(&mut approved, Path::new("/Users/test"), project.path())
             .unwrap();
 
         assert!(
-            profile
+            approved
                 .allow_write
                 .contains(&SandboxPath::dir(project.path().to_path_buf()))
         );
-        assert!(!profile.allow_write.iter().any(|grant| {
-            grant.path == project.path().join("target") || grant.path == external.path()
-        }));
-        assert!(!profile.allow_exec.iter().any(|grant| {
-            grant.path == project.path().join("target") || grant.path == external.path()
-        }));
         assert!(
-            !profile
-                .allow_read
-                .iter()
-                .any(|grant| grant.path == external.path()),
-            "generated output symlinks are not inferred as source read grants"
+            approved
+                .allow_write
+                .contains(&SandboxPath::dir(external.path().to_path_buf()))
         );
+        assert!(approved.allow_exec.contains(&SandboxPath::dir(
+            std::fs::canonicalize(external.path()).unwrap()
+        )));
     }
 
     #[test]
@@ -2735,7 +2806,8 @@ mod tests {
             &["npm".to_owned(), "install".to_owned()],
             &home,
             &project,
-        );
+        )
+        .unwrap();
         let error = resolve_standard_path_aliases(&mut profile, &home, &project).unwrap_err();
         assert!(error.to_string().contains("--allow-write"));
         assert!(
@@ -2753,7 +2825,8 @@ mod tests {
             &["npm".to_owned(), "install".to_owned()],
             &home,
             &project,
-        );
+        )
+        .unwrap();
         resolve_standard_path_aliases(&mut approved, &home, &project).unwrap();
         assert!(
             approved
@@ -2782,7 +2855,8 @@ mod tests {
             &["npm".to_owned(), "install".to_owned()],
             &home,
             &project,
-        );
+        )
+        .unwrap();
         resolve_standard_path_aliases(&mut profile, &home, &project).unwrap();
 
         assert!(
@@ -2818,7 +2892,8 @@ mod tests {
             &["cargo".to_owned(), "build".to_owned()],
             root.path(),
             &project,
-        );
+        )
+        .unwrap();
         resolve_standard_path_aliases(&mut profile, root.path(), &project).unwrap();
 
         assert!(
@@ -2860,7 +2935,8 @@ mod tests {
             &["cargo".to_owned(), "build".to_owned()],
             Path::new("/Users/test"),
             project.path(),
-        );
+        )
+        .unwrap();
 
         assert!(profile.deny_read.contains(&SandboxPath::file(denied)));
     }
@@ -2878,7 +2954,8 @@ mod tests {
             &["sbt".to_owned(), "compile".to_owned()],
             home.path(),
             project.path(),
-        );
+        )
+        .unwrap();
 
         for cache in [".sbt/boot", ".ivy2/cache", ".cache/coursier"] {
             assert!(
@@ -2931,7 +3008,8 @@ mod tests {
             ],
             home,
             project.path(),
-        );
+        )
+        .unwrap();
 
         let cargo_root = std::env::var_os("CARGO_INSTALL_ROOT")
             .or_else(|| std::env::var_os("CARGO_HOME"))
@@ -2955,6 +3033,70 @@ mod tests {
     }
 
     #[test]
+    fn standard_cargo_paths_use_the_resolved_profile_environment() {
+        let project = tempfile::tempdir().unwrap();
+        let home = tempfile::tempdir().unwrap();
+        let target = tempfile::tempdir().unwrap();
+        let install_root = tempfile::tempdir().unwrap();
+
+        let mut build_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        build_profile.env.insert(
+            "CARGO_TARGET_DIR".to_owned(),
+            target.path().to_string_lossy().into_owned(),
+        );
+        apply_standard_profile(
+            &mut build_profile,
+            &["cargo".to_owned(), "build".to_owned()],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            build_profile
+                .allow_write
+                .contains(&SandboxPath::dir(target.path().to_path_buf()))
+        );
+        assert!(
+            build_profile
+                .allow_exec
+                .contains(&SandboxPath::dir(target.path().to_path_buf()))
+        );
+
+        let mut install_profile =
+            SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), project.path());
+        install_profile.env.insert(
+            "CARGO_INSTALL_ROOT".to_owned(),
+            install_root.path().to_string_lossy().into_owned(),
+        );
+        install_profile.env.insert(
+            "CARGO_HOME".to_owned(),
+            home.path().join("ignored-cargo-home").display().to_string(),
+        );
+        apply_standard_profile(
+            &mut install_profile,
+            &[
+                "cargo".to_owned(),
+                "install".to_owned(),
+                "ripgrep".to_owned(),
+            ],
+            home.path(),
+            project.path(),
+        )
+        .unwrap();
+        assert!(
+            install_profile
+                .allow_write
+                .contains(&SandboxPath::dir(install_root.path().to_path_buf()))
+        );
+        assert!(
+            install_profile
+                .allow_exec
+                .contains(&SandboxPath::dir(install_root.path().join("bin")))
+        );
+    }
+
+    #[test]
     fn standard_cargo_install_honors_explicit_root() {
         let project = tempfile::tempdir().unwrap();
         let install_root = tempfile::tempdir().unwrap();
@@ -2971,7 +3113,8 @@ mod tests {
             ],
             home,
             project.path(),
-        );
+        )
+        .unwrap();
 
         assert!(
             profile

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -125,8 +125,8 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         resolve_standard_path_aliases(&mut profile, &home, &pwd)?;
     }
 
-    if args.strict && !args.dry_run {
-        if cargo_uses_persistent_target(&args.command) {
+    if !args.dry_run {
+        if args.strict && cargo_uses_persistent_target(&args.command) {
             ensure_child_directory(&pwd, c"target")?;
         }
         #[cfg(target_os = "linux")]
@@ -809,6 +809,17 @@ fn apply_standard_profile(
     }
 
     if command_is(command, "cargo") {
+        let cargo_home = effective_cargo_home(profile, home, project_dir);
+        replace_builtin_write_path(
+            profile,
+            &home.join(".cargo/registry"),
+            SandboxPath::dir(cargo_home.join("registry")),
+        );
+        replace_builtin_write_path(
+            profile,
+            &home.join(".cargo/git"),
+            SandboxPath::dir(cargo_home.join("git")),
+        );
         let cargo_cli_target = command_option_value(command, "--target-dir").map(PathBuf::from);
         if let Some(path) = cargo_cli_target {
             let path = if path.is_absolute() {
@@ -862,8 +873,7 @@ fn apply_standard_profile(
         } else {
             None
         };
-        let cargo_home = effective_environment_path(profile, "CARGO_HOME")
-            .unwrap_or_else(|| home.join(".cargo"));
+        let cargo_home = effective_cargo_home(profile, home, project_dir);
         if explicit_root.is_none() && environment_root.is_none() && config_root.is_none() {
             reject_implicit_cargo_install_root(project_dir, &cargo_home)?;
         }
@@ -898,18 +908,22 @@ fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<Pa
         .or_else(|| std::env::var_os(name).map(PathBuf::from))
 }
 
+fn effective_cargo_home(profile: &SandboxProfile, home: &Path, project_dir: &Path) -> PathBuf {
+    let cargo_home =
+        effective_environment_path(profile, "CARGO_HOME").unwrap_or_else(|| home.join(".cargo"));
+    if cargo_home.is_absolute() {
+        cargo_home
+    } else {
+        project_dir.join(cargo_home)
+    }
+}
+
 fn protect_effective_credential_paths(
     profile: &mut SandboxProfile,
     home: &Path,
     project_dir: &Path,
 ) {
-    let cargo_home =
-        effective_environment_path(profile, "CARGO_HOME").unwrap_or_else(|| home.join(".cargo"));
-    let cargo_home = if cargo_home.is_absolute() {
-        cargo_home
-    } else {
-        project_dir.join(cargo_home)
-    };
+    let cargo_home = effective_cargo_home(profile, home, project_dir);
     for name in ["credentials.toml", "credentials"] {
         insert_builtin_read_denial(profile, SandboxPath::file(cargo_home.join(name)));
     }
@@ -1441,7 +1455,8 @@ fn append_standard_workspace_read_aliases(
     profile: &mut SandboxProfile,
     project_dir: &Path,
 ) -> anyhow::Result<()> {
-    let read_aliases = workspace_read_aliases(profile, project_dir)?;
+    let scan_root = standard_workspace_read_root(profile, project_dir);
+    let read_aliases = workspace_read_aliases(profile, &scan_root)?;
     for alias in read_aliases {
         if !profile.allow_read.contains(&alias) {
             profile.grant_origins.push(GrantRecord {
@@ -1453,6 +1468,16 @@ fn append_standard_workspace_read_aliases(
         }
     }
     Ok(())
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn standard_workspace_read_root(profile: &SandboxProfile, project_dir: &Path) -> PathBuf {
+    profile.allow_read[..profile.first_user_allow_read.min(profile.allow_read.len())]
+        .iter()
+        .filter(|grant| grant.kind == PathKind::Subpath && project_dir.starts_with(&grant.path))
+        .map(|grant| grant.path.clone())
+        .min_by_key(|path| path.components().count())
+        .unwrap_or_else(|| project_dir.to_path_buf())
 }
 
 #[allow(
@@ -4991,6 +5016,19 @@ mod tests {
                 .allow_exec
                 .contains(&SandboxPath::dir(install_root.path().join("bin")))
         );
+        let custom_cargo_home = home.path().join("ignored-cargo-home");
+        for cache in ["registry", "git"] {
+            assert!(
+                install_profile
+                    .allow_write
+                    .contains(&SandboxPath::dir(custom_cargo_home.join(cache)))
+            );
+            assert!(
+                !install_profile
+                    .allow_write
+                    .contains(&SandboxPath::dir(home.path().join(".cargo").join(cache)))
+            );
+        }
     }
 
     #[test]
@@ -5673,6 +5711,20 @@ mod tests {
                 .contains(&SandboxPath::dir(repository.path().to_path_buf())),
             "standard mode keeps root writes scoped to generated workspace outputs"
         );
+        assert_eq!(
+            standard_workspace_read_root(&profile, &member),
+            repository.path()
+        );
+        #[cfg(target_os = "linux")]
+        {
+            ensure_literal_write_targets(
+                &profile,
+                &["npm".to_owned(), "install".to_owned()],
+                &member,
+            )
+            .unwrap();
+            assert!(repository.path().join("package-lock.json").is_file());
+        }
     }
 
     #[cfg(target_os = "linux")]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -85,7 +85,7 @@ pub async fn execute(args: &RunArgs) -> ExitCode {
 async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
     let pwd = std::env::current_dir().context("failed to get current directory")?;
     let home = dirs::home_dir().context("could not determine home directory")?;
-    reject_project_relocation(&args.command)?;
+    reject_project_relocation(&args.command, &pwd)?;
 
     // Determine ecosystem
     let command_name = &args.command[0];
@@ -113,7 +113,7 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         });
     }
     profile.finalize();
-    protect_effective_cargo_credentials(&mut profile, &home, &pwd);
+    protect_effective_credential_paths(&mut profile, &home, &pwd);
     if args.strict {
         enable_existing_dependency_execution(&mut profile, &args.command);
     } else {
@@ -641,6 +641,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "DOCKER_CONFIG",
         "GPG_AGENT_INFO",
         "GH_CONFIG_DIR",
+        "GNUPGHOME",
         "GOOGLE_APPLICATION_CREDENTIALS",
         "KUBECONFIG",
         "MONGODB_URI",
@@ -895,7 +896,7 @@ fn effective_environment_path(profile: &SandboxProfile, name: &str) -> Option<Pa
         .or_else(|| std::env::var_os(name).map(PathBuf::from))
 }
 
-fn protect_effective_cargo_credentials(
+fn protect_effective_credential_paths(
     profile: &mut SandboxProfile,
     home: &Path,
     project_dir: &Path,
@@ -909,6 +910,21 @@ fn protect_effective_cargo_credentials(
     };
     for name in ["credentials.toml", "credentials"] {
         insert_builtin_read_denial(profile, SandboxPath::file(cargo_home.join(name)));
+    }
+
+    // Ambient GH_CONFIG_DIR is filtered as a sensitive locator. When it is absent from the
+    // resolved profile, gh falls back to XDG_CONFIG_HOME/gh before ~/.config/gh.
+    if !profile.env.contains_key("GH_CONFIG_DIR") {
+        let github_config = effective_environment_path(profile, "XDG_CONFIG_HOME")
+            .map(|directory| {
+                if directory.is_absolute() {
+                    directory.join("gh")
+                } else {
+                    project_dir.join(directory).join("gh")
+                }
+            })
+            .unwrap_or_else(|| home.join(".config/gh"));
+        insert_builtin_read_denial(profile, SandboxPath::dir(github_config));
     }
 }
 
@@ -1841,8 +1857,33 @@ fn command_is(command: &[String], expected: &str) -> bool {
         .is_some_and(|name| name == expected)
 }
 
-fn reject_project_relocation(command: &[String]) -> anyhow::Result<()> {
+#[allow(
+    clippy::disallowed_methods,
+    reason = "policy preparation resolves Cargo's selected manifest before comparing its workspace"
+)]
+fn reject_project_relocation(command: &[String], project_dir: &Path) -> anyhow::Result<()> {
     let Some(option) = project_relocation_option(command) else {
+        if command_is(command, "cargo")
+            && let Some(manifest) = command_option_value(command, "--manifest-path")
+        {
+            let manifest = PathBuf::from(manifest);
+            let manifest = if manifest.is_absolute() {
+                manifest
+            } else {
+                project_dir.join(manifest)
+            };
+            let project =
+                std::fs::canonicalize(project_dir).unwrap_or_else(|_| project_dir.to_path_buf());
+            let resolved = resolve_existing_ancestor(&manifest).unwrap_or(manifest);
+            if !resolved.starts_with(&project) {
+                anyhow::bail!(
+                    "Cargo manifest '{}' resolves outside the sandbox workspace '{}'; change \
+                     directory before invoking sbe",
+                    resolved.display(),
+                    project.display()
+                );
+            }
+        }
         return Ok(());
     };
     anyhow::bail!(
@@ -2672,7 +2713,7 @@ fn ensure_literal_write_targets(
 
     use sbe_core::config::PathKind;
 
-    reject_project_relocation(command)?;
+    reject_project_relocation(command, project_dir)?;
     let program = command
         .first()
         .and_then(|program| Path::new(program).file_name())
@@ -3501,6 +3542,7 @@ mod tests {
                     "/tmp/google-credentials.json".to_owned(),
                 ),
                 ("GH_CONFIG_DIR".to_owned(), "/tmp/gh-config".to_owned()),
+                ("GNUPGHOME".to_owned(), "/tmp/gnupg".to_owned()),
             ],
             false,
         );
@@ -3533,7 +3575,11 @@ mod tests {
             .env
             .insert("CARGO_HOME".to_owned(), "custom-cargo".to_owned());
 
-        protect_effective_cargo_credentials(&mut profile, home.path(), project.path());
+        profile
+            .env
+            .insert("XDG_CONFIG_HOME".to_owned(), "custom-config".to_owned());
+
+        protect_effective_credential_paths(&mut profile, home.path(), project.path());
 
         for name in ["credentials.toml", "credentials"] {
             let denied = SandboxPath::file(project.path().join("custom-cargo").join(name));
@@ -3544,6 +3590,11 @@ mod tests {
                     && record.value == denied.path.to_string_lossy()
             }));
         }
+        assert!(
+            profile
+                .deny_read
+                .contains(&SandboxPath::dir(project.path().join("custom-config/gh")))
+        );
     }
 
     #[tokio::test]
@@ -5291,6 +5342,7 @@ mod tests {
 
     #[test]
     fn project_relocation_options_are_rejected_before_policy_preparation() {
+        let project = tempfile::tempdir().unwrap();
         for command in [
             vec!["npm", "--prefix", "subproject", "install"],
             vec!["npm", "install", "--prefix=subproject"],
@@ -5307,27 +5359,61 @@ mod tests {
         ] {
             let command: Vec<String> = command.into_iter().map(str::to_owned).collect();
             assert!(
-                reject_project_relocation(&command).is_err(),
+                reject_project_relocation(&command, project.path()).is_err(),
                 "relocating command was accepted: {command:?}"
             );
         }
         assert!(
-            reject_project_relocation(&[
-                "npm".to_owned(),
-                "install".to_owned(),
-                "--".to_owned(),
-                "--prefix".to_owned(),
-                "payload".to_owned(),
-            ])
+            reject_project_relocation(
+                &[
+                    "npm".to_owned(),
+                    "install".to_owned(),
+                    "--".to_owned(),
+                    "--prefix".to_owned(),
+                    "payload".to_owned(),
+                ],
+                project.path(),
+            )
             .is_ok()
         );
         for flag in ["-fae", "-ff", "-fn"] {
             assert!(
-                reject_project_relocation(&["mvn".to_owned(), flag.to_owned(), "test".to_owned(),])
-                    .is_ok(),
+                reject_project_relocation(
+                    &["mvn".to_owned(), flag.to_owned(), "test".to_owned(),],
+                    project.path(),
+                )
+                .is_ok(),
                 "Maven failure-mode flag was treated as a project path: {flag}"
             );
         }
+
+        let external = tempfile::tempdir().unwrap();
+        assert!(
+            reject_project_relocation(
+                &[
+                    "cargo".to_owned(),
+                    "build".to_owned(),
+                    "--manifest-path".to_owned(),
+                    external.path().join("Cargo.toml").display().to_string(),
+                ],
+                project.path(),
+            )
+            .unwrap_err()
+            .to_string()
+            .contains("outside the sandbox workspace")
+        );
+        assert!(
+            reject_project_relocation(
+                &[
+                    "cargo".to_owned(),
+                    "build".to_owned(),
+                    "--manifest-path=apps/cli/Cargo.toml".to_owned(),
+                ],
+                project.path(),
+            )
+            .is_ok(),
+            "in-workspace manifests used by release workflows must remain supported"
+        );
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -649,6 +649,7 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "MONGODB_URI",
         "MONGO_URL",
         "MYSQL_PWD",
+        "NPM_CONFIG_USERCONFIG",
         "PASSWORD",
         "PASSWD",
         "PGPASSFILE",
@@ -3569,6 +3570,10 @@ mod tests {
                 ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
                 ("SYSTEM_ACCESSTOKEN".to_owned(), "sentinel".to_owned()),
                 ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
+                (
+                    "NPM_CONFIG_USERCONFIG".to_owned(),
+                    "/tmp/custom-npmrc".to_owned(),
+                ),
                 ("OPENAI_API_KEY".to_owned(), "sentinel".to_owned()),
                 ("TOKEN".to_owned(), "sentinel".to_owned()),
                 ("API_KEY".to_owned(), "sentinel".to_owned()),

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -329,7 +329,9 @@ impl ProfileConfig {
         if self.allow_degraded == Some(true) {
             return Err(config_policy(
                 path,
-                "allowDegraded in configuration is no longer accepted; use the capability-specific CLI option --allow-insecure-linux-network for one trusted invocation",
+                "allowDegraded in configuration is no longer accepted; use the \
+                 capability-specific CLI options --strict and --allow-insecure-linux-network for \
+                 one trusted invocation",
             ));
         }
         let lists = [
@@ -418,7 +420,8 @@ impl ProfileConfig {
         if expands_authority {
             return Err(config_policy(
                 path,
-                "project configuration may only add denyRead/denyExec or explicitly disable allowAllNetwork/allowDegraded; pass --trust-project-config to authorize expansion",
+                "project configuration may only add denyRead/denyExec or explicitly disable \
+                 allowAllNetwork/allowDegraded; pass --trust-project-config to authorize expansion",
             ));
         }
         Ok(())

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,4 +14,6 @@ pub mod sandbox;
 
 #[cfg(target_os = "linux")]
 pub use sandbox::maybe_run_launcher;
-pub use sandbox::{BackendFeatures, BackendInfo, BackendOptions, Sandbox, SandboxBackend};
+pub use sandbox::{
+    BackendFeatures, BackendInfo, BackendOptions, Sandbox, SandboxBackend, SecurityMode,
+};

--- a/crates/core/src/profile/defaults-linux.yaml
+++ b/crates/core/src/profile/defaults-linux.yaml
@@ -340,8 +340,8 @@ profiles:
       - "$PWD/project/target/"
       - "$PWD/project/project/"
       # Scala / sbt
-      # sbt's XDG runtime socket and tool caches are redirected to SBE's
-      # private per-run directory by the launcher environment.
+      # Standard mode grants the ordinary persistent caches at runtime. Strict
+      # mode redirects sbt, Ivy, and Coursier state into SBE's private root.
     allowDomains:
       - "repo1.maven.org"
       - "repo.maven.apache.org"

--- a/crates/core/src/profile/defaults-linux.yaml
+++ b/crates/core/src/profile/defaults-linux.yaml
@@ -219,6 +219,7 @@ profiles:
       - "$PWD/Cargo.lock"
       - "~/.cargo/registry/"
       - "~/.cargo/git/"
+      - "~/.cache/sccache/"
       # NOTE: ~/.cargo/bin/ is NOT writable — prevents trojaning cargo binaries
       - "~/.cache/zig/"
     allowDomains:
@@ -232,6 +233,8 @@ profiles:
     allowExec:
       - "~/.cargo/bin/"
       - "~/.rustup/toolchains/"
+      - "/usr/bin/sccache"
+      - "/usr/local/bin/sccache"
 
   python:
     allowWrite:

--- a/crates/core/src/profile/defaults-macos.yaml
+++ b/crates/core/src/profile/defaults-macos.yaml
@@ -178,6 +178,7 @@ profiles:
       - "$PWD/Cargo.lock"
       - "~/.cargo/registry/"
       - "~/.cargo/git/"
+      - "~/Library/Caches/Mozilla.sccache/"
       # NOTE: ~/.cargo/bin/ is NOT writable — prevents trojaning cargo binaries
       - "~/.cache/zig/"
     allowDomains:
@@ -191,6 +192,8 @@ profiles:
     allowExec:
       - "~/.cargo/bin/"
       - "~/.rustup/toolchains/"
+      - "/opt/homebrew/bin/sccache"
+      - "/usr/local/bin/sccache"
       - "/usr/bin/xcrun"
       - "/usr/bin/xcodebuild"
       - "~/Library/Caches/cargo-zigbuild/"

--- a/crates/core/src/profile/defaults-macos.yaml
+++ b/crates/core/src/profile/defaults-macos.yaml
@@ -315,7 +315,8 @@ profiles:
       - "$PWD/build/"
       - "$PWD/target/"
       # Scala / sbt
-      # Coursier (Scala dependency manager)
+      # Standard mode grants the ordinary persistent caches at runtime. Strict
+      # mode redirects sbt, Ivy, and Coursier state into SBE's private root.
     allowDomains:
       - "repo1.maven.org"
       - "repo.maven.apache.org"

--- a/crates/core/src/profile/mod.rs
+++ b/crates/core/src/profile/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
 use std::{
     collections::HashMap,
     fmt,
@@ -5,9 +7,6 @@ use std::{
     path::{Path, PathBuf},
     str::FromStr,
 };
-
-#[cfg(unix)]
-use std::os::unix::fs::MetadataExt;
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 
@@ -838,7 +837,8 @@ fn visit_regular_files(
             *inspected = inspected.saturating_add(1);
             if *inspected > MAX_WRITABLE_ALIAS_SCAN_ENTRIES {
                 return Err(crate::error::CoreError::ProfileLint(format!(
-                    "persistent writable-alias scan exceeds {MAX_WRITABLE_ALIAS_SCAN_ENTRIES} entries"
+                    "persistent writable-alias scan exceeds {MAX_WRITABLE_ALIAS_SCAN_ENTRIES} \
+                     entries"
                 )));
             }
             let path = entry.path();

--- a/crates/core/src/sandbox/linux/exec.rs
+++ b/crates/core/src/sandbox/linux/exec.rs
@@ -44,8 +44,22 @@ struct LauncherPayload {
     proxy_port: Option<u16>,
     command: Vec<String>,
     environment: HashMap<String, String>,
-    options: BackendOptions,
+    options: LauncherOptions,
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+pub(super) struct LauncherOptions {
+    backend: BackendOptions,
     security_mode: SecurityMode,
+}
+
+impl LauncherOptions {
+    pub(super) const fn new(backend: BackendOptions, security_mode: SecurityMode) -> Self {
+        Self {
+            backend,
+            security_mode,
+        }
+    }
 }
 
 /// Parent-side asynchronous wrapper: write a private bounded payload and
@@ -56,12 +70,11 @@ pub(super) async fn run_sandboxed(
     command: &[String],
     extra_env: &HashMap<String, String>,
     probe: &ProbeResult,
-    options: BackendOptions,
-    security_mode: SecurityMode,
+    options: LauncherOptions,
     pid_tx: Option<tokio::sync::oneshot::Sender<u32>>,
 ) -> Result<ExitStatus, CoreError> {
-    enforce_network_capability(profile, probe, options, security_mode)?;
-    if security_mode.is_strict() {
+    enforce_network_capability(profile, probe, options.backend, options.security_mode)?;
+    if options.security_mode.is_strict() {
         profile.validate_security_invariants()?;
     }
     if command.is_empty() {
@@ -79,7 +92,6 @@ pub(super) async fn run_sandboxed(
         command: command.to_vec(),
         environment: extra_env.clone(),
         options,
-        security_mode,
     };
     let encoded = serde_json::to_vec(&payload)
         .map_err(|error| CoreError::Backend(format!("serialize launcher policy: {error}")))?;
@@ -254,7 +266,7 @@ fn launcher_main(policy_fd: RawFd) -> Result<ExitCode, CoreError> {
     profile.first_user_allow_exec = payload.first_user_allow_exec;
     profile.first_user_allow_read = payload.first_user_allow_read;
     profile.ephemeral_write_exec = payload.ephemeral_write_exec;
-    if payload.security_mode.is_strict() {
+    if payload.options.security_mode.is_strict() {
         profile.validate_structural_security_invariants()?;
     }
 
@@ -262,22 +274,22 @@ fn launcher_main(policy_fd: RawFd) -> Result<ExitCode, CoreError> {
     enforce_network_capability(
         &profile,
         &live_probe,
-        payload.options,
-        payload.security_mode,
+        payload.options.backend,
+        payload.options.security_mode,
     )?;
     let compiled_landlock = landlock::compile(
         &profile,
         payload.proxy_port,
         &live_probe,
-        payload.options,
-        payload.security_mode,
+        payload.options.backend,
+        payload.options.security_mode,
     )?;
     let compiled_seccomp = seccomp::compile(
         &profile,
         payload.proxy_port,
         &live_probe,
-        payload.options,
-        payload.security_mode,
+        payload.options.backend,
+        payload.options.security_mode,
     )?;
 
     let program = payload
@@ -542,8 +554,7 @@ mod tests {
             proxy_port: None,
             command: vec!["/bin/true".to_owned()],
             environment: HashMap::new(),
-            options: BackendOptions::default(),
-            security_mode: SecurityMode::Standard,
+            options: LauncherOptions::new(BackendOptions::default(), SecurityMode::Standard),
         };
         let encoded = serde_json::to_vec(&payload).unwrap();
         let decoded: LauncherPayload = serde_json::from_slice(&encoded).unwrap();

--- a/crates/core/src/sandbox/linux/exec.rs
+++ b/crates/core/src/sandbox/linux/exec.rs
@@ -21,7 +21,7 @@ use super::{landlock, probe, seccomp};
 use crate::{
     error::CoreError,
     profile::{NetworkMode, SandboxProfile},
-    sandbox::{BackendOptions, linux::probe::ProbeResult},
+    sandbox::{BackendOptions, SecurityMode, linux::probe::ProbeResult},
 };
 
 const LAUNCHER_MARKER: &str = "__sbe_linux_launcher";
@@ -45,6 +45,7 @@ struct LauncherPayload {
     command: Vec<String>,
     environment: HashMap<String, String>,
     options: BackendOptions,
+    security_mode: SecurityMode,
 }
 
 /// Parent-side asynchronous wrapper: write a private bounded payload and
@@ -56,10 +57,13 @@ pub(super) async fn run_sandboxed(
     extra_env: &HashMap<String, String>,
     probe: &ProbeResult,
     options: BackendOptions,
+    security_mode: SecurityMode,
     pid_tx: Option<tokio::sync::oneshot::Sender<u32>>,
 ) -> Result<ExitStatus, CoreError> {
-    enforce_network_capability(profile, probe, options)?;
-    profile.validate_security_invariants()?;
+    enforce_network_capability(profile, probe, options, security_mode)?;
+    if security_mode.is_strict() {
+        profile.validate_security_invariants()?;
+    }
     if command.is_empty() {
         return Err(CoreError::Backend("empty command vector".to_owned()));
     }
@@ -75,6 +79,7 @@ pub(super) async fn run_sandboxed(
         command: command.to_vec(),
         environment: extra_env.clone(),
         options,
+        security_mode,
     };
     let encoded = serde_json::to_vec(&payload)
         .map_err(|error| CoreError::Backend(format!("serialize launcher policy: {error}")))?;
@@ -249,14 +254,31 @@ fn launcher_main(policy_fd: RawFd) -> Result<ExitCode, CoreError> {
     profile.first_user_allow_exec = payload.first_user_allow_exec;
     profile.first_user_allow_read = payload.first_user_allow_read;
     profile.ephemeral_write_exec = payload.ephemeral_write_exec;
-    profile.validate_structural_security_invariants()?;
+    if payload.security_mode.is_strict() {
+        profile.validate_structural_security_invariants()?;
+    }
 
     let live_probe = probe::run()?;
-    enforce_network_capability(&profile, &live_probe, payload.options)?;
-    let compiled_landlock =
-        landlock::compile(&profile, payload.proxy_port, &live_probe, payload.options)?;
-    let compiled_seccomp =
-        seccomp::compile(&profile, payload.proxy_port, &live_probe, payload.options)?;
+    enforce_network_capability(
+        &profile,
+        &live_probe,
+        payload.options,
+        payload.security_mode,
+    )?;
+    let compiled_landlock = landlock::compile(
+        &profile,
+        payload.proxy_port,
+        &live_probe,
+        payload.options,
+        payload.security_mode,
+    )?;
+    let compiled_seccomp = seccomp::compile(
+        &profile,
+        payload.proxy_port,
+        &live_probe,
+        payload.options,
+        payload.security_mode,
+    )?;
 
     let program = payload
         .command
@@ -340,6 +362,7 @@ fn enforce_network_capability(
     profile: &SandboxProfile,
     probe: &ProbeResult,
     options: BackendOptions,
+    security_mode: SecurityMode,
 ) -> Result<(), CoreError> {
     if matches!(
         profile.network_mode,
@@ -347,6 +370,14 @@ fn enforce_network_capability(
     ) {
         // DenyAll is fully enforced by the unconditional seccomp socket(2)
         // rule and does not depend on Landlock's ABI-v4 TCP port mediation.
+        return Ok(());
+    }
+    if !security_mode.is_strict() {
+        eprintln!(
+            "sbe: WARNING: standard Linux mode cannot enforce domain egress while preserving \
+             local build services; filesystem, environment, descriptor, privilege, and proxy \
+             protections remain active (use --strict for fail-closed networking)"
+        );
         return Ok(());
     }
     if profile.network_mode == NetworkMode::Proxy && !options.allow_insecure_network {
@@ -385,9 +416,10 @@ fn enforce_network_capability(
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
     use crate::detect::Ecosystem;
-    use std::path::PathBuf;
 
     #[test]
     fn strict_proxy_mode_refuses_port_only_linux_confinement() {
@@ -400,8 +432,13 @@ mod tests {
             kernel: "test".to_owned(),
             abi: super::super::probe::LandlockAbi::V9,
         };
-        let error =
-            enforce_network_capability(&profile, &probe, BackendOptions::default()).unwrap_err();
+        let error = enforce_network_capability(
+            &profile,
+            &probe,
+            BackendOptions::default(),
+            SecurityMode::Strict,
+        )
+        .unwrap_err();
         assert!(format!("{error}").contains("strict-domain-egress"));
     }
 
@@ -424,6 +461,30 @@ mod tests {
                     allow_insecure_network: true,
                     ..BackendOptions::default()
                 },
+                SecurityMode::Strict,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn standard_proxy_mode_keeps_partial_linux_protection() {
+        let profile = SandboxProfile::for_ecosystem(
+            Ecosystem::Node,
+            &PathBuf::from("/home/test"),
+            &PathBuf::from("/work/project"),
+        );
+        let probe = ProbeResult {
+            kernel: "test".to_owned(),
+            abi: super::super::probe::LandlockAbi::V3,
+        };
+
+        assert!(
+            enforce_network_capability(
+                &profile,
+                &probe,
+                BackendOptions::default(),
+                SecurityMode::Standard,
             )
             .is_ok()
         );
@@ -444,7 +505,15 @@ mod tests {
             abi: super::super::probe::LandlockAbi::V3,
         };
 
-        assert!(enforce_network_capability(&profile, &probe, BackendOptions::default()).is_ok());
+        assert!(
+            enforce_network_capability(
+                &profile,
+                &probe,
+                BackendOptions::default(),
+                SecurityMode::Standard,
+            )
+            .is_ok()
+        );
     }
 
     #[test]
@@ -474,6 +543,7 @@ mod tests {
             command: vec!["/bin/true".to_owned()],
             environment: HashMap::new(),
             options: BackendOptions::default(),
+            security_mode: SecurityMode::Standard,
         };
         let encoded = serde_json::to_vec(&payload).unwrap();
         let decoded: LauncherPayload = serde_json::from_slice(&encoded).unwrap();

--- a/crates/core/src/sandbox/linux/landlock.rs
+++ b/crates/core/src/sandbox/linux/landlock.rs
@@ -207,15 +207,12 @@ fn effective_network_mode(mode: NetworkMode, security_mode: SecurityMode) -> Net
     }
 }
 
-fn handled_fs_access(abi: ABI, mode: NetworkMode) -> BitFlags<AccessFs> {
-    let mut access = AccessFs::from_all(abi);
-    if mode == NetworkMode::AllowAll {
-        // ResolveUnix is classified as a filesystem right by Landlock, but it
-        // is network mediation. Handling it in allow-all mode would still
-        // block ambient sockets outside the private runtime root.
-        access.remove(AccessFs::ResolveUnix);
-    }
-    access
+fn handled_fs_access(abi: ABI) -> BitFlags<AccessFs> {
+    // ResolveUnix is a filesystem capability even when TCP networking is
+    // unrestricted. Keep it handled so AllowAll cannot implicitly expose
+    // capability brokers such as /var/run/docker.sock. Only per-run private
+    // roots receive ResolveUnix through ephemeral_write_access().
+    AccessFs::from_all(abi)
 }
 
 /// A ready-to-apply Landlock ruleset. Built in the single-threaded launcher;
@@ -249,7 +246,7 @@ pub fn compile(
     let effective_network = effective_network_mode(profile.network_mode, security_mode);
     let ruleset = Ruleset::default()
         .set_compatibility(CompatLevel::HardRequirement)
-        .handle_access(handled_fs_access(abi, effective_network))?;
+        .handle_access(handled_fs_access(abi))?;
     // Signals are a process-isolation capability, not a network capability,
     // so keep them scoped even when the user explicitly requests AllowAll
     // networking. Abstract Unix sockets, on the other hand, are deliberately
@@ -1128,9 +1125,8 @@ mod tests {
     }
 
     #[test]
-    fn allow_all_does_not_handle_unix_socket_resolution() {
-        assert!(handled_fs_access(ABI::V9, NetworkMode::Proxy).contains(AccessFs::ResolveUnix));
-        assert!(!handled_fs_access(ABI::V9, NetworkMode::AllowAll).contains(AccessFs::ResolveUnix));
+    fn allow_all_keeps_unix_socket_resolution_mediated() {
+        assert!(handled_fs_access(ABI::V9).contains(AccessFs::ResolveUnix));
     }
 
     #[test]

--- a/crates/core/src/sandbox/linux/landlock.rs
+++ b/crates/core/src/sandbox/linux/landlock.rs
@@ -864,6 +864,10 @@ fn root_owned_chain(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode snapshots an existing denied symlink referent before launch"
+)]
 fn build_forbidden_reads(
     profile: &SandboxProfile,
     security_mode: SecurityMode,

--- a/crates/core/src/sandbox/linux/landlock.rs
+++ b/crates/core/src/sandbox/linux/landlock.rs
@@ -32,7 +32,7 @@ use crate::{
     error::CoreError,
     profile::{NetworkMode, SandboxProfile},
     sandbox::{
-        BackendOptions,
+        BackendOptions, SecurityMode,
         linux::probe::{LandlockAbi, ProbeResult},
     },
 };
@@ -97,6 +97,7 @@ const MAX_CARVED_READ_ENTRIES: usize = 100_000;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum UntrustedSymlinkBehavior {
+    Follow,
     Reject,
     Skip,
 }
@@ -198,6 +199,14 @@ fn highest_abi(probe: &ProbeResult) -> ABI {
     }
 }
 
+fn effective_network_mode(mode: NetworkMode, security_mode: SecurityMode) -> NetworkMode {
+    if security_mode.is_strict() || mode == NetworkMode::DenyAll {
+        mode
+    } else {
+        NetworkMode::AllowAll
+    }
+}
+
 fn handled_fs_access(abi: ABI, mode: NetworkMode) -> BitFlags<AccessFs> {
     let mut access = AccessFs::from_all(abi);
     if mode == NetworkMode::AllowAll {
@@ -229,16 +238,18 @@ pub fn compile(
     proxy_port: Option<u16>,
     probe: &ProbeResult,
     options: BackendOptions,
+    security_mode: SecurityMode,
 ) -> Result<CompiledLandlock, CoreError> {
     // 1. Lints.
     lint_allow_exec_for_priv_escalation(profile, options)?;
-    let forbidden_reads = build_forbidden_reads(profile)?;
-    lint_forbidden_reads_against_grants(profile, &forbidden_reads, options)?;
+    let forbidden_reads = build_forbidden_reads(profile, security_mode)?;
+    lint_forbidden_reads_against_grants(profile, &forbidden_reads, security_mode)?;
 
     let abi = highest_abi(probe);
+    let effective_network = effective_network_mode(profile.network_mode, security_mode);
     let ruleset = Ruleset::default()
         .set_compatibility(CompatLevel::HardRequirement)
-        .handle_access(handled_fs_access(abi, profile.network_mode))?;
+        .handle_access(handled_fs_access(abi, effective_network))?;
     // Signals are a process-isolation capability, not a network capability,
     // so keep them scoped even when the user explicitly requests AllowAll
     // networking. Abstract Unix sockets, on the other hand, are deliberately
@@ -246,7 +257,7 @@ pub fn compile(
     // Landlock domain and can signal/connect to one another.
     let ruleset = if probe.abi.supports_scopes() {
         let ruleset = ruleset.scope(Scope::Signal)?;
-        if profile.network_mode == NetworkMode::AllowAll {
+        if effective_network == NetworkMode::AllowAll {
             ruleset
         } else {
             ruleset.scope(Scope::AbstractUnixSocket)?
@@ -255,7 +266,7 @@ pub fn compile(
         ruleset
     };
     let ruleset =
-        if probe.abi.supports_net_port_filter() && profile.network_mode != NetworkMode::AllowAll {
+        if probe.abi.supports_net_port_filter() && effective_network != NetworkMode::AllowAll {
             ruleset.handle_access(AccessNet::ConnectTcp | AccessNet::BindTcp)?
         } else {
             ruleset
@@ -286,10 +297,23 @@ pub fn compile(
             &forbidden_reads,
             abi,
             &mut carved_entries,
+            UntrustedSymlinkBehavior::Reject,
         )?;
     }
     for sp in &profile.allow_read {
-        created = add_read_rule(created, sp, &forbidden_reads, abi, &mut carved_entries)?;
+        let symlink_behavior = if security_mode.is_strict() {
+            UntrustedSymlinkBehavior::Reject
+        } else {
+            UntrustedSymlinkBehavior::Follow
+        };
+        created = add_read_rule(
+            created,
+            sp,
+            &forbidden_reads,
+            abi,
+            &mut carved_entries,
+            symlink_behavior,
+        )?;
     }
 
     for sp in &profile.allow_write {
@@ -302,15 +326,21 @@ pub fn compile(
         } else {
             write_access(abi)
         };
-        created = add_write_rule(created, sp, access, abi)?;
+        let symlink_behavior = if security_mode.is_strict() {
+            UntrustedSymlinkBehavior::Reject
+        } else {
+            UntrustedSymlinkBehavior::Follow
+        };
+        created = add_write_rule(created, sp, access, abi, symlink_behavior)?;
         // Mutable caches and outputs must be readable to be useful, but they
         // remain non-executable. The forbidden-read lint rejects overlaps.
-        created = add_path_rules(
+        created = add_read_rule(
             created,
-            std::slice::from_ref(&sp.path),
-            read_access(abi),
+            sp,
+            &forbidden_reads,
             abi,
-            UntrustedSymlinkBehavior::Reject,
+            &mut carved_entries,
+            symlink_behavior,
         )?;
     }
     for path in BASELINE_WRITE_PATHS {
@@ -319,6 +349,7 @@ pub fn compile(
             &SandboxPath::file(PathBuf::from(path)),
             write_access(abi),
             abi,
+            UntrustedSymlinkBehavior::Reject,
         )?;
     }
 
@@ -334,7 +365,9 @@ pub fn compile(
         // omitting its rule is fail-closed and lets unrelated commands use
         // the profile. User/runtime grants remain strict because silently
         // ignoring an explicitly requested capability would be misleading.
-        let symlink_behavior = if index < profile.first_user_allow_exec {
+        let symlink_behavior = if !security_mode.is_strict() {
+            UntrustedSymlinkBehavior::Follow
+        } else if index < profile.first_user_allow_exec {
             UntrustedSymlinkBehavior::Skip
         } else {
             UntrustedSymlinkBehavior::Reject
@@ -350,7 +383,7 @@ pub fn compile(
 
     // Net rules — only on v4+. Loopback (proxy) or :443 fallback.
     if probe.abi.supports_net_port_filter() {
-        match profile.network_mode {
+        match effective_network {
             NetworkMode::Proxy => {
                 let port = proxy_port.ok_or_else(|| {
                     CoreError::Backend("proxy network mode has no live proxy port".to_owned())
@@ -377,25 +410,31 @@ fn add_read_rule(
     forbidden: &BTreeSet<PathBuf>,
     abi: ABI,
     visited: &mut usize,
+    symlink_behavior: UntrustedSymlinkBehavior,
 ) -> Result<RulesetCreated, CoreError> {
     use crate::config::PathKind;
 
+    let comparison_path = if symlink_behavior == UntrustedSymlinkBehavior::Follow {
+        canonicalize_if_present(&path.path)?
+    } else {
+        path.path.clone()
+    };
     if forbidden
         .iter()
-        .any(|denied| path_is_under(&path.path, denied))
+        .any(|denied| path_is_under(&comparison_path, denied))
     {
         return Ok(created);
     }
     let has_denied_descendant = forbidden
         .iter()
-        .any(|denied| denied != &path.path && path_is_under(denied, &path.path));
+        .any(|denied| denied != &comparison_path && path_is_under(denied, &comparison_path));
     if !has_denied_descendant {
         return add_path_rules(
             created,
             std::slice::from_ref(&path.path),
             read_access(abi),
             abi,
-            UntrustedSymlinkBehavior::Reject,
+            symlink_behavior,
         );
     }
     if !matches!(path.kind, PathKind::Subpath) {
@@ -404,10 +443,22 @@ fn add_read_rule(
             path.path.display()
         )));
     }
-    let Some(fd) = open_existing_safely(&path.path)? else {
+    let Some(fd) = open_existing_safely_with(&path.path, symlink_behavior)? else {
         return Ok(created);
     };
-    add_carved_read_directory(created, fd, &path.path, forbidden, abi, visited)
+    add_carved_read_directory(created, fd, &comparison_path, forbidden, abi, visited)
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode compares the opened referent with protected paths before launch"
+)]
+fn canonicalize_if_present(path: &Path) -> Result<PathBuf, CoreError> {
+    match std::fs::canonicalize(path) {
+        Ok(resolved) => Ok(resolved),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(path.to_path_buf()),
+        Err(error) => Err(CoreError::Io(error)),
+    }
 }
 
 #[allow(
@@ -509,11 +560,12 @@ fn add_write_rule(
     path: &SandboxPath,
     access: BitFlags<AccessFs>,
     abi: ABI,
+    symlink_behavior: UntrustedSymlinkBehavior,
 ) -> Result<RulesetCreated, CoreError> {
     use crate::config::PathKind;
     let fd = match path.kind {
-        PathKind::Subpath => Some(open_or_create_directory(&path.path)?),
-        PathKind::Literal => open_existing_safely(&path.path)?,
+        PathKind::Subpath => Some(open_or_create_directory(&path.path, symlink_behavior)?),
+        PathKind::Literal => open_existing_safely_with(&path.path, symlink_behavior)?,
         PathKind::Regex => {
             return Err(CoreError::ProfileLint(format!(
                 "regex write grants are not safely enforceable on Linux: '{}'",
@@ -553,13 +605,6 @@ fn access_for_fd(
     }
 }
 
-/// Open an existing path with no symlink or magic-link traversal. A distro
-/// symlink is accepted only if every original and canonical ancestor is
-/// root-owned and not group/world writable.
-fn open_existing_safely(path: &Path) -> Result<Option<OwnedFd>, CoreError> {
-    open_existing_safely_with(path, UntrustedSymlinkBehavior::Reject)
-}
-
 #[allow(
     clippy::disallowed_methods,
     reason = "the policy compiler runs synchronously in the pre-runtime Linux launcher"
@@ -582,6 +627,11 @@ fn open_existing_safely_with(
                 Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
                 Err(error) => return Err(CoreError::Io(error)),
             };
+            if symlink_behavior == UntrustedSymlinkBehavior::Follow {
+                return open_no_symlinks(&canonical, false)
+                    .map(Some)
+                    .map_err(CoreError::Io);
+            }
             if let Err(reason) = root_owned_chain(path) {
                 return handle_untrusted_symlink(path, &reason, symlink_behavior);
             }
@@ -603,6 +653,7 @@ fn handle_untrusted_symlink(
     behavior: UntrustedSymlinkBehavior,
 ) -> Result<Option<OwnedFd>, CoreError> {
     match behavior {
+        UntrustedSymlinkBehavior::Follow => unreachable!("follow is handled before validation"),
         UntrustedSymlinkBehavior::Reject => Err(CoreError::ProfileLint(format!(
             "allowlist path '{}' traverses an untrusted symlink: {reason}",
             path.display()
@@ -621,7 +672,18 @@ fn handle_untrusted_symlink(
 /// Atomically walk and create a writable directory using directory FDs. No
 /// component may be a symlink, so a concurrent rename cannot redirect the
 /// grant outside the requested path.
-fn open_or_create_directory(path: &Path) -> Result<OwnedFd, CoreError> {
+fn open_or_create_directory(
+    path: &Path,
+    symlink_behavior: UntrustedSymlinkBehavior,
+) -> Result<OwnedFd, CoreError> {
+    if symlink_behavior == UntrustedSymlinkBehavior::Follow {
+        let resolved = resolve_for_creation(path)?;
+        return open_or_create_directory_no_symlinks(&resolved);
+    }
+    open_or_create_directory_no_symlinks(path)
+}
+
+fn open_or_create_directory_no_symlinks(path: &Path) -> Result<OwnedFd, CoreError> {
     if !path.is_absolute() {
         return Err(CoreError::ProfileLint(format!(
             "sandbox path must be absolute: '{}'",
@@ -661,6 +723,41 @@ fn open_or_create_directory(path: &Path) -> Result<OwnedFd, CoreError> {
         current = next;
     }
     Ok(current)
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode snapshots trusted pre-existing symlinks before launching the child"
+)]
+fn resolve_for_creation(path: &Path) -> Result<PathBuf, CoreError> {
+    let mut existing = path;
+    let mut missing = Vec::new();
+    loop {
+        match std::fs::canonicalize(existing) {
+            Ok(mut resolved) => {
+                for component in missing.iter().rev() {
+                    resolved.push(component);
+                }
+                return Ok(resolved);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                let name = existing.file_name().ok_or_else(|| {
+                    CoreError::ProfileLint(format!(
+                        "sandbox path has no existing ancestor: '{}'",
+                        path.display()
+                    ))
+                })?;
+                missing.push(name.to_os_string());
+                existing = existing.parent().ok_or_else(|| {
+                    CoreError::ProfileLint(format!(
+                        "sandbox path has no parent: '{}'",
+                        path.display()
+                    ))
+                })?;
+            }
+            Err(error) => return Err(CoreError::Io(error)),
+        }
+    }
 }
 
 fn open_no_symlinks(path: &Path, directory: bool) -> std::io::Result<OwnedFd> {
@@ -767,19 +864,34 @@ fn root_owned_chain(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-fn build_forbidden_reads(profile: &SandboxProfile) -> Result<BTreeSet<PathBuf>, CoreError> {
+fn build_forbidden_reads(
+    profile: &SandboxProfile,
+    security_mode: SecurityMode,
+) -> Result<BTreeSet<PathBuf>, CoreError> {
     let mut set = BTreeSet::new();
     let mut inspected = 0_usize;
     for sp in &profile.deny_read {
         match open_no_symlinks(&sp.path, false) {
-            Ok(fd) => reject_aliased_forbidden_tree(&fd, &sp.path, &mut inspected)?,
+            Ok(fd) if security_mode.is_strict() => {
+                reject_aliased_forbidden_tree(&fd, &sp.path, &mut inspected)?;
+            }
+            Ok(_) => {}
             Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
             Err(error) if error.raw_os_error() == Some(libc::ELOOP) => {
-                return Err(CoreError::ProfileLint(format!(
-                    "denyRead path '{}' traverses a symlink; refusing a policy whose canonical \
-                     target could receive a read grant",
-                    sp.path.display()
-                )));
+                if security_mode.is_strict() {
+                    return Err(CoreError::ProfileLint(format!(
+                        "denyRead path '{}' traverses a symlink; refusing a policy whose \
+                         canonical target could receive a read grant",
+                        sp.path.display()
+                    )));
+                }
+                match std::fs::canonicalize(&sp.path) {
+                    Ok(resolved) => {
+                        set.insert(resolved);
+                    }
+                    Err(resolve_error) if resolve_error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(resolve_error) => return Err(CoreError::Io(resolve_error)),
+                }
             }
             Err(error) => return Err(CoreError::Io(error)),
         }
@@ -809,8 +921,8 @@ fn reject_aliased_forbidden_tree(
     if file_type == libc::S_IFREG {
         if stat.st_nlink > 1 {
             return Err(CoreError::ProfileLint(format!(
-                "denyRead file '{}' has {} hard links; Landlock cannot deny one pathname while \
-                 an alias grants the same inode",
+                "denyRead file '{}' has {} hard links; Landlock cannot deny one pathname while an \
+                 alias grants the same inode",
                 logical_path.display(),
                 stat.st_nlink,
             )));
@@ -867,12 +979,16 @@ fn reject_aliased_forbidden_tree(
 /// (indices `>= first_user_*`). Built-in defaults intentionally overlap
 /// denyRead in places such as `$PWD/.env`; those built-in read roots are
 /// compiled as carved descriptor rules instead of a broad parent grant.
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode compares pre-existing grant referents with protected paths before \
+              launch"
+)]
 fn lint_forbidden_reads_against_grants(
     profile: &SandboxProfile,
     forbidden: &BTreeSet<PathBuf>,
-    options: BackendOptions,
+    security_mode: SecurityMode,
 ) -> Result<(), CoreError> {
-    let _ = options;
     let user_slices: [(&str, &[SandboxPath]); 3] = [
         (
             "allowWrite",
@@ -889,8 +1005,18 @@ fn lint_forbidden_reads_against_grants(
     ];
     for (field, paths) in user_slices {
         for sp in paths {
+            let resolved = if security_mode.is_strict() {
+                None
+            } else {
+                std::fs::canonicalize(&sp.path).ok()
+            };
             for f in forbidden {
-                if path_is_under(f, &sp.path) || path_is_under(&sp.path, f) {
+                let overlaps = path_is_under(f, &sp.path)
+                    || path_is_under(&sp.path, f)
+                    || resolved
+                        .as_ref()
+                        .is_some_and(|path| path_is_under(f, path) || path_is_under(path, f));
+                if overlaps {
                     return Err(CoreError::ProfileLint(format!(
                         "denyRead path '{}' overlaps user-supplied {} entry '{}'. Landlock grants \
                          on allowWrite and allowExec include data-read, so this would silently \
@@ -1053,7 +1179,11 @@ mod tests {
         symlink(outside.path(), temp.path().join("redirect")).unwrap();
 
         let missing = temp.path().join("redirect/missing");
-        assert!(open_existing_safely(&missing).unwrap().is_none());
+        assert!(
+            open_existing_safely_with(&missing, UntrustedSymlinkBehavior::Reject)
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[test]
@@ -1066,11 +1196,17 @@ mod tests {
         symlink(target.path(), temp.path().join("redirect")).unwrap();
 
         let redirect = temp.path().join("redirect");
-        assert!(open_existing_safely(&redirect).is_err());
+        assert!(open_existing_safely_with(&redirect, UntrustedSymlinkBehavior::Reject).is_err());
         assert!(
             open_existing_safely_with(&redirect, UntrustedSymlinkBehavior::Skip)
                 .unwrap()
                 .is_none()
+        );
+        assert!(
+            open_existing_safely_with(&redirect, UntrustedSymlinkBehavior::Follow)
+                .unwrap()
+                .is_some(),
+            "standard mode should authorize the opened referent"
         );
     }
 
@@ -1128,9 +1264,9 @@ mod tests {
             path: PathBuf::from("/etc/ssh"),
             kind: PathKind::Subpath,
         });
-        let forbidden = build_forbidden_reads(&profile).unwrap();
+        let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
         let lint =
-            lint_forbidden_reads_against_grants(&profile, &forbidden, BackendOptions::default());
+            lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard);
         assert!(lint.is_ok(), "baseline anchor overlap must not lint");
     }
 
@@ -1151,10 +1287,9 @@ mod tests {
             path: PathBuf::from("/home/test"),
             kind: PathKind::Subpath,
         });
-        let forbidden = build_forbidden_reads(&profile).unwrap();
-        let err =
-            lint_forbidden_reads_against_grants(&profile, &forbidden, BackendOptions::default())
-                .unwrap_err();
+        let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+        let err = lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard)
+            .unwrap_err();
         assert!(format!("{err}").contains("denyRead"));
         assert!(format!("{err}").contains("allowRead"));
     }
@@ -1179,10 +1314,9 @@ mod tests {
             path: PathBuf::from("/home/test"),
             kind: PathKind::Subpath,
         });
-        let forbidden = build_forbidden_reads(&profile).unwrap();
-        let err =
-            lint_forbidden_reads_against_grants(&profile, &forbidden, BackendOptions::default())
-                .unwrap_err();
+        let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+        let err = lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard)
+            .unwrap_err();
         assert!(format!("{err}").contains("denyRead"));
         assert!(format!("{err}").contains("allowWrite"));
     }
@@ -1205,11 +1339,44 @@ mod tests {
             path: PathBuf::from("/home/test/.aws"),
             kind: PathKind::Subpath,
         });
-        let forbidden = build_forbidden_reads(&profile).unwrap();
-        let err =
-            lint_forbidden_reads_against_grants(&profile, &forbidden, BackendOptions::default())
-                .unwrap_err();
+        let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+        let err = lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard)
+            .unwrap_err();
         assert!(format!("{err}").contains("allowExec"));
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "synchronous filesystem setup is isolated to this Linux policy unit test"
+    )]
+    fn standard_symlink_grants_cannot_bypass_a_forbidden_referent() {
+        use std::os::unix::fs::symlink;
+
+        let home = tempfile::tempdir().unwrap();
+        let protected = home.path().join("protected");
+        std::fs::create_dir(&protected).unwrap();
+        let alias = home.path().join("ordinary-alias");
+        symlink(&protected, &alias).unwrap();
+
+        for field in ["allowRead", "allowWrite", "allowExec"] {
+            let mut profile =
+                SandboxProfile::for_ecosystem(Ecosystem::Rust, home.path(), home.path());
+            profile.deny_read = vec![SandboxPath::dir(protected.clone())];
+            let grant = SandboxPath::dir(alias.clone());
+            match field {
+                "allowRead" => profile.allow_read.push(grant),
+                "allowWrite" => profile.allow_write.push(grant),
+                "allowExec" => profile.allow_exec.push(grant),
+                _ => unreachable!(),
+            }
+
+            let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+            let error =
+                lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard)
+                    .unwrap_err();
+            assert!(format!("{error}").contains(field));
+        }
     }
 
     #[test]
@@ -1232,13 +1399,10 @@ mod tests {
                 _ => unreachable!(),
             }
 
-            let forbidden = build_forbidden_reads(&profile).unwrap();
-            let error = lint_forbidden_reads_against_grants(
-                &profile,
-                &forbidden,
-                BackendOptions::default(),
-            )
-            .unwrap_err();
+            let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+            let error =
+                lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard)
+                    .unwrap_err();
             assert!(format!("{error}").contains(field));
         }
     }
@@ -1260,8 +1424,12 @@ mod tests {
             SandboxProfile::for_ecosystem(Ecosystem::Rust, project.path(), project.path());
         profile.deny_read = vec![SandboxPath::file(denied)];
 
-        let error = build_forbidden_reads(&profile).unwrap_err();
+        let error = build_forbidden_reads(&profile, SecurityMode::Strict).unwrap_err();
         assert!(format!("{error}").contains("traverses a symlink"));
+
+        let standard = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+        assert!(standard.contains(&target));
+        assert!(standard.contains(&project.path().join(".env")));
     }
 
     #[test]
@@ -1279,7 +1447,7 @@ mod tests {
             SandboxProfile::for_ecosystem(Ecosystem::Rust, project.path(), project.path());
         profile.deny_read = vec![SandboxPath::file(denied)];
 
-        let error = build_forbidden_reads(&profile).unwrap_err();
+        let error = build_forbidden_reads(&profile, SecurityMode::Strict).unwrap_err();
         assert!(format!("{error}").contains("hard links"));
     }
 
@@ -1299,12 +1467,12 @@ mod tests {
             SandboxProfile::for_ecosystem(Ecosystem::Rust, project.path(), project.path());
         profile.deny_read = vec![SandboxPath::dir(denied_directory)];
 
-        let error = build_forbidden_reads(&profile).unwrap_err();
+        let error = build_forbidden_reads(&profile, SecurityMode::Strict).unwrap_err();
         assert!(format!("{error}").contains("hard links"));
     }
 
     #[test]
-    fn test_should_not_bypass_forbidden_read_overlap_under_allow_degraded() {
+    fn test_should_reject_forbidden_read_overlap_in_standard_mode() {
         let mut profile = SandboxProfile::for_ecosystem(
             Ecosystem::Rust,
             &PathBuf::from("/home/test"),
@@ -1319,16 +1487,12 @@ mod tests {
             path: PathBuf::from("/home/test"),
             kind: PathKind::Subpath,
         });
-        let forbidden = build_forbidden_reads(&profile).unwrap();
-        let res = lint_forbidden_reads_against_grants(
-            &profile,
-            &forbidden,
-            BackendOptions {
-                allow_degraded: true,
-                ..BackendOptions::default()
-            },
+        let forbidden = build_forbidden_reads(&profile, SecurityMode::Standard).unwrap();
+        let res = lint_forbidden_reads_against_grants(&profile, &forbidden, SecurityMode::Standard);
+        assert!(
+            res.is_err(),
+            "standard symlink support must not bypass denyRead"
         );
-        assert!(res.is_err(), "allow_degraded must not bypass the seal lint");
     }
 
     #[test]
@@ -1338,7 +1502,7 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         symlink(outside.path(), temp.path().join("redirect")).unwrap();
         let target = temp.path().join("redirect/cache");
-        assert!(open_or_create_directory(&target).is_err());
+        assert!(open_or_create_directory(&target, UntrustedSymlinkBehavior::Reject).is_err());
         assert!(!outside.path().join("cache").exists());
     }
 }

--- a/crates/core/src/sandbox/linux/landlock.rs
+++ b/crates/core/src/sandbox/linux/landlock.rs
@@ -298,18 +298,13 @@ pub fn compile(
         )?;
     }
     for sp in &profile.allow_read {
-        let symlink_behavior = if security_mode.is_strict() {
-            UntrustedSymlinkBehavior::Reject
-        } else {
-            UntrustedSymlinkBehavior::Follow
-        };
         created = add_read_rule(
             created,
             sp,
             &forbidden_reads,
             abi,
             &mut carved_entries,
-            symlink_behavior,
+            UntrustedSymlinkBehavior::Reject,
         )?;
     }
 
@@ -323,12 +318,11 @@ pub fn compile(
         } else {
             write_access(abi)
         };
-        let symlink_behavior = if security_mode.is_strict() {
-            UntrustedSymlinkBehavior::Reject
-        } else {
-            UntrustedSymlinkBehavior::Follow
-        };
-        created = add_write_rule(created, sp, access, abi, symlink_behavior)?;
+        // Standard mode has already replaced existing symlink grants with
+        // canonical snapshots. Reject here so missing paths are created via
+        // the descriptor-relative no-symlink walk and a parallel build cannot
+        // insert a late symlink between profile resolution and compilation.
+        created = add_write_rule(created, sp, access, abi, UntrustedSymlinkBehavior::Reject)?;
         // Mutable caches and outputs must be readable to be useful, but they
         // remain non-executable. The forbidden-read lint rejects overlaps.
         created = add_read_rule(
@@ -337,7 +331,7 @@ pub fn compile(
             &forbidden_reads,
             abi,
             &mut carved_entries,
-            symlink_behavior,
+            UntrustedSymlinkBehavior::Reject,
         )?;
     }
     for path in BASELINE_WRITE_PATHS {
@@ -350,21 +344,17 @@ pub fn compile(
         )?;
     }
 
-    // Exec allowlist (read+exec); covers shared libraries too. Per-entry
-    // policy: Follow for root-owned system paths (/lib, /usr/, /bin, …)
-    // because those are symlinks on usr-merge distros and only root can
-    // tamper with them; Refuse for anything else (notably $HOME-relative
-    // entries like ~/.cargo/bin/, ~/.nvm/) because a hostile earlier
-    // build can plant a symlink there.
+    // Exec allowlist (read+exec); covers shared libraries too. Standard mode
+    // supplies canonical snapshots, while strict mode skips unsafe optional
+    // built-in alternatives and rejects user/runtime aliases.
     for (index, sp) in profile.allow_exec.iter().enumerate() {
         // Built-in profiles list alternatives for multiple distributions and
         // tool managers. If an optional alias exists under a mutable parent,
         // omitting its rule is fail-closed and lets unrelated commands use
         // the profile. User/runtime grants remain strict because silently
         // ignoring an explicitly requested capability would be misleading.
-        let symlink_behavior = if !security_mode.is_strict() {
-            UntrustedSymlinkBehavior::Follow
-        } else if index < profile.first_user_allow_exec {
+        let symlink_behavior = if security_mode.is_strict() && index < profile.first_user_allow_exec
+        {
             UntrustedSymlinkBehavior::Skip
         } else {
             UntrustedSymlinkBehavior::Reject

--- a/crates/core/src/sandbox/linux/mod.rs
+++ b/crates/core/src/sandbox/linux/mod.rs
@@ -105,21 +105,13 @@ impl SandboxBackend for LinuxSandbox {
         pid_tx: Option<tokio::sync::oneshot::Sender<u32>>,
     ) -> impl std::future::Future<Output = Result<ExitStatus, CoreError>> + Send {
         let probe = self.probe.clone();
-        let options = self.options;
-        let security_mode = self.security_mode;
+        let options = exec::LauncherOptions::new(self.options, self.security_mode);
         let profile = profile.clone();
         let command = command.to_vec();
         let extra_env = extra_env.clone();
         async move {
             exec::run_sandboxed(
-                &profile,
-                proxy_port,
-                &command,
-                &extra_env,
-                &probe,
-                options,
-                security_mode,
-                pid_tx,
+                &profile, proxy_port, &command, &extra_env, &probe, options, pid_tx,
             )
             .await
         }

--- a/crates/core/src/sandbox/linux/mod.rs
+++ b/crates/core/src/sandbox/linux/mod.rs
@@ -23,7 +23,7 @@ pub use probe::ProbeResult;
 use crate::{
     error::CoreError,
     profile::SandboxProfile,
-    sandbox::{BackendInfo, BackendOptions, SandboxBackend},
+    sandbox::{BackendInfo, BackendOptions, SandboxBackend, SecurityMode},
 };
 
 /// Linux backend wrapping Landlock + seccomp-bpf.
@@ -31,6 +31,7 @@ use crate::{
 pub struct LinuxSandbox {
     info: BackendInfo,
     options: BackendOptions,
+    security_mode: SecurityMode,
     probe: ProbeResult,
 }
 
@@ -43,6 +44,14 @@ impl LinuxSandbox {
 
     /// Constructor with capability-specific runtime options.
     pub fn new_with_options(options: BackendOptions) -> Result<Self, CoreError> {
+        Self::new_with_mode(options, SecurityMode::Standard)
+    }
+
+    /// Constructor variant that selects the product-level security contract.
+    pub fn new_with_mode(
+        options: BackendOptions,
+        security_mode: SecurityMode,
+    ) -> Result<Self, CoreError> {
         let probe = probe::run()?;
         let features = probe.features();
         let info = BackendInfo {
@@ -53,6 +62,7 @@ impl LinuxSandbox {
         Ok(Self {
             info,
             options,
+            security_mode,
             probe,
         })
     }
@@ -82,6 +92,7 @@ impl SandboxBackend for LinuxSandbox {
             proxy_port,
             &self.probe,
             self.options,
+            self.security_mode,
         ))
     }
 
@@ -95,12 +106,20 @@ impl SandboxBackend for LinuxSandbox {
     ) -> impl std::future::Future<Output = Result<ExitStatus, CoreError>> + Send {
         let probe = self.probe.clone();
         let options = self.options;
+        let security_mode = self.security_mode;
         let profile = profile.clone();
         let command = command.to_vec();
         let extra_env = extra_env.clone();
         async move {
             exec::run_sandboxed(
-                &profile, proxy_port, &command, &extra_env, &probe, options, pid_tx,
+                &profile,
+                proxy_port,
+                &command,
+                &extra_env,
+                &probe,
+                options,
+                security_mode,
+                pid_tx,
             )
             .await
         }

--- a/crates/core/src/sandbox/linux/policy.rs
+++ b/crates/core/src/sandbox/linux/policy.rs
@@ -85,7 +85,7 @@ pub fn render(
     if probe.abi.supports_ioctl_dev() {
         let _ = writeln!(out, "      - ioctlDev");
     }
-    if probe.abi.supports_unix_path_filter() && effective_network != NetworkMode::AllowAll {
+    if probe.abi.supports_unix_path_filter() {
         let _ = writeln!(out, "      - resolveUnix");
     }
     if features.net_port_filter && effective_network != NetworkMode::AllowAll {
@@ -105,10 +105,20 @@ pub fn render(
 
     let _ = writeln!(out, "  pathBeneath:");
     for sp in &profile.allow_write {
+        let access = if probe.abi.supports_unix_path_filter()
+            && profile
+                .ephemeral_write_exec
+                .iter()
+                .any(|root| sp.path.starts_with(root))
+        {
+            "writeAllowlist+resolveUnix"
+        } else {
+            "writeAllowlist"
+        };
         let _ = writeln!(
             out,
-            "    - path: {}\n      access: writeAllowlist",
-            yaml_string(&sp.path.to_string_lossy())
+            "    - path: {}\n      access: {access}",
+            yaml_string(&sp.path.to_string_lossy()),
         );
     }
     for sp in &profile.allow_exec {
@@ -311,7 +321,7 @@ mod tests {
         let fs = handled["fs"].as_sequence().expect("filesystem rights");
 
         assert!(handled["net"].is_null());
-        assert!(!fs.iter().any(|right| right.as_str() == Some("resolveUnix")));
+        assert!(fs.iter().any(|right| right.as_str() == Some("resolveUnix")));
         let scoped = value["landlock"]["scoped"]
             .as_sequence()
             .expect("signal scope remains active");

--- a/crates/core/src/sandbox/linux/policy.rs
+++ b/crates/core/src/sandbox/linux/policy.rs
@@ -7,7 +7,7 @@ use std::fmt::Write;
 
 use crate::{
     profile::{NetworkMode, SandboxProfile},
-    sandbox::{BackendOptions, linux::probe::ProbeResult},
+    sandbox::{BackendOptions, SecurityMode, linux::probe::ProbeResult},
 };
 
 /// Render the live policy view for the given profile + proxy state.
@@ -16,6 +16,7 @@ pub fn render(
     proxy_port: Option<u16>,
     probe: &ProbeResult,
     options: BackendOptions,
+    security_mode: SecurityMode,
 ) -> String {
     let mut out = String::with_capacity(2048);
 
@@ -23,6 +24,15 @@ pub fn render(
     let _ = writeln!(out, "backend: landlock+seccomp");
     let _ = writeln!(out, "kernel: {}", yaml_string(&probe.kernel));
     let _ = writeln!(out, "landlockAbi: {}", probe.abi.as_str());
+    let _ = writeln!(
+        out,
+        "securityMode: {}",
+        if security_mode.is_strict() {
+            "strict"
+        } else {
+            "standard"
+        }
+    );
     let _ = writeln!(out, "legacyAllowDegraded: {}", options.allow_degraded);
     let _ = writeln!(
         out,
@@ -37,6 +47,12 @@ pub fn render(
         profile.network_mode == NetworkMode::Proxy
     );
     let _ = writeln!(out, "strictDomainEgressEnforced: false");
+    let effective_network =
+        if security_mode.is_strict() || profile.network_mode == NetworkMode::DenyAll {
+            profile.network_mode
+        } else {
+            NetworkMode::AllowAll
+        };
 
     // Resolved features
     let features = probe.features();
@@ -69,10 +85,10 @@ pub fn render(
     if probe.abi.supports_ioctl_dev() {
         let _ = writeln!(out, "      - ioctlDev");
     }
-    if probe.abi.supports_unix_path_filter() && profile.network_mode != NetworkMode::AllowAll {
+    if probe.abi.supports_unix_path_filter() && effective_network != NetworkMode::AllowAll {
         let _ = writeln!(out, "      - resolveUnix");
     }
-    if features.net_port_filter && profile.network_mode != NetworkMode::AllowAll {
+    if features.net_port_filter && effective_network != NetworkMode::AllowAll {
         let _ = writeln!(out, "    net:");
         let _ = writeln!(out, "      - connectTcp");
         let _ = writeln!(out, "      - bindTcp");
@@ -80,7 +96,7 @@ pub fn render(
     if probe.abi.supports_scopes() {
         let _ = writeln!(out, "  scoped:");
         let _ = writeln!(out, "    - signal");
-        if profile.network_mode != NetworkMode::AllowAll {
+        if effective_network != NetworkMode::AllowAll {
             let _ = writeln!(out, "    - abstractUnixSocket");
         }
     } else {
@@ -117,9 +133,9 @@ pub fn render(
         let _ = writeln!(out, "    - {}", yaml_string(&sp.path.to_string_lossy()));
     }
 
-    if features.net_port_filter && profile.network_mode != NetworkMode::AllowAll {
+    if features.net_port_filter && effective_network != NetworkMode::AllowAll {
         let _ = writeln!(out, "  netConnectTcp:");
-        match profile.network_mode {
+        match effective_network {
             NetworkMode::Proxy => {
                 if let Some(port) = proxy_port {
                     let _ = writeln!(out, "    - {port}");
@@ -148,8 +164,8 @@ pub fn render(
     for syscall in super::seccomp::ERRNO_LIST {
         let _ = writeln!(out, "        - {syscall}");
     }
-    if profile.network_mode != NetworkMode::AllowAll {
-        match profile.network_mode {
+    if effective_network != NetworkMode::AllowAll {
+        match effective_network {
             NetworkMode::DenyAll => {
                 let _ = writeln!(out, "        - socket(all families)");
             }
@@ -167,7 +183,7 @@ pub fn render(
     }
     if !features.net_port_filter
         && matches!(
-            profile.network_mode,
+            effective_network,
             NetworkMode::Proxy | NetworkMode::DirectHttps443
         )
     {
@@ -211,6 +227,14 @@ mod tests {
         }
     }
 
+    const fn strict_mode() -> SecurityMode {
+        SecurityMode::Strict
+    }
+
+    fn strict_options() -> BackendOptions {
+        BackendOptions::default()
+    }
+
     #[test]
     fn test_should_render_baseline_yaml() {
         let home = PathBuf::from("/home/test");
@@ -220,7 +244,8 @@ mod tests {
             &profile,
             Some(12345),
             &probe(LandlockAbi::V4),
-            BackendOptions::default(),
+            strict_options(),
+            strict_mode(),
         );
 
         assert!(out.starts_with("# sbe linux backend inspection"));
@@ -240,7 +265,8 @@ mod tests {
             &profile,
             Some(12345),
             &probe(LandlockAbi::V3),
-            BackendOptions::default(),
+            strict_options(),
+            strict_mode(),
         );
 
         assert!(!out.contains("netConnectTcp:"));
@@ -256,7 +282,8 @@ mod tests {
             &profile,
             Some(8000),
             &probe(LandlockAbi::V4),
-            BackendOptions::default(),
+            strict_options(),
+            strict_mode(),
         );
 
         let value: serde_yaml::Value = serde_yaml::from_str(&out).expect("policy YAML parses");
@@ -276,7 +303,8 @@ mod tests {
             &profile,
             None,
             &probe(LandlockAbi::V9),
-            BackendOptions::default(),
+            strict_options(),
+            strict_mode(),
         );
         let value: serde_yaml::Value = serde_yaml::from_str(&out).expect("policy YAML parses");
         let handled = &value["landlock"]["handled"];
@@ -301,7 +329,8 @@ mod tests {
             &profile,
             Some(12345),
             &probe(LandlockAbi::V9),
-            BackendOptions::default(),
+            strict_options(),
+            strict_mode(),
         );
         let value: serde_yaml::Value = serde_yaml::from_str(&out).expect("policy YAML parses");
         let scoped = value["landlock"]["scoped"]
@@ -334,6 +363,7 @@ mod tests {
             Some(12345),
             &probe(LandlockAbi::V5),
             BackendOptions::default(),
+            SecurityMode::Standard,
         );
         let value: serde_yaml::Value = serde_yaml::from_str(&out).expect("policy YAML parses");
 
@@ -357,6 +387,7 @@ mod tests {
             None,
             &probe(LandlockAbi::V3),
             BackendOptions::default(),
+            SecurityMode::Standard,
         );
 
         assert!(!out.contains("netFallback:"));

--- a/crates/core/src/sandbox/linux/seccomp.rs
+++ b/crates/core/src/sandbox/linux/seccomp.rs
@@ -21,7 +21,7 @@ use seccompiler::{
 use crate::{
     error::CoreError,
     profile::{NetworkMode, SandboxProfile},
-    sandbox::{BackendOptions, linux::probe::ProbeResult},
+    sandbox::{BackendOptions, SecurityMode, linux::probe::ProbeResult},
 };
 
 /// Syscalls killed outright when invoked from inside the sandbox.
@@ -97,6 +97,7 @@ pub fn compile(
     proxy_port: Option<u16>,
     probe: &ProbeResult,
     _options: BackendOptions,
+    security_mode: SecurityMode,
 ) -> Result<CompiledSeccomp, CoreError> {
     let target_arch = std::env::consts::ARCH
         .try_into()
@@ -127,7 +128,13 @@ pub fn compile(
             errno_rules.entry(nr).or_default();
         }
     }
-    add_network_socket_rules(&mut errno_rules, profile.network_mode)?;
+    let network_mode = if security_mode.is_strict() || profile.network_mode == NetworkMode::DenyAll
+    {
+        profile.network_mode
+    } else {
+        NetworkMode::AllowAll
+    };
+    add_network_socket_rules(&mut errno_rules, network_mode)?;
 
     // A pre-v4 `connect()` address filter is intentionally impossible here:
     // seccomp cannot inspect `copy_from_user`-backed sockaddrs, and matching
@@ -324,6 +331,7 @@ mod tests {
             Some(8080),
             &probe(LandlockAbi::V4),
             BackendOptions::default(),
+            SecurityMode::Strict,
         )
         .expect("seccomp compile");
         assert!(!compiled.kill.is_empty(), "kill filter empty");

--- a/crates/core/src/sandbox/macos/exec.rs
+++ b/crates/core/src/sandbox/macos/exec.rs
@@ -6,7 +6,11 @@ use tempfile::NamedTempFile;
 use tokio::process::Command;
 use tracing::debug;
 
-use crate::{error::CoreError, profile::SandboxProfile, sandbox::macos::sbpl};
+use crate::{
+    error::CoreError,
+    profile::SandboxProfile,
+    sandbox::{SecurityMode, macos::sbpl},
+};
 
 /// Spawn the user command under `sandbox-exec` and wait for it to exit.
 pub(super) async fn run_sandboxed(
@@ -14,10 +18,13 @@ pub(super) async fn run_sandboxed(
     proxy_port: Option<u16>,
     command: &[String],
     extra_env: &HashMap<String, String>,
+    security_mode: SecurityMode,
     pid_tx: Option<tokio::sync::oneshot::Sender<u32>>,
 ) -> Result<ExitStatus, CoreError> {
-    profile.validate_security_invariants()?;
-    let sbpl_text = sbpl::generate(profile, proxy_port)?;
+    if security_mode.is_strict() {
+        profile.validate_security_invariants()?;
+    }
+    let sbpl_text = sbpl::generate(profile, proxy_port, security_mode)?;
     let sbpl_file = write_sbpl_tempfile(&sbpl_text)?;
     let sbpl_path = sbpl_file.path().to_path_buf();
     debug!(path = %sbpl_path.display(), "wrote SBPL profile");

--- a/crates/core/src/sandbox/macos/mod.rs
+++ b/crates/core/src/sandbox/macos/mod.rs
@@ -8,13 +8,14 @@ use std::{collections::HashMap, path::Path, process::ExitStatus};
 use crate::{
     error::CoreError,
     profile::SandboxProfile,
-    sandbox::{BackendFeatures, BackendInfo, BackendOptions, SandboxBackend},
+    sandbox::{BackendFeatures, BackendInfo, BackendOptions, SandboxBackend, SecurityMode},
 };
 
 /// macOS backend wrapping `/usr/bin/sandbox-exec`.
 #[derive(Debug)]
 pub struct MacosSandbox {
     info: BackendInfo,
+    security_mode: SecurityMode,
 }
 
 impl MacosSandbox {
@@ -25,7 +26,15 @@ impl MacosSandbox {
 
     /// Constructor variant that takes [`BackendOptions`]; macOS ignores
     /// `allow_degraded` because there is no degraded path on this platform.
-    pub fn new_with_options(_options: BackendOptions) -> Result<Self, CoreError> {
+    pub fn new_with_options(options: BackendOptions) -> Result<Self, CoreError> {
+        Self::new_with_mode(options, SecurityMode::Standard)
+    }
+
+    /// Constructor variant that selects the product-level security contract.
+    pub fn new_with_mode(
+        _options: BackendOptions,
+        security_mode: SecurityMode,
+    ) -> Result<Self, CoreError> {
         if !Path::new("/usr/bin/sandbox-exec").exists() {
             return Err(CoreError::BackendUnavailable {
                 reason: "sandbox-exec not found at /usr/bin/sandbox-exec; this may indicate \
@@ -50,7 +59,10 @@ impl MacosSandbox {
                 audit_stream: false,
             },
         };
-        Ok(Self { info })
+        Ok(Self {
+            info,
+            security_mode,
+        })
     }
 }
 
@@ -68,7 +80,7 @@ impl SandboxBackend for MacosSandbox {
         profile: &SandboxProfile,
         proxy_port: Option<u16>,
     ) -> Result<String, CoreError> {
-        sbpl::generate(profile, proxy_port)
+        sbpl::generate(profile, proxy_port, self.security_mode)
     }
 
     fn run(
@@ -79,7 +91,14 @@ impl SandboxBackend for MacosSandbox {
         extra_env: &HashMap<String, String>,
         pid_tx: Option<tokio::sync::oneshot::Sender<u32>>,
     ) -> impl std::future::Future<Output = Result<ExitStatus, CoreError>> + Send {
-        exec::run_sandboxed(profile, proxy_port, command, extra_env, pid_tx)
+        exec::run_sandboxed(
+            profile,
+            proxy_port,
+            command,
+            extra_env,
+            self.security_mode,
+            pid_tx,
+        )
     }
 }
 

--- a/crates/core/src/sandbox/macos/sbpl.rs
+++ b/crates/core/src/sandbox/macos/sbpl.rs
@@ -1,9 +1,14 @@
-use std::{collections::BTreeSet, fmt::Write, path::Path};
+use std::{
+    collections::BTreeSet,
+    fmt::Write,
+    path::{Path, PathBuf},
+};
 
 use crate::{
     config::{PathKind, SandboxPath},
     error::CoreError,
     profile::{NetworkMode, SandboxProfile},
+    sandbox::SecurityMode,
 };
 
 /// Generate a Seatbelt Profile Language (SBPL) policy string from a `SandboxProfile`.
@@ -13,7 +18,11 @@ use crate::{
 /// - All reads allowed except explicit denylist (secrets)
 /// - All network denied except proxy/localhost
 /// - All risky process-exec denied
-pub fn generate(profile: &SandboxProfile, proxy_port: Option<u16>) -> Result<String, CoreError> {
+pub fn generate(
+    profile: &SandboxProfile,
+    proxy_port: Option<u16>,
+    security_mode: SecurityMode,
+) -> Result<String, CoreError> {
     let mut sb = String::with_capacity(4096);
 
     if profile.name.chars().any(char::is_control) {
@@ -32,7 +41,7 @@ pub fn generate(profile: &SandboxProfile, proxy_port: Option<u16>) -> Result<Str
     section_process(&mut sb, profile)?;
     section_file_read(&mut sb, profile)?;
     section_file_write(&mut sb, profile)?;
-    section_network(&mut sb, profile, proxy_port)?;
+    section_network(&mut sb, profile, proxy_port, security_mode)?;
     section_misc(&mut sb);
 
     Ok(sb)
@@ -76,12 +85,7 @@ fn section_file_read(sb: &mut String, profile: &SandboxProfile) -> Result<(), Co
             .chain(&profile.allow_write)
             .chain(&profile.allow_exec)
             .map(|sandbox_path| sandbox_path.path.as_path())
-            .chain(
-                profile
-                    .ephemeral_write_exec
-                    .iter()
-                    .map(|path| path.as_path()),
-            )
+            .chain(profile.ephemeral_write_exec.iter().map(PathBuf::as_path))
             .filter(|path| path.starts_with(shared))
             .collect();
         let mut ancestor_literals = BTreeSet::new();
@@ -175,6 +179,7 @@ fn section_network(
     sb: &mut String,
     profile: &SandboxProfile,
     proxy_port: Option<u16>,
+    security_mode: SecurityMode,
 ) -> Result<(), CoreError> {
     writeln!(sb, ";; Network").ok();
 
@@ -192,14 +197,26 @@ fn section_network(
             writeln!(sb, "(deny network*)").ok();
             writeln!(sb, "(allow network-outbound").ok();
             writeln!(sb, "    (remote tcp \"localhost:{port}\")").ok();
+            if !security_mode.is_strict() {
+                writeln!(sb, "    (remote ip \"localhost:*\")").ok();
+            }
             writeln!(sb, ")").ok();
+            if !security_mode.is_strict() {
+                writeln!(sb, "(allow network-inbound (local ip \"localhost:*\"))").ok();
+            }
         }
         NetworkMode::DirectHttps443 => {
             writeln!(sb, "(deny network*)").ok();
             writeln!(sb, "(allow network-outbound").ok();
             writeln!(sb, "    (remote tcp \"*:443\")").ok();
+            if !security_mode.is_strict() {
+                writeln!(sb, "    (remote ip \"localhost:*\")").ok();
+            }
             writeln!(sb, "    (literal \"/private/var/run/mDNSResponder\")").ok();
             writeln!(sb, ")").ok();
+            if !security_mode.is_strict() {
+                writeln!(sb, "(allow network-inbound (local ip \"localhost:*\"))").ok();
+            }
         }
     }
 
@@ -293,12 +310,16 @@ mod tests {
     use super::*;
     use crate::detect::Ecosystem;
 
+    const fn strict_options() -> SecurityMode {
+        SecurityMode::Strict
+    }
+
     #[test]
     fn test_should_generate_valid_sbpl_for_node() {
         let home = PathBuf::from("/Users/test");
         let pwd = PathBuf::from("/Users/test/project");
         let profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &pwd);
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
 
         assert!(sbpl.contains("(version 1)"));
         assert!(sbpl.contains("(deny default)"));
@@ -320,10 +341,22 @@ mod tests {
         let home = PathBuf::from("/Users/test");
         let pwd = PathBuf::from("/Users/test/project");
         let profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &pwd);
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
 
         assert!(sbpl.contains("(remote tcp \"localhost:12345\")"));
         assert!(!sbpl.contains("remote ip \"localhost:*\""));
+    }
+
+    #[test]
+    fn standard_proxy_mode_allows_local_build_services() {
+        let home = PathBuf::from("/Users/test");
+        let pwd = PathBuf::from("/Users/test/project");
+        let profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &pwd);
+        let sbpl = generate(&profile, Some(12345), SecurityMode::Standard).unwrap();
+
+        assert!(sbpl.contains("(remote tcp \"localhost:12345\")"));
+        assert!(sbpl.contains("(remote ip \"localhost:*\")"));
+        assert!(sbpl.contains("(allow network-inbound (local ip \"localhost:*\"))"));
     }
 
     #[test]
@@ -333,7 +366,7 @@ mod tests {
         let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &pwd);
         profile.allow_all_network = true;
         profile.recompute_network_mode();
-        let sbpl = generate(&profile, None).unwrap();
+        let sbpl = generate(&profile, None, strict_options()).unwrap();
 
         assert!(sbpl.contains("(allow network*)"));
         assert!(!sbpl.contains("(deny network*)"));
@@ -350,7 +383,7 @@ mod tests {
         profile
             .ephemeral_write_exec
             .push(PathBuf::from("/private/tmp/sbe-private"));
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
 
         assert!(sbpl.contains("/private/tmp/sbe-private"));
         assert_eq!(sbpl.matches("(subpath \"/private/tmp\")").count(), 1);
@@ -366,7 +399,7 @@ mod tests {
         let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &pwd);
         profile.enable_proxy = false;
         profile.recompute_network_mode();
-        let sbpl = generate(&profile, None).unwrap();
+        let sbpl = generate(&profile, None, strict_options()).unwrap();
 
         assert!(sbpl.contains("(remote tcp \"*:443\")"));
         assert!(!sbpl.contains("(remote ip \"localhost:*\")"));
@@ -380,7 +413,7 @@ mod tests {
         let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &pwd);
         profile.allow_domains.clear();
         profile.recompute_network_mode();
-        let sbpl = generate(&profile, None).unwrap();
+        let sbpl = generate(&profile, None, strict_options()).unwrap();
 
         assert!(sbpl.contains("(deny network*)"));
         assert!(!sbpl.contains("(remote tcp \"*:443\")"));
@@ -393,7 +426,7 @@ mod tests {
 
         for eco in Ecosystem::ALL {
             let profile = SandboxProfile::for_ecosystem(eco, &home, &pwd);
-            let sbpl = generate(&profile, Some(12345)).unwrap();
+            let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
             assert!(sbpl.contains("(version 1)"), "missing version for {eco}");
             assert!(
                 sbpl.contains("(deny default)"),
@@ -407,7 +440,7 @@ mod tests {
         let home = PathBuf::from("/Users/test");
         let pwd = PathBuf::from("/Users/test/project");
         let profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &pwd);
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
 
         // Individual binaries should be literal
         assert!(sbpl.contains("(literal \"/bin/sh\")"));
@@ -422,7 +455,7 @@ mod tests {
         let home = PathBuf::from("/Users/test");
         let pwd = PathBuf::from("/Users/test/project");
         let profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &pwd);
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
 
         // Should have scoped mach-lookup, not blanket allow
         assert!(sbpl.contains("(allow mach-lookup"));
@@ -440,7 +473,7 @@ mod tests {
         profile
             .allow_write
             .push(SandboxPath::file(PathBuf::from("/tmp/a\"b\\c")));
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
         assert!(sbpl.contains("(literal \"/tmp/a\\\"b\\\\c\")"));
     }
 
@@ -452,7 +485,7 @@ mod tests {
         profile
             .allow_write
             .push(SandboxPath::file(PathBuf::from("/tmp/a\nb")));
-        assert!(generate(&profile, Some(12345)).is_err());
+        assert!(generate(&profile, Some(12345), strict_options()).is_err());
     }
 
     #[test]
@@ -477,7 +510,7 @@ mod tests {
         let mut profile =
             SandboxProfile::for_ecosystem(Ecosystem::Rust, directory.path(), directory.path());
         profile.deny_read = vec![SandboxPath::dir(alias.clone())];
-        let sbpl = generate(&profile, Some(12345)).unwrap();
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
 
         assert!(sbpl.contains(&format!("(subpath \"{}\")", alias.display())));
         assert!(sbpl.contains(&format!("(subpath \"{}\")", canonical_protected.display())));

--- a/crates/core/src/sandbox/macos/sbpl.rs
+++ b/crates/core/src/sandbox/macos/sbpl.rs
@@ -220,7 +220,7 @@ fn section_network(
         }
     }
 
-    if !security_mode.is_strict() {
+    if !security_mode.is_strict() && profile.network_mode != NetworkMode::DenyAll {
         // Standard mode intentionally trusts ordinary same-user local build
         // services. Keep IP traffic constrained by the mode-specific rules
         // above while allowing pathname Unix-domain clients and servers.
@@ -442,6 +442,13 @@ mod tests {
 
         assert!(sbpl.contains("(deny network*)"));
         assert!(!sbpl.contains("(remote tcp \"*:443\")"));
+        assert!(!sbpl.contains("(local unix-socket)"));
+        assert!(!sbpl.contains("(remote unix-socket)"));
+
+        let standard = generate(&profile, None, SecurityMode::Standard).unwrap();
+        assert!(standard.contains("(deny network*)"));
+        assert!(!standard.contains("(local unix-socket)"));
+        assert!(!standard.contains("(remote unix-socket)"));
     }
 
     #[test]

--- a/crates/core/src/sandbox/macos/sbpl.rs
+++ b/crates/core/src/sandbox/macos/sbpl.rs
@@ -220,6 +220,18 @@ fn section_network(
         }
     }
 
+    if !security_mode.is_strict() {
+        // Standard mode intentionally trusts ordinary same-user local build
+        // services. Keep IP traffic constrained by the mode-specific rules
+        // above while allowing pathname Unix-domain clients and servers.
+        writeln!(
+            sb,
+            "(allow network-bind network-inbound (local unix-socket))"
+        )
+        .ok();
+        writeln!(sb, "(allow network-outbound (remote unix-socket))").ok();
+    }
+
     writeln!(sb).ok();
     Ok(())
 }
@@ -357,6 +369,19 @@ mod tests {
         assert!(sbpl.contains("(remote tcp \"localhost:12345\")"));
         assert!(sbpl.contains("(remote ip \"localhost:*\")"));
         assert!(sbpl.contains("(allow network-inbound (local ip \"localhost:*\"))"));
+        assert!(sbpl.contains("(allow network-bind network-inbound (local unix-socket))"));
+        assert!(sbpl.contains("(allow network-outbound (remote unix-socket))"));
+    }
+
+    #[test]
+    fn strict_proxy_mode_does_not_allow_ambient_unix_sockets() {
+        let home = PathBuf::from("/Users/test");
+        let pwd = PathBuf::from("/Users/test/project");
+        let profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &pwd);
+        let sbpl = generate(&profile, Some(12345), SecurityMode::Strict).unwrap();
+
+        assert!(!sbpl.contains("(local unix-socket)"));
+        assert!(!sbpl.contains("(remote unix-socket)"));
     }
 
     #[test]

--- a/crates/core/src/sandbox/mod.rs
+++ b/crates/core/src/sandbox/mod.rs
@@ -16,8 +16,9 @@
 
 use std::{collections::HashMap, process::ExitStatus};
 
-use crate::{error::CoreError, profile::SandboxProfile};
 use serde::{Deserialize, Serialize};
+
+use crate::{error::CoreError, profile::SandboxProfile};
 
 #[cfg(target_os = "macos")]
 mod macos;
@@ -119,4 +120,23 @@ pub struct BackendOptions {
     /// Explicit opt-in to Linux's destination-port-only compatibility mode.
     /// This never disables filesystem or privilege-escalation lints.
     pub allow_insecure_network: bool,
+}
+
+/// Product-level security contract selected for one sandbox invocation.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum SecurityMode {
+    /// Practical containment for ordinary builds and developer tooling.
+    #[default]
+    Standard,
+    /// Fail closed unless every high-assurance invariant is available.
+    Strict,
+}
+
+impl SecurityMode {
+    /// Whether this mode requires the strict 0.4 security boundary.
+    #[must_use]
+    pub const fn is_strict(self) -> bool {
+        matches!(self, Self::Strict)
+    }
 }

--- a/crates/proxy/src/server.rs
+++ b/crates/proxy/src/server.rs
@@ -88,12 +88,17 @@ impl ProxyEndpoint {
         )
     }
 
-    fn java_tool_options(&self, agent_path: &str, temp_path: &str) -> String {
+    fn java_tool_options(
+        &self,
+        agent_path: &str,
+        temp_path: &str,
+        non_proxy_hosts: &str,
+    ) -> String {
         format!(
             "-javaagent:{agent_path} -Djava.io.tmpdir={temp_path} -Dhttp.proxyHost=127.0.0.1 \
              -Dhttp.proxyPort={} -Dhttp.proxyProtocol=http -Dhttps.proxyHost=127.0.0.1 \
-             -Dhttps.proxyPort={} -Dhttps.proxyProtocol=http -Dhttp.nonProxyHosts= \
-             -Djdk.http.auth.tunneling.disabledSchemes=",
+             -Dhttps.proxyPort={} -Dhttps.proxyProtocol=http \
+             -Dhttp.nonProxyHosts={non_proxy_hosts} -Djdk.http.auth.tunneling.disabledSchemes=",
             self.port, self.port
         )
     }
@@ -104,11 +109,12 @@ impl ProxyEndpoint {
         &self,
         agent_path: &str,
         temp_path: &str,
+        non_proxy_hosts: &str,
     ) -> [(&'static str, String); 2] {
         [
             (
                 "JAVA_TOOL_OPTIONS",
-                self.java_tool_options(agent_path, temp_path),
+                self.java_tool_options(agent_path, temp_path, non_proxy_hosts),
             ),
             ("SBE_PROXY_TOKEN", self.token.clone()),
         ]
@@ -648,18 +654,31 @@ mod tests {
             port: 12345,
             token: "sentinel-token".to_owned(),
         };
-        let environment = endpoint.java_environment("/private/sbe/proxy-agent.jar", "/private/sbe");
+        let environment =
+            endpoint.java_environment("/private/sbe/proxy-agent.jar", "/private/sbe", "");
         let options = &environment[0].1;
 
         assert!(options.contains("-javaagent:/private/sbe/proxy-agent.jar"));
         assert!(options.contains("-Djava.io.tmpdir=/private/sbe"));
         assert!(options.contains("-Dhttp.proxyProtocol=http"));
         assert!(options.contains("-Dhttps.proxyProtocol=http"));
+        assert!(options.contains("-Dhttp.nonProxyHosts= "));
         assert!(options.contains("-Djdk.http.auth.tunneling.disabledSchemes="));
         assert!(!options.contains("sentinel-token"));
         assert_eq!(
             environment[1],
             ("SBE_PROXY_TOKEN", "sentinel-token".to_owned())
+        );
+
+        let standard = endpoint.java_environment(
+            "/private/sbe/proxy-agent.jar",
+            "/private/sbe",
+            "localhost|*.localhost|127.*|[::1]",
+        );
+        assert!(
+            standard[0]
+                .1
+                .contains("-Dhttp.nonProxyHosts=localhost|*.localhost|127.*|[::1]")
         );
     }
 

--- a/crates/proxy/src/server.rs
+++ b/crates/proxy/src/server.rs
@@ -90,13 +90,9 @@ impl ProxyEndpoint {
 
     fn java_tool_options(&self, agent_path: &str, temp_path: &str) -> String {
         format!(
-            "-javaagent:{agent_path} \
-             -Djava.io.tmpdir={temp_path} \
-             -Dhttp.proxyHost=127.0.0.1 -Dhttp.proxyPort={} \
-             -Dhttp.proxyProtocol=http \
-             -Dhttps.proxyHost=127.0.0.1 -Dhttps.proxyPort={} \
-             -Dhttps.proxyProtocol=http \
-             -Dhttp.nonProxyHosts= \
+            "-javaagent:{agent_path} -Djava.io.tmpdir={temp_path} -Dhttp.proxyHost=127.0.0.1 \
+             -Dhttp.proxyPort={} -Dhttp.proxyProtocol=http -Dhttps.proxyHost=127.0.0.1 \
+             -Dhttps.proxyPort={} -Dhttps.proxyProtocol=http -Dhttp.nonProxyHosts= \
              -Djdk.http.auth.tunneling.disabledSchemes=",
             self.port, self.port
         )

--- a/crates/proxy/tests/proxy_integration.rs
+++ b/crates/proxy/tests/proxy_integration.rs
@@ -23,7 +23,8 @@ async fn test_should_reject_non_allowed_domain() {
     stream
         .write_all(
             format!(
-                "CONNECT evil.com:443 HTTP/1.1\r\nHost: evil.com\r\nProxy-Authorization: {}\r\n\r\n",
+                "CONNECT evil.com:443 HTTP/1.1\r\nHost: evil.com\r\nProxy-Authorization: \
+                 {}\r\n\r\n",
                 endpoint.authorization_header()
             )
             .as_bytes(),
@@ -105,7 +106,8 @@ async fn test_should_allow_permitted_domain() {
     stream
         .write_all(
             format!(
-                "CONNECT localhost:{upstream_port} HTTP/1.1\r\nHost: localhost\r\nProxy-Authorization: {}\r\n\r\n",
+                "CONNECT localhost:{upstream_port} HTTP/1.1\r\nHost: \
+                 localhost\r\nProxy-Authorization: {}\r\n\r\n",
                 endpoint.authorization_header()
             )
             .as_bytes(),
@@ -236,7 +238,8 @@ async fn test_should_enforce_header_count_limit() {
     stream
         .write_all(
             format!(
-                "CONNECT registry.npmjs.org:443 HTTP/1.1\r\nProxy-Authorization: {}\r\nX-Extra: rejected\r\n\r\n",
+                "CONNECT registry.npmjs.org:443 HTTP/1.1\r\nProxy-Authorization: {}\r\nX-Extra: \
+                 rejected\r\n\r\n",
                 endpoint.authorization_header()
             )
             .as_bytes(),

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,6 +1,7 @@
 # sbe Architecture
 
-> **Status:** Current for SBE 0.4.0. Security requirements and finding IDs are
+> **Status:** Current for SBE 0.4.1. Standard mode is the default; `--strict`
+> retains the 0.4 fail-closed boundary. Security requirements and finding IDs are
 > defined in the [security hardening design](../specs/security-hardening-design.md).
 
 ## 1. Security model
@@ -11,15 +12,19 @@ the SBE host process are trusted. Stdin, stdout, and stderr are intentional
 capabilities; kernel vulnerabilities, resource exhaustion, and side channels
 are outside the boundary.
 
-The cross-platform invariants are:
+Both modes retain these cross-platform invariants:
 
-1. the child receives no ambient environment variables or file descriptors;
+1. the child receives no ambient file descriptors or high-confidence
+   credential/capability environment variables;
 2. an auto-discovered project configuration cannot expand authority without
    `--trust-project-config`;
-3. empty or unavailable policy components fail closed;
-4. persistent paths are not both writable and executable;
-5. the local proxy is authenticated, destination-restricted, and bounded; and
-6. capability output does not claim a guarantee the running backend lacks.
+3. an empty allowlist never becomes broader network access;
+4. the local proxy is authenticated, destination-restricted, and bounded; and
+5. capability output does not claim a guarantee the running backend lacks.
+
+Strict mode additionally uses a positive environment allowlist, rejects
+persistent W+X, denies ambient local services, keeps source writes narrow, and
+fails before launch when a requested high-assurance capability is unavailable.
 
 ## 2. Components
 
@@ -76,11 +81,11 @@ An enabled proxy with no domains resolves to `DenyAll`, never direct port 443.
 
 ## 4. Process launch and environment
 
-The child environment is cleared and rebuilt from a small positive allowlist,
-explicit `--keep-env`/`--env` grants, profile variables, and SBE-owned runtime
-variables. Proxy credentials, temporary paths, and output-directory variables
-are reserved. Inspection prints environment names and origins with every value
-redacted.
+The child environment is always rebuilt explicitly. Standard mode inherits
+ordinary build configuration after removing high-confidence secret, agent,
+dynamic-loader, and reserved variables. Strict mode uses the 0.4 positive
+allowlist. Explicit `--keep-env`/`--env` grants work in both modes. Inspection
+prints environment names and origins with every value redacted.
 
 Every descriptor above stderr is marked close-on-exec. macOS uses a bounded
 `fcntl` pass. Linux uses `close_range(CLOSE_RANGE_CLOEXEC)` with a bounded
@@ -91,8 +96,15 @@ Each invocation owns a canonical mode-0700 temporary root used for `TMPDIR`,
 on macOS they are also denied for reads except for paths explicitly belonging
 to the invocation.
 
-For Rust, Cargo's stable `build.build-dir` split keeps final artifacts in the
-non-executable `$PWD/target` grant and places intermediate objects, build
+In standard mode the workspace is writable and conventional output roots are
+writable+executable. Persistent workspace, cache, and install results are
+tainted. SBE recognizes only top-level install intent; it does not reproduce a
+package manager's lockfile and output grammar. An inherited
+`CARGO_TARGET_DIR` receives matching write and execute authority; otherwise
+standard Rust mode selects `$PWD/target` without parsing layered Cargo config.
+
+Under `--strict`, Cargo's stable `build.build-dir` split keeps final artifacts
+in the non-executable `$PWD/target` grant and places intermediate objects, build
 scripts, and procedural build tools in the private per-run W+X root. Commands
 that execute target artifacts, including cargo-nextest, use a private
 `CARGO_TARGET_DIR`. Node install commands keep `node_modules` writable and
@@ -105,12 +117,11 @@ and project-relocation flags are honored before policy preparation. Bun
 mutations select `bun.lock` and add `yarn.lock` only for `--yarn`. Python
 environment installation and execution apply the same invocation-specific
 write-or-execute split to project `.venv` and `venv` roots.
-All persistent outputs and caches remain tainted untrusted data; the sandbox
-does not certify them for later execution outside the boundary.
-Before launch, inode validation rejects a writable regular file unless every
-hard-link pathname is accounted for inside writable roots, even when an unseen
-alias is not executable. This prevents writable aliases from modifying source,
-workflow, toolchain, or other protected content.
+The sandbox never certifies persistent output for later execution outside the
+boundary. In strict mode, inode validation rejects a writable regular file
+unless every hard-link pathname is accounted for inside writable roots, even
+when an unseen alias is not executable. This prevents writable aliases from
+modifying source, workflow, toolchain, or other protected content.
 
 ## 5. macOS backend
 
@@ -123,9 +134,11 @@ The policy uses:
 
 - allow-most reads with explicit secret and shared-temp denials; secret rules
   cover both configured and canonical paths so symlinks cannot bypass them;
-- deny-by-default writes with output-specific grants;
+- deny-by-default writes with workspace/tool-data grants in standard mode and
+  output-specific grants in strict mode;
 - an executable allowlist plus explicit sensitive-binary denials;
-- only the exact authenticated proxy port in `Proxy` mode; and
+- the authenticated proxy plus localhost developer services in standard mode,
+  or only the exact proxy port in strict `Proxy` mode; and
 - a narrow Mach-service list that excludes `com.apple.SecurityServer`.
 
 The allow-most read model is a compatibility limitation, not a complete home
@@ -149,9 +162,10 @@ launcher:
 A dedicated status descriptor distinguishes setup failure from a target that
 itself exits 126.
 
-Linux paths use descriptor-relative `openat2` resolution with
-`RESOLVE_BENEATH`, `RESOLVE_NO_SYMLINKS`, and `RESOLVE_NO_MAGICLINKS`.
-Root-owned immutable distribution symlinks are the only exception. Landlock
+Linux paths use descriptor-backed resolution and always reject magic links.
+Standard mode follows an existing ordinary symlink to its opened referent;
+strict mode uses `RESOLVE_NO_SYMLINKS`, with root-owned immutable distribution
+aliases as the exception. Landlock
 read grants exclude `Execute`; write grants add only data-read rights, while
 execute grants are separate. Parent read trees are carved into safe inode
 rules when they contain a protected descendant such as `$PWD/.env`.
@@ -164,12 +178,12 @@ restricted network modes also scope abstract Unix sockets. ABI v9 additionally
 mediates connections to pathname Unix sockets. `sbe inspect` reports only the
 scopes supported and installed on the current kernel.
 
-Landlock ABI v4 can restrict a TCP destination **port**, not an address. SBE
-therefore refuses `Proxy` mode on Linux by default. The user must explicitly
-acknowledge the bypass with `--allow-insecure-linux-network`, ideally combined
-with a network namespace or trusted egress firewall. Proxy mode uses seccomp to
-reject Internet datagram/raw/packet sockets; direct-443 compatibility retains
-datagrams for libc DNS while still rejecting raw and packet sockets. The
+Landlock ABI v4 can restrict a TCP destination **port**, not an address.
+Standard mode therefore permits the TCP needed by local build services and
+reports external domain egress as best-effort; proxy-compatible clients still
+use the authenticated proxy. Strict proxy mode refuses unless the legacy
+`--allow-insecure-linux-network` compatibility acknowledgement is supplied,
+ideally together with a network namespace or trusted egress firewall. The
 syscall layer also blocks keyring access, cross-process descriptor duplication,
 `io_uring`, and old and new mount APIs that could bypass ordinary syscall or
 capability paths.

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -166,9 +166,10 @@ A dedicated status descriptor distinguishes setup failure from a target that
 itself exits 126.
 
 Linux paths use descriptor-backed resolution and always reject magic links.
-Standard mode follows an existing ordinary symlink to its opened referent;
-strict mode uses `RESOLVE_NO_SYMLINKS`, with root-owned immutable distribution
-aliases as the exception. Landlock
+Standard mode follows an existing ordinary symlink to its opened referent and
+snapshots source-tree symlink targets outside generated dependency/output
+directories; strict mode uses `RESOLVE_NO_SYMLINKS`, with root-owned immutable
+distribution aliases as the exception. Landlock
 read grants exclude `Execute`; write grants add only data-read rights, while
 execute grants are separate. Parent read trees are carved into safe inode
 rules when they contain a protected descendant such as `$PWD/.env`.

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -102,6 +102,9 @@ tainted. SBE recognizes only top-level install intent; it does not reproduce a
 package manager's lockfile and output grammar. An inherited
 `CARGO_TARGET_DIR` receives matching write and execute authority; otherwise
 standard Rust mode selects `$PWD/target` without parsing layered Cargo config.
+Workspace contents, including `.env*`, are readable in standard mode so Linux
+can grant general create/read/write semantics without package-manager-specific
+precreation. Strict mode retains project secret-file denials.
 
 Under `--strict`, Cargo's stable `build.build-dir` split keeps final artifacts
 in the non-executable `$PWD/target` grant and places intermediate objects, build

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,7 @@
 # Docs Index
 
 - [Architecture](arch.md) — Detailed system architecture: threat model, crate layout, execution lifecycle, profile resolution, SBPL generation, proxy subsystem, audit, security properties.
+
+## Research
+
+- [Historical sccache private IPC study](research/study-sccache-private-ipc.md) — Source study that informed, but was superseded by, the no-vendoring and no-managed-adapter decision.

--- a/docs/research/study-sccache-private-ipc.md
+++ b/docs/research/study-sccache-private-ipc.md
@@ -1,0 +1,140 @@
+# Study: sccache 0.17 private IPC under SBE
+
+Status: Done · Owner: SBE · Date: 2026-08-28 · Source revision:
+Upstream sccache commit `c037e117c7625a2668633574028a6addf2a96a6e`
+
+> **Historical research.** The private-IPC experiment remains valid evidence,
+> but [Usable Security Design](../../specs/usable-security-design.md) rejects a
+> product-specific managed sccache adapter and source vendoring.
+
+## Why this study
+
+SBE 0.4.0 blocks a globally configured Homebrew `sccache` before Cargo can
+query rustc. A project-level workaround must grant the resolved executable,
+cache writes, and `allowAllNetwork`, weakening the primary network boundary.
+This study answers whether SBE can support sccache with no ambient local
+service access and no broad network grant.
+
+## Architecture map
+
+```text
+SBE trusted parent
+│
+├─ creates mode-0700 per-run root
+│  ├─ startup notification socket
+│  └─ sccache server socket
+│
+└─ sandbox domain
+   ├─ managed sccache server ────────▶ persistent data-only cache
+   │          ▲                                  no execute right
+   │          │ private pathname UDS
+   │          ▼
+   ├─ sccache compiler clients
+   │          │ SCCACHE_CLIENT_SIDE=1
+   │          ▼
+   └─ rustc executes inside the same sandbox domain
+
+All Internet and ambient local-service connections remain governed by the
+ordinary SBE network mode.
+```
+
+## Hot path walkthrough
+
+1. sccache selects `SCCACHE_SERVER_UDS` before falling back to TCP
+   `127.0.0.1:4226`
+   ([commands.rs:46](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/commands.rs#L46)).
+2. If that socket is absent, the client creates a second startup-notification
+   Unix socket below `TMPDIR`, re-executes itself with
+   `SCCACHE_START_SERVER=1`, and waits for readiness
+   ([commands.rs:89](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/commands.rs#L89)).
+3. The server removes a stale pathname, binds the configured Unix listener,
+   and reports the actual address
+   ([server.rs:495](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/server.rs#L495)).
+4. With `SCCACHE_CLIENT_SIDE=1`, compiler discovery, hashing, cache-hit
+   materialization, fallback compilation, and output handling run in the CLI
+   process. The daemon implements cache storage IPC and stats aggregation
+   ([commands.rs:652](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/commands.rs#L652),
+   [Architecture.md:103](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/docs/Architecture.md#L103)).
+5. Without `SCCACHE_NO_DAEMON=1`, the server daemonizes
+   ([util.rs:900](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/util.rs#L900)). SBE 0.4.0 waits only
+   for the wrapped command and therefore does not own that detached lifetime
+   ([executor.rs:186](../../apps/cli/src/executor.rs#L186)).
+
+## Findings
+
+1. ✅ **A private pathname Unix socket is sufficient.** On macOS 26.5.2, a
+   policy denying `network*` and allowing only `network-bind`,
+   `network-inbound`, and `network-outbound` below one canonical private temp
+   directory successfully ran sccache 0.17.0 over UDS and returned rustc
+   1.98.0 version data. TCP and ambient Unix sockets were not granted.
+2. ✅ **Linux already has most of the filesystem-side primitive.** SBE grants
+   `ResolveUnix` only to the per-run 0700 root on Landlock ABI v9
+   ([landlock.rs:160](../../crates/core/src/sandbox/linux/landlock.rs#L160)).
+   Older ABIs need an explicit capability statement and kernel integration
+   coverage; they must not be described as path-mediated.
+3. ⚠️ **Client-side mode is necessary when using an external daemon, but an
+   environment variable alone is not a proof.** sccache ignores client-side
+   mode when error-file logging or distributed compilation is configured
+   ([config.rs:1364](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/config.rs#L1364)). A private
+   server inside the same sandbox domain removes the external-execution bypass
+   even if a future sccache version changes this mode.
+4. ⚠️ **Automatic daemonization is incompatible with structured cleanup.** A
+   detached server can outlive the command and the private temp directory.
+   SBE must start a foreground server itself, wait for readiness, terminate it
+   after the command, and reap it on every success, failure, cancellation, and
+   signal path.
+5. ⚠️ **The cache is persistent untrusted data.** The default macOS location is
+   `~/Library/Caches/Mozilla.sccache`, and upstream supports only one local
+   cache server at a time
+   ([Local.md:1](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/docs/Local.md#L1)). It must be writable
+   but never executable. Concurrent SBE invocations need one SBE-owned shared
+   server or isolated cache roots; starting independent servers against one
+   cache is invalid.
+6. ⚠️ **Trace logging can disclose compiler environment values.** The compile
+   request contains the environment passed to the compiler and is rendered
+   with `Debug` at trace level
+   ([commands.rs:404](https://github.com/mozilla/sccache/blob/c037e117c7625a2668633574028a6addf2a96a6e/src/commands.rs#L404)). The spike
+   confirmed that this includes environment values. SBE's cleared,
+   allowlisted environment remains mandatory, and tests must use synthetic
+   sentinel secrets to prove they never appear in logs.
+
+## What we will adopt
+
+- A private, canonical pathname socket under SBE's existing per-run root.
+- Narrow macOS socket rules for that root; no `allowAllNetwork` transition.
+- An SBE-owned foreground server lifecycle in the sandbox domain.
+- A data-only persistent cache grant and a minimal SBE-owned sccache config.
+- Client-side mode as defense in depth, not as the sole isolation mechanism.
+- Wrapper discovery that recognizes only the supported `sccache` adapter and
+  never turns an arbitrary project-configured wrapper into executable
+  authority.
+
+## What we will avoid
+
+- Connecting to the ambient TCP server at `127.0.0.1:4226`.
+- Connecting to an ambient pathname or abstract Unix socket.
+- `allowAllNetwork` or a generic localhost capability.
+- Letting sccache daemonize or survive the wrapped command.
+- Automatically granting an arbitrary `rustc-wrapper` path from project Cargo
+  configuration.
+- Treating cache contents as trusted executable artifacts.
+
+## Decision
+
+**GO with amendments.** Safe zero-config sccache support is feasible, but only
+as a first-class SBE Rust-tool adapter with private IPC and lifecycle
+supervision. Adding Homebrew paths and broad network permissions to the Rust
+profile is rejected.
+
+## Risks identified
+
+- macOS SBPL socket filters are an implementation detail and require a real
+  kernel integration test on each supported macOS release.
+- Linux ABI v1-v8 behavior must be reported precisely and tested separately
+  from ABI v9 pathname mediation.
+- Concurrent cache ownership needs an explicit lock/server-sharing decision
+  before implementation; upstream forbids independent servers over one local
+  cache.
+- sccache upgrades can change environment, config, or daemon semantics; pin an
+  integration fixture to the minimum supported version and test the latest
+  release in CI.

--- a/specs/index.md
+++ b/specs/index.md
@@ -5,3 +5,4 @@
 - [sbe Implementation Plan](sbe-impl-plan.md) — 3-phase roadmap: core sandbox → network proxy → audit & polish
 - [Cross-Platform Backend Design](cross-platform-backend-design.md) — `SandboxBackend` trait, macOS/Linux parity matrix, Landlock+seccomp port, per-OS profile defaults, phased migration
 - [Security Hardening Design](security-hardening-design.md) — Threat model, prioritized security findings, process/network/filesystem hardening, supply-chain controls, and adversarial acceptance tests
+- [Usable Security Design](usable-security-design.md) — SBE 0.4.1 product contract: usable standard mode, opt-in strict mode, referent-based symlink policy, no vendored tool adapters, and a control-by-control simplification audit

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -382,7 +382,8 @@ feature switches, terminal settings, and tool paths. It removes:
 - known credential variables independent of spelling convention, including
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
   platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
-  paths such as `AWS_WEB_IDENTITY_TOKEN_FILE`;
+  paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
+  as `AWS_SHARED_CREDENTIALS_FILE`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -350,6 +350,11 @@ reopens a mutable lexical link after its referent was approved. On Linux it
 opens the canonical final object with descriptor-relative kernel resolution,
 rejects magic links, validates the opened object's type and boundary, and
 installs the Landlock rule from that file descriptor.
+Before retaining a canonical built-in read or execute alias, SBE compares its
+referent with every protected read denial. This check includes project-local
+wrapper entries such as `gradlew` and `mvnw`, because Landlock execute authority
+also permits reading the executable inode. A built-in alias never overrides a
+protected read denial.
 When the final writable object is missing, policy resolution walks to the
 nearest existing ancestor, canonicalizes that ancestor, appends the unresolved
 suffix, and validates the reconstructed target against the same writable

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -240,7 +240,9 @@ Standard mode grants writes to:
 For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then a simple
 project `.npmrc` `cache=path`, user `~/.npmrc`, then the default `~/.npm`.
 An npm `--userconfig` or explicitly restored user-config locator selects the
-user layer and receives an exact read grant.
+user layer. The effective existing user configuration receives an exact read
+grant so the child npm, npx, or pnpm process sees the same configuration SBE
+used without opening the containing directory.
 pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
 `.npmrc` select its store in the same manner. The effective cache/store replaces
 the corresponding default writable grant; relative paths are anchored to the
@@ -252,7 +254,8 @@ For uv and pip commands, `--cache-dir` overrides the corresponding
 `UV_CACHE_DIR` or `PIP_CACHE_DIR`. uv then resolves a simple `cache-dir` from
 project `uv.toml`, or `[tool.uv]` in `pyproject.toml` when no adjacent
 `uv.toml` exists. pip resolves `cache-dir` from its legacy/current user
-configuration after environment overrides. `XDG_CACHE_HOME` and the
+configuration after environment overrides; each effective existing user
+configuration receives an exact read grant. `XDG_CACHE_HOME` and the
 conventional cache are the final fallback. The selected cache replaces only
 that tool's default grant; a repository-selected uv cache outside the workspace
 requires `--allow-write`. Conventional macOS caches live beneath

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -272,6 +272,9 @@ When a Node command starts in a declared monorepo member, bounded no-follow
 metadata discovery promotes the matching workspace root to readable input and
 grants only its manager-specific lockfile/dependency outputs for write and
 execution; it does not make the whole parent workspace writable.
+On Linux, missing selected root lockfiles are created with the descriptor-bound
+no-follow helper before Landlock, and source-symlink discovery starts once at
+the workspace root so linked root dependencies receive safe referent grants.
 
 Recognizing `cargo install` as install intent is acceptable; parsing Cargo
 metadata and recreating Cargo's installation transaction is not. The package
@@ -283,6 +286,8 @@ with `--root` guidance rather than granting a repository-selected external
 location or reproducing Cargo's layered configuration. Inspection must say
 that the selected install root is writable and that the installed result is
 untrusted.
+Cargo's writable `registry` and `git` dependency caches follow the same
+effective `CARGO_HOME`, while its credential files stay denied.
 
 Path grants derived from environment variables use the same final precedence
 as the child environment: trusted configuration and explicit CLI environment

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -253,6 +253,11 @@ arguments and CLI user properties override project configuration and JVM system
 properties. Relative selections are anchored to the command project; quoted,
 expanded, or otherwise ambiguous option values fail with guidance to use a
 direct unambiguous command property.
+Because `.mvn/maven.config` and `.mvn/jvm.config` are repository-controlled,
+their selected repository may expand authority automatically only inside the
+workspace or conventional `~/.m2/repository` namespace. An external referent
+requires a matching explicit writable grant; command and host-environment
+sources continue to represent direct user intent.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -259,6 +259,11 @@ Built-in profiles should remain small declarations of roots, domains, reserved
 environment names, and optional local IPC needs. They must not contain a second
 grammar for every supported package manager.
 
+Project-relocation options do not silently retarget an already resolved policy.
+Until configuration discovery and every grant are rooted at the requested
+project, both modes reject the option early and tell the user to change
+directory before invoking SBE.
+
 ### 6.2 Strict authority envelope
 
 Strict mode does not infer fine-grained output authority from arbitrary command

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -268,8 +268,9 @@ one Cargo target or install root and then launch Cargo with another.
 Explicit tool arguments remain higher precedence still: Cargo `--target-dir`
 overrides target environment/config paths, while Gradle's user-home flags and
 `gradle.user.home` system property override `GRADLE_OPTS` and
-`GRADLE_USER_HOME`. A `GRADLE_OPTS` value requiring shell expansion is rejected
-with guidance to use an explicit, unambiguous user-home mechanism.
+`JAVA_OPTS`, then `GRADLE_USER_HOME`. Repeated JVM properties use the last
+value. An inherited JVM-option value requiring shell expansion is rejected with
+guidance to use an explicit, unambiguous user-home mechanism.
 
 Built-in profiles should remain small declarations of roots, domains, reserved
 environment names, and optional local IPC needs. They must not contain a second

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -350,6 +350,12 @@ reopens a mutable lexical link after its referent was approved. On Linux it
 opens the canonical final object with descriptor-relative kernel resolution,
 rejects magic links, validates the opened object's type and boundary, and
 installs the Landlock rule from that file descriptor.
+When the final writable object is missing, policy resolution walks to the
+nearest existing ancestor, canonicalizes that ancestor, appends the unresolved
+suffix, and validates the reconstructed target against the same writable
+envelope. The launcher receives only that snapshot. Thus a cold cache such as
+`~/.cache -> /mnt/cache` with missing `~/.cache/coursier` works after
+`/mnt/cache/` is approved, without reopening the mutable home-directory link.
 For the built-in workspace read grant, standard mode discovers symlinks in the
 source tree without descending into conventional generated dependency and
 output directories, then installs separate read rules for safe external

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -277,7 +277,7 @@ as the child environment: trusted configuration and explicit CLI environment
 values override the parent environment. Policy compilation must not authorize
 one Cargo target or install root and then launch Cargo with another.
 Tool-native precedence must be preserved: Cargo `--target-dir` wins first,
-then Cargo target environment variables, then a direct
+then `CARGO_TARGET_DIR`, then `CARGO_BUILD_TARGET_DIR`, then a direct
 `--config build.target-dir='path'`. Gradle's user-home flags and
 `gradle.user.home` system property override `GRADLE_OPTS` and
 `JAVA_OPTS`, then `GRADLE_USER_HOME`. Repeated JVM properties use the last
@@ -420,7 +420,8 @@ feature switches, terminal settings, and tool paths. It removes:
   paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
   as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, `AZURE_CONFIG_DIR`, Azure
   client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker
-  client TLS key directories selected by `DOCKER_CERT_PATH`;
+  client TLS key directories selected by `DOCKER_CERT_PATH`, plus custom GitHub
+  CLI credential directories selected by `GH_CONFIG_DIR`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -255,6 +255,11 @@ An explicit `--root` is the selected install root and takes precedence over
 the selected install root is writable and that the installed result is
 untrusted.
 
+Path grants derived from environment variables use the same final precedence
+as the child environment: trusted configuration and explicit CLI environment
+values override the parent environment. Policy compilation must not authorize
+one Cargo target or install root and then launch Cargo with another.
+
 Built-in profiles should remain small declarations of roots, domains, reserved
 environment names, and optional local IPC needs. They must not contain a second
 grammar for every supported package manager.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -511,9 +511,13 @@ feature switches, terminal settings, and tool paths. It removes:
 - Python package configuration locators `PIP_CONFIG_FILE` and
   `UV_CONFIG_FILE`, and Poetry's `POETRY_CONFIG_DIR`, because those files or
   directories can contain authenticated indexes;
+- pip and uv index URL inputs, including primary/default and additional index
+  variables, because URLs can embed registry usernames and tokens;
 - Git's environment-backed configuration transports `GIT_CONFIG_COUNT`,
   `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, and `GIT_CONFIG_PARAMETERS`, because
-  they can carry authorization headers and other credentials directly;
+  they can carry authorization headers and other credentials directly, plus
+  `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` because those locators can select
+  files containing the same values;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -268,6 +268,10 @@ The workspace is also readable as one authority root in standard mode. Project
 them on Linux prevents general `O_RDWR` creation of new package-manager files
 and leads back to per-tool precreation. Credentials that must remain secret from
 dependencies belong outside an untrusted workspace or require strict mode.
+When a Node command starts in a declared monorepo member, bounded no-follow
+metadata discovery promotes the matching workspace root to readable input and
+grants only its manager-specific lockfile/dependency outputs for write and
+execution; it does not make the whole parent workspace writable.
 
 Recognizing `cargo install` as install intent is acceptable; parsing Cargo
 metadata and recreating Cargo's installation transaction is not. The package
@@ -431,8 +435,9 @@ feature switches, terminal settings, and tool paths. It removes:
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
   platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN` and GitLab's
   `CI_JOB_JWT` / `CI_JOB_JWT_V2`, plus OIDC bearer paths such as
-  `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
-  as `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`,
+  `AWS_WEB_IDENTITY_TOKEN_FILE` and `ARM_OIDC_TOKEN_FILE_PATH`, certificate
+  locators such as `ARM_CLIENT_CERTIFICATE_PATH`, and custom credential stores
+  such as `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`,
   `AZURE_CONFIG_DIR`, Azure
   client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker
   client TLS key directories selected by `DOCKER_CERT_PATH`, custom GitHub CLI

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -256,12 +256,14 @@ repository-selected external path requires `--allow-write`.
 For uv and pip commands, `--cache-dir` overrides the corresponding
 `UV_CACHE_DIR` or `PIP_CACHE_DIR`. uv then resolves a simple `cache-dir` from
 project `uv.toml`, or `[tool.uv]` in `pyproject.toml` when no adjacent
-`uv.toml` exists. pip resolves `cache-dir` from its legacy/current user
-configuration after environment overrides; each effective existing user
-configuration receives an exact read grant. `XDG_CACHE_HOME` and the
-conventional cache are the final fallback. The selected cache replaces only
-that tool's default grant; a repository-selected uv cache outside the workspace
-requires `--allow-write`. Conventional macOS caches live beneath
+`uv.toml` exists, then its XDG user `uv.toml`. An explicit `--config-file` or
+restored `UV_CONFIG_FILE` replaces discovered files. Selected user/explicit
+files receive exact read grants. pip resolves `cache-dir` from its
+legacy/current user configuration after environment overrides; each effective
+existing user configuration receives an exact read grant. `XDG_CACHE_HOME` and
+the conventional cache are the final fallback. The selected cache replaces
+only that tool's default grant; a repository-selected uv cache outside the
+workspace requires `--allow-write`. Conventional macOS caches live beneath
 `~/Library/Caches`; Linux follows XDG conventions.
 Poetry follows command `--cache-dir`, `POETRY_CACHE_DIR`, project
 `poetry.toml`, global `config.toml`, then `XDG_CACHE_HOME`. The effective global

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -238,10 +238,11 @@ Standard mode grants writes to:
   an install operation.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
-user home: `--gradle-user-home`/`-g`, inherited `GRADLE_USER_HOME`, then
-`~/.gradle`. Relative selections are anchored to the command's project. Only
-runtime subdirectories such as caches, wrapper distributions, daemons, and
-toolchains are writable; the user-home root and `init.d` remain immutable.
+user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,
+inherited `GRADLE_USER_HOME`, then `~/.gradle`. Relative selections are anchored
+to the command's project. Only runtime subdirectories such as `.tmp`, caches,
+wrapper distributions, daemons, and toolchains are writable; the user-home root
+and `init.d` remain immutable.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and
@@ -266,7 +267,8 @@ as the child environment: trusted configuration and explicit CLI environment
 values override the parent environment. Policy compilation must not authorize
 one Cargo target or install root and then launch Cargo with another.
 Explicit tool arguments remain higher precedence still: Cargo `--target-dir`
-overrides target environment/config paths, while Gradle's user-home flags and
+overrides direct `--config build.target-dir='path'` and target environment
+paths, while Gradle's user-home flags and
 `gradle.user.home` system property override `GRADLE_OPTS` and
 `JAVA_OPTS`, then `GRADLE_USER_HOME`. Repeated JVM properties use the last
 value. An inherited JVM-option value requiring shell expansion is rejected with

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -260,6 +260,9 @@ conventional cache are the final fallback. The selected cache replaces only
 that tool's default grant; a repository-selected uv cache outside the workspace
 requires `--allow-write`. Conventional macOS caches live beneath
 `~/Library/Caches`; Linux follows XDG conventions.
+Poetry follows command `--cache-dir`, `POETRY_CACHE_DIR`, then
+`XDG_CACHE_HOME`; its selected `pypoetry` cache replaces the conventional
+writable grants, including both historical macOS-compatible locations.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -325,7 +325,9 @@ file descriptor. It does not require `RESOLVE_NO_SYMLINKS` for ordinary grants.
 For the built-in workspace read grant, standard mode discovers symlinks in the
 source tree without descending into conventional generated dependency and
 output directories, then installs separate read rules for safe external
-referents. Referents overlapping protected read denials are omitted.
+referents. External directory referents are inspected for nested source links;
+canonical directory identities break cycles. Referents overlapping protected
+read denials are omitted.
 
 On macOS it resolves and validates the target before rendering both necessary
 SBPL spellings. Because the untrusted child has not started and cannot write

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -434,6 +434,11 @@ still removed, but standard mode does not claim isolation from discoverable
 local services. Strict mode permits only SBE-owned proxy/private IPC endpoints
 explicitly present in the final policy.
 
+When the external proxy is active, standard mode injects localhost-only
+`NO_PROXY`/`no_proxy` and Java `http.nonProxyHosts` values so ordinary clients
+actually use the permitted loopback path. Strict mode keeps those bypasses
+empty.
+
 ### 9.2 Linux
 
 Landlock destination-port filtering is not domain filtering and cannot express

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -273,8 +273,11 @@ Recognizing `cargo install` as install intent is acceptable; parsing Cargo
 metadata and recreating Cargo's installation transaction is not. The package
 manager owns its destination format, locking, overwrite behavior, and rollback.
 An explicit `--root` is the selected install root and takes precedence over
-`CARGO_INSTALL_ROOT`, `CARGO_HOME`, and the default. Inspection must say that
-the selected install root is writable and that the installed result is
+`CARGO_INSTALL_ROOT`, a direct `--config install.root='path'`, `CARGO_HOME`, and
+the default. An implicit Cargo config install root is rejected before launch
+with `--root` guidance rather than granting a repository-selected external
+location or reproducing Cargo's layered configuration. Inspection must say
+that the selected install root is writable and that the installed result is
 untrusted.
 
 Path grants derived from environment variables use the same final precedence
@@ -283,7 +286,9 @@ values override the parent environment. Policy compilation must not authorize
 one Cargo target or install root and then launch Cargo with another.
 Tool-native precedence must be preserved: Cargo `--target-dir` wins first,
 then `CARGO_TARGET_DIR`, then `CARGO_BUILD_TARGET_DIR`, then a direct
-`--config build.target-dir='path'`. Gradle's user-home flags and
+`--config build.target-dir='path'`. Cargo install uses `--root`, then
+`CARGO_INSTALL_ROOT`, then a direct `--config install.root='path'`, then
+`CARGO_HOME` and the default. Gradle's user-home flags and
 `gradle.user.home` system property override `GRADLE_OPTS` and
 `JAVA_OPTS`, then `GRADLE_USER_HOME`. Repeated JVM properties use the last
 value. An inherited JVM-option value requiring shell expansion is rejected with
@@ -422,8 +427,9 @@ feature switches, terminal settings, and tool paths. It removes:
   passwords, private keys, and cloud credentials;
 - known credential variables independent of spelling convention, including
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
-  platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
-  paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
+  platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN` and GitLab's
+  `CI_JOB_JWT` / `CI_JOB_JWT_V2`, plus OIDC bearer paths such as
+  `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
   as `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`,
   `AZURE_CONFIG_DIR`, Azure
   client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -434,7 +434,9 @@ feature switches, terminal settings, and tool paths. It removes:
   `AZURE_CONFIG_DIR`, Azure
   client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker
   client TLS key directories selected by `DOCKER_CERT_PATH`, plus custom GitHub
-  CLI credential directories selected by `GH_CONFIG_DIR`;
+  CLI credential directories selected by `GH_CONFIG_DIR`; Cargo credential
+  files beneath the effective `CARGO_HOME` receive matching path denials rather
+  than withholding the ordinary Cargo configuration locator;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -239,6 +239,8 @@ Standard mode grants writes to:
 
 For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then a simple
 project `.npmrc` `cache=path`, user `~/.npmrc`, then the default `~/.npm`.
+An npm `--userconfig` or explicitly restored user-config locator selects the
+user layer and receives an exact read grant.
 pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
 `.npmrc` select its store in the same manner. The effective cache/store replaces
 the corresponding default writable grant; relative paths are anchored to the
@@ -246,7 +248,10 @@ command project. A repository-selected external path requires `--allow-write`.
 
 For uv and pip commands, `--cache-dir` overrides the corresponding
 `UV_CACHE_DIR` or `PIP_CACHE_DIR`, followed by `XDG_CACHE_HOME` and the
-conventional cache. The selected cache replaces only that tool's default grant.
+conventional cache. pip also resolves `cache-dir` from its legacy/current user
+configuration after environment overrides. The selected cache replaces only
+that tool's default grant. Conventional macOS caches live beneath
+`~/Library/Caches`; Linux follows XDG conventions.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -244,13 +244,18 @@ user layer and receives an exact read grant.
 pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
 `.npmrc` select its store in the same manner. The effective cache/store replaces
 the corresponding default writable grant; relative paths are anchored to the
-command project. A repository-selected external path requires `--allow-write`.
+command project. Without an override, `PNPM_HOME/store` precedes the XDG and
+conventional defaults. A repository-selected external path requires
+`--allow-write`.
 
 For uv and pip commands, `--cache-dir` overrides the corresponding
-`UV_CACHE_DIR` or `PIP_CACHE_DIR`, followed by `XDG_CACHE_HOME` and the
-conventional cache. pip also resolves `cache-dir` from its legacy/current user
-configuration after environment overrides. The selected cache replaces only
-that tool's default grant. Conventional macOS caches live beneath
+`UV_CACHE_DIR` or `PIP_CACHE_DIR`. uv then resolves a simple `cache-dir` from
+project `uv.toml`, or `[tool.uv]` in `pyproject.toml` when no adjacent
+`uv.toml` exists. pip resolves `cache-dir` from its legacy/current user
+configuration after environment overrides. `XDG_CACHE_HOME` and the
+conventional cache are the final fallback. The selected cache replaces only
+that tool's default grant; a repository-selected uv cache outside the workspace
+requires `--allow-write`. Conventional macOS caches live beneath
 `~/Library/Caches`; Linux follows XDG conventions.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
@@ -285,8 +290,10 @@ command and host-environment sources continue to represent direct user intent.
 Explicit user/global settings files and the effective user `.m2` directory are
 granted read-only access; only the selected repository receives write access.
 A settings path selected by repository-controlled Maven config must stay inside
-the workspace or receive explicit `--allow-read` approval. Built-in secret
-denials remain sealed even against an explicit read grant.
+the workspace or receive explicit `--allow-read` approval. The same read gate
+applies when project `.mvn/jvm.config` changes `user.home` and therefore the
+effective `.m2` directory. Built-in secret denials remain sealed even against
+an explicit read grant.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -244,6 +244,10 @@ pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
 the corresponding default writable grant; relative paths are anchored to the
 command project. A repository-selected external path requires `--allow-write`.
 
+For uv and pip commands, `--cache-dir` overrides the corresponding
+`UV_CACHE_DIR` or `PIP_CACHE_DIR`, followed by `XDG_CACHE_HOME` and the
+conventional cache. The selected cache replaces only that tool's default grant.
+
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,
 inherited `GRADLE_USER_HOME`, then `~/.gradle`. Relative selections are anchored
@@ -474,6 +478,8 @@ feature switches, terminal settings, and tool paths. It removes:
   withheld because they commonly contain registry authentication tokens, as
   are Kerberos ticket-cache/keytab locators `KRB5CCNAME`, `KRB5_KTNAME`, and
   `KRB5_CLIENT_KTNAME`, plus the custom netrc locator `NETRC`;
+- Python package configuration locators `PIP_CONFIG_FILE` and
+  `UV_CONFIG_FILE`, because those files can contain authenticated indexes;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -237,9 +237,10 @@ Standard mode grants writes to:
 - an installation root only when the user's top-level command clearly requests
   an install operation.
 
-For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then the
-default `~/.npm`. The effective cache replaces the default writable grant;
-relative paths are anchored to the command project.
+For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then a simple
+project `.npmrc` `cache=path`, then the default `~/.npm`. The effective cache
+replaces the default writable grant; relative paths are anchored to the command
+project. A repository-selected external cache requires `--allow-write`.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,
@@ -272,6 +273,9 @@ namespace. An external referent requires a matching explicit writable grant;
 command and host-environment sources continue to represent direct user intent.
 Explicit user/global settings files and the effective user `.m2` directory are
 granted read-only access; only the selected repository receives write access.
+A settings path selected by repository-controlled Maven config must stay inside
+the workspace or receive explicit `--allow-read` approval. Built-in secret
+denials remain sealed even against an explicit read grant.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -237,6 +237,10 @@ Standard mode grants writes to:
 - an installation root only when the user's top-level command clearly requests
   an install operation.
 
+For Gradle commands, the conventional cache grant follows Gradle's effective
+user home: `--gradle-user-home`/`-g`, inherited `GRADLE_USER_HOME`, then
+`~/.gradle`. Relative selections are anchored to the command's project.
+
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and
 system locations remain outside the envelope.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -420,6 +420,13 @@ injected proxy settings, but capability output labels external egress
 `bestEffort`. SBE keeps the filesystem, environment, descriptor, privilege,
 and proxy defenses instead of refusing the entire command.
 
+On Landlock ABI v9 and newer, filesystem-backed Unix-socket resolution remains
+mediated independently of TCP policy. Standard mode grants it only beneath the
+private per-run root used by cooperating build processes; capability brokers
+such as `/var/run/docker.sock` remain outside the envelope. Older kernels
+cannot enforce pathname socket mediation and must report it unavailable rather
+than imply that unrestricted TCP also authorizes ambient filesystem sockets.
+
 Strict Linux domain egress remains unavailable until a destination-aware
 backend exists. This limitation is a capability result, not a command-line
 option named “insecure” that every Linux user must routinely paste.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -317,6 +317,10 @@ Examples:
   offers a one-time or durable narrow approval; it does not tell the user to
   remove the symlink.
 - `$PWD/output -> ~/.ssh` is not authorized by the built-in workspace grant.
+- `~/.npm -> ~/.config/autostart` is not authorized by the built-in cache
+  grant; the user must explicitly grant the resolved target if that unusual
+  layout is intentional. A link into `~/.cache` or `~/Library/Caches` remains
+  inside the conventional cache envelope.
 - A source symlink into an ordinary sibling checkout is readable in standard
   mode, but a symlink into `~/.aws` remains denied.
 
@@ -366,7 +370,8 @@ feature switches, terminal settings, and tool paths. It removes:
 
 - names matching a maintained high-confidence secret pattern such as tokens,
   passwords, private keys, and cloud credentials;
-- known credential variables independent of spelling convention;
+- known credential variables independent of spelling convention, including
+  prefix-encoded forms such as Terraform's `TF_TOKEN_<host>`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -160,6 +160,7 @@ Standard mode protects:
 Standard mode deliberately does not protect:
 
 - integrity of the current workspace;
+- confidentiality of files placed inside the selected workspace;
 - integrity or confidentiality of declared package caches and build outputs;
 - future execution of artifacts written during this or an earlier invocation;
 - local development services and build daemons needed by ordinary tooling;
@@ -239,6 +240,12 @@ Standard mode grants writes to:
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and
 system locations remain outside the envelope.
+
+The workspace is also readable as one authority root in standard mode. Project
+`.env*` files are therefore not a separate confidentiality boundary: carving
+them on Linux prevents general `O_RDWR` creation of new package-manager files
+and leads back to per-tool precreation. Credentials that must remain secret from
+dependencies belong outside an untrusted workspace or require strict mode.
 
 Recognizing `cargo install` as install intent is acceptable; parsing Cargo
 metadata and recreating Cargo's installation transaction is not. The package
@@ -548,7 +555,8 @@ prevent launch.
 
 ### 14.2 Standard security
 
-Existing hostile fixtures must still fail to read known credential files,
+Existing hostile fixtures must still fail to read known host credential files
+outside the workspace,
 inherit sentinel credential environment variables or descriptors, modify
 shell/SSH persistence targets outside the workspace, invoke privilege
 escalation successfully, or exhaust/crash the trusted proxy. Tests separately

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -245,8 +245,11 @@ wrapper distributions, daemons, and toolchains are writable; the user-home root
 and `init.d` remain immutable.
 
 For Maven commands, `-D`/`--define maven.repo.local=path` selects the writable
-local repository and replaces the default `~/.m2/repository` write grant.
-Relative selections are anchored to the command project.
+local repository, followed in precedence by `MAVEN_OPTS`, project
+`.mvn/jvm.config`, and the default `~/.m2/repository`. Within JVM option sources
+the last property wins, matching Java. Relative selections are anchored to the
+command project; quoted, expanded, or otherwise ambiguous option values fail
+with guidance to use a direct unambiguous command property.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -301,7 +301,9 @@ grammar for every supported package manager.
 Project-relocation options do not silently retarget an already resolved policy.
 Until configuration discovery and every grant are rooted at the requested
 project, both modes reject the option early and tell the user to change
-directory before invoking SBE.
+directory before invoking SBE. Cargo `--manifest-path` remains usable when its
+resolved manifest stays inside the selected workspace, including release
+workflow subcrates, but an external manifest receives the same early guidance.
 
 ### 6.2 Strict authority envelope
 
@@ -433,10 +435,12 @@ feature switches, terminal settings, and tool paths. It removes:
   as `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`,
   `AZURE_CONFIG_DIR`, Azure
   client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker
-  client TLS key directories selected by `DOCKER_CERT_PATH`, plus custom GitHub
-  CLI credential directories selected by `GH_CONFIG_DIR`; Cargo credential
-  files beneath the effective `CARGO_HOME` receive matching path denials rather
-  than withholding the ordinary Cargo configuration locator;
+  client TLS key directories selected by `DOCKER_CERT_PATH`, custom GitHub CLI
+  credential directories selected by `GH_CONFIG_DIR`, and GnuPG homes selected
+  by `GNUPGHOME`; Cargo credential files beneath the effective `CARGO_HOME` and
+  GitHub CLI credentials beneath an inherited `XDG_CONFIG_HOME` receive
+  matching path denials rather than withholding those ordinary configuration
+  locators;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -237,12 +237,18 @@ Standard mode grants writes to:
 - an installation root only when the user's top-level command clearly requests
   an install operation.
 
+For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then the
+default `~/.npm`. The effective cache replaces the default writable grant;
+relative paths are anchored to the command project.
+
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,
 inherited `GRADLE_USER_HOME`, then `~/.gradle`. Relative selections are anchored
 to the command's project. Only runtime subdirectories such as `.tmp`, caches,
 wrapper distributions, daemons, and toolchains are writable; the user-home root
-and `init.d` remain immutable.
+and `init.d` remain immutable. The effective user-home root is readable so
+Gradle can load root-level properties, initialization scripts, and wrapper
+metadata without making those persistence-capable files writable.
 
 For Maven commands, `-D`/`--define maven.repo.local=path` on the actual command
 selects the writable local repository, followed in precedence by `MAVEN_ARGS`,
@@ -264,6 +270,8 @@ their selected repository, settings, or effective home may expand authority
 automatically only inside the workspace or conventional `~/.m2/repository`
 namespace. An external referent requires a matching explicit writable grant;
 command and host-environment sources continue to represent direct user intent.
+Explicit user/global settings files and the effective user `.m2` directory are
+granted read-only access; only the selected repository receives write access.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -267,7 +267,9 @@ values override the parent environment. Policy compilation must not authorize
 one Cargo target or install root and then launch Cargo with another.
 Explicit tool arguments remain higher precedence still: Cargo `--target-dir`
 overrides target environment/config paths, while Gradle's user-home flags and
-`gradle.user.home` system property override `GRADLE_USER_HOME`.
+`gradle.user.home` system property override `GRADLE_OPTS` and
+`GRADLE_USER_HOME`. A `GRADLE_OPTS` value requiring shell expansion is rejected
+with guidance to use an explicit, unambiguous user-home mechanism.
 
 Built-in profiles should remain small declarations of roots, domains, reserved
 environment names, and optional local IPC needs. They must not contain a second

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -239,7 +239,9 @@ Standard mode grants writes to:
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`/`-g`, inherited `GRADLE_USER_HOME`, then
-`~/.gradle`. Relative selections are anchored to the command's project.
+`~/.gradle`. Relative selections are anchored to the command's project. Only
+runtime subdirectories such as caches, wrapper distributions, daemons, and
+toolchains are writable; the user-home root and `init.d` remain immutable.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -379,13 +379,14 @@ envelope. The launcher receives only that snapshot. Thus a cold cache such as
 `~/.cache -> /mnt/cache` with missing `~/.cache/coursier` works after
 `/mnt/cache/` is approved, without reopening the mutable home-directory link.
 For the built-in workspace read grant, standard mode discovers symlinks in the
-source tree without descending into conventional generated dependency and
-output directories, then installs separate read rules for safe external
-referents. External directory referents are inspected for nested source links;
-canonical directory identities break cycles, and fixed entry/depth budgets
-bound startup time and memory. Exceeding either budget fails policy resolution
-instead of continuing with a partial authority view. Referents overlapping
-protected read denials are omitted.
+source tree and performs a shallow symlink-entry check inside conventional
+generated dependency and output roots, then installs separate read rules for
+safe external referents. It does not recurse through ordinary contents beneath
+those generated roots. External directory referents are inspected for nested
+source links; canonical directory identities break cycles, and fixed
+entry/depth budgets bound startup time and memory. Exceeding either budget
+fails policy resolution instead of continuing with a partial authority view.
+Referents overlapping protected read denials are omitted.
 
 On macOS it resolves and validates the target before rendering its canonical
 SBPL grant. Because the untrusted child has not started and cannot write
@@ -423,7 +424,8 @@ feature switches, terminal settings, and tool paths. It removes:
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
   platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
   paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
-  as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, `AZURE_CONFIG_DIR`, Azure
+  as `AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`,
+  `AZURE_CONFIG_DIR`, Azure
   client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker
   client TLS key directories selected by `DOCKER_CERT_PATH`, plus custom GitHub
   CLI credential directories selected by `GH_CONFIG_DIR`;

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -381,7 +381,8 @@ feature switches, terminal settings, and tool paths. It removes:
   passwords, private keys, and cloud credentials;
 - known credential variables independent of spelling convention, including
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
-  platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`;
+  platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
+  paths such as `AWS_WEB_IDENTITY_TOKEN_FILE`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -247,7 +247,10 @@ and `init.d` remain immutable.
 For Maven commands, `-D`/`--define maven.repo.local=path` on the actual command
 selects the writable local repository, followed in precedence by `MAVEN_ARGS`,
 project `.mvn/maven.config`, `MAVEN_OPTS`, project `.mvn/jvm.config`, and the
-default `~/.m2/repository`. Within each source the last property wins. This
+effective settings `<localRepository>`, then the default `~/.m2/repository`.
+Settings selection follows the actual command, `MAVEN_ARGS`, project
+`.mvn/maven.config`, then the default user settings. Within each source the
+last property wins. This
 matches Maven's CLI merge, where environment arguments precede actual CLI
 arguments and CLI user properties override project configuration and JVM system
 properties. Relative selections are anchored to the command project; quoted,
@@ -451,7 +454,9 @@ feature switches, terminal settings, and tool paths. It removes:
   GitHub CLI credentials beneath an inherited `XDG_CONFIG_HOME` receive
   matching path denials rather than withholding those ordinary configuration
   locators; npm user-config files selected by `NPM_CONFIG_USERCONFIG` are
-  withheld because they commonly contain registry authentication tokens;
+  withheld because they commonly contain registry authentication tokens, as
+  are Kerberos ticket-cache/keytab locators `KRB5CCNAME`, `KRB5_KTNAME`, and
+  `KRB5_CLIENT_KTNAME`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -244,6 +244,10 @@ to the command's project. Only runtime subdirectories such as `.tmp`, caches,
 wrapper distributions, daemons, and toolchains are writable; the user-home root
 and `init.d` remain immutable.
 
+For Maven commands, `-D`/`--define maven.repo.local=path` selects the writable
+local repository and replaces the default `~/.m2/repository` write grant.
+Relative selections are anchored to the command project.
+
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and
 system locations remain outside the envelope.
@@ -266,9 +270,9 @@ Path grants derived from environment variables use the same final precedence
 as the child environment: trusted configuration and explicit CLI environment
 values override the parent environment. Policy compilation must not authorize
 one Cargo target or install root and then launch Cargo with another.
-Explicit tool arguments remain higher precedence still: Cargo `--target-dir`
-overrides direct `--config build.target-dir='path'` and target environment
-paths, while Gradle's user-home flags and
+Tool-native precedence must be preserved: Cargo `--target-dir` wins first,
+then Cargo target environment variables, then a direct
+`--config build.target-dir='path'`. Gradle's user-home flags and
 `gradle.user.home` system property override `GRADLE_OPTS` and
 `JAVA_OPTS`, then `GRADLE_USER_HOME`. Repeated JVM properties use the last
 value. An inherited JVM-option value requiring shell expansion is rejected with
@@ -408,7 +412,8 @@ feature switches, terminal settings, and tool paths. It removes:
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
   platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
   paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
-  as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, and `AZURE_CONFIG_DIR`;
+  as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, `AZURE_CONFIG_DIR`, and
+  Docker client TLS key directories selected by `DOCKER_CERT_PATH`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -450,7 +450,8 @@ feature switches, terminal settings, and tool paths. It removes:
   by `GNUPGHOME`; Cargo credential files beneath the effective `CARGO_HOME` and
   GitHub CLI credentials beneath an inherited `XDG_CONFIG_HOME` receive
   matching path denials rather than withholding those ordinary configuration
-  locators;
+  locators; npm user-config files selected by `NPM_CONFIG_USERCONFIG` are
+  withheld because they commonly contain registry authentication tokens;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -242,7 +242,9 @@ project `.npmrc` `cache=path`, user `~/.npmrc`, then the default `~/.npm`.
 An npm `--userconfig` or explicitly restored user-config locator selects the
 user layer. The effective existing user configuration receives an exact read
 grant so the child npm, npx, or pnpm process sees the same configuration SBE
-used without opening the containing directory.
+used without opening the containing directory. An explicitly restored or
+command-selected global configuration likewise receives only an exact file
+grant.
 pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
 `.npmrc` select its store in the same manner. The effective cache/store replaces
 the corresponding default writable grant; relative paths are anchored to the
@@ -260,18 +262,22 @@ conventional cache are the final fallback. The selected cache replaces only
 that tool's default grant; a repository-selected uv cache outside the workspace
 requires `--allow-write`. Conventional macOS caches live beneath
 `~/Library/Caches`; Linux follows XDG conventions.
-Poetry follows command `--cache-dir`, `POETRY_CACHE_DIR`, then
-`XDG_CACHE_HOME`; its selected `pypoetry` cache replaces the conventional
-writable grants, including both historical macOS-compatible locations.
+Poetry follows command `--cache-dir`, `POETRY_CACHE_DIR`, project
+`poetry.toml`, global `config.toml`, then `XDG_CACHE_HOME`. The effective global
+configuration receives an exact file read grant. A project-selected external
+cache requires `--allow-write`; the selected `pypoetry` cache replaces the
+conventional writable grants, including both historical macOS-compatible
+locations.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,
 inherited `GRADLE_USER_HOME`, then `~/.gradle`. Relative selections are anchored
-to the command's project. Only runtime subdirectories such as `.tmp`, caches,
-wrapper distributions, daemons, and toolchains are writable; the user-home root
-and `init.d` remain immutable. The effective user-home root is readable so
-Gradle can load root-level properties, initialization scripts, and wrapper
-metadata without making those persistence-capable files writable.
+to the command's project. A direct `--project-cache-dir` receives its selected
+directory as writable authority. Only runtime subdirectories such as `.tmp`,
+caches, wrapper distributions, daemons, and toolchains are writable beneath the
+user home; its root and `init.d` remain immutable. The effective user-home root
+is readable so Gradle can load root-level properties, initialization scripts,
+and wrapper metadata without making those persistence-capable files writable.
 
 For Maven commands, `-D`/`--define maven.repo.local=path` on the actual command
 selects the writable local repository, followed in precedence by `MAVEN_ARGS`,
@@ -492,12 +498,14 @@ feature switches, terminal settings, and tool paths. It removes:
   by `GNUPGHOME`; Cargo credential files beneath the effective `CARGO_HOME` and
   GitHub CLI credentials beneath an inherited `XDG_CONFIG_HOME` receive
   matching path denials rather than withholding those ordinary configuration
-  locators; npm user-config files selected by `NPM_CONFIG_USERCONFIG` are
-  withheld because they commonly contain registry authentication tokens, as
-  are Kerberos ticket-cache/keytab locators `KRB5CCNAME`, `KRB5_KTNAME`, and
+  locators; npm user/global config files selected by
+  `NPM_CONFIG_USERCONFIG`/`NPM_CONFIG_GLOBALCONFIG` are withheld because they
+  commonly contain registry authentication tokens, as are Kerberos
+  ticket-cache/keytab locators `KRB5CCNAME`, `KRB5_KTNAME`, and
   `KRB5_CLIENT_KTNAME`, plus the custom netrc locator `NETRC`;
 - Python package configuration locators `PIP_CONFIG_FILE` and
-  `UV_CONFIG_FILE`, because those files can contain authenticated indexes;
+  `UV_CONFIG_FILE`, and Poetry's `POETRY_CONFIG_DIR`, because those files or
+  directories can contain authenticated indexes;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -1,0 +1,605 @@
+# SBE Usable Security Design
+
+- Status: Accepted for 0.4.1
+- Delivery: 0.4.1 implements the standard/strict split and immediate
+  compatibility changes; narrow persistent approvals remain follow-up work
+- Owner: SBE
+- Last updated: 2026-08-28
+- Supersedes the 0.4 hardening design as the default product contract while
+  retaining it as the strict-mode contract:
+  [Security Hardening Design](security-hardening-design.md)
+
+## 1. Decision summary
+
+SBE 0.4 fixed real vulnerabilities, but it also made the strongest threat
+model the only product mode. That choice turned secondary guarantees into
+startup requirements and made SBE understand package-manager internals. The
+result is secure only when users can keep it enabled; ordinary failures push
+users toward broad escape flags or abandoning SBE entirely.
+
+The next release adopts these decisions:
+
+1. `sbe run -- <command>` uses a usable `standard` mode by default. It reduces
+   the blast radius of untrusted build code without promising perfect
+   containment.
+2. `sbe run --strict -- <command>` provides the fail-closed, high-assurance
+   boundary. Strictness is a deliberate user choice, not a hidden requirement
+   of every built-in profile.
+3. SBE treats the command tree as opaque. It may classify a small number of
+   top-level user intents, but it does not reimplement Cargo, npm, Yarn, Bun,
+   Poetry, or other package-manager argument and metadata semantics.
+4. A symlink is not unsafe by itself. A grant authorizes its resolved target;
+   safety depends on the operation, grant origin, resolved location, and
+   whether the rule is installed without a race.
+5. SBE does not vendor sccache, Cargo, or other tools that it neither patches,
+   builds, nor ships. Compatibility is tested through public interfaces.
+6. W^X, cache poisoning resistance, exact-output promotion, and strict domain
+   egress are separate guarantees. Their absence must not discard the useful
+   environment, filesystem, process, and release protections that remain.
+
+This is not a rollback to silent insecurity. `inspect` reports both the
+requested mode and the guarantees actually enforced. Standard mode degrades
+individual capabilities instead of failing the whole command; strict mode
+still fails before launch when one of its promised capabilities is missing.
+
+### 1.1 0.4.1 delivery boundary
+
+0.4.1 delivers the mode split, standard workspace/output behavior,
+non-sensitive environment inheritance, referent-aware symlinks, ordinary
+sccache compatibility, top-level Cargo install intent, local developer
+services, and truthful Linux best-effort networking. It preserves the 0.4
+implementation behind `--strict` for regression compatibility.
+
+Narrow durable approvals, per-capability status enums, removal of the remaining
+curated standard executable list, and strict-mode startup-cost simplification
+are follow-up work. Until then, `inspect` exposes the selected security mode and
+the backend's existing feature/policy fields rather than claiming that those
+future interfaces already exist.
+
+## 2. Product contract
+
+The primary UX is unchanged and must work without repository-specific SBE
+configuration:
+
+```text
+sbe run -- cargo build
+sbe run -- npm install
+sbe run -- uv sync
+sbe run -- ./gradlew build
+```
+
+Common host-tool arrangements are part of the acceptance matrix, including
+tool-manager symlinks, external build directories, compiler wrappers, local
+build daemons, and user package caches.
+
+The default promise is:
+
+> If dependency code becomes malicious, SBE substantially limits its access to
+> ambient credentials and its ability to persist outside the project and
+> expected tool data, while preserving normal build-tool behavior.
+
+The strict promise is:
+
+> If SBE reports that a strict command started, every requested strict
+> capability was kernel-enforced; otherwise SBE did not start the command.
+
+SBE is defense in depth. It is not a proof that dependencies, generated
+artifacts, the workspace, or persistent package caches are trustworthy.
+
+## 3. Why 0.4 is over-designed
+
+0.4 correctly repaired fail-open networking, ambient environment and
+descriptor inheritance, unsafe SBPL encoding, proxy resource exhaustion, and
+Linux launch hazards. Those changes directly protect the advertised boundary
+at low compatibility cost and remain.
+
+The over-design comes from composing every defense-in-depth idea into the
+default launch gate:
+
+- Linux cannot enforce destination-aware domain egress, so an otherwise useful
+  filesystem sandbox refuses every normal networked build unless the user
+  supplies a flag named `--allow-insecure-linux-network`.
+- Persistent W^X is modeled as a universal pre-launch invariant even though
+  build directories, virtual environments, `node_modules`, compiler wrappers,
+  and installers routinely combine mutation and later execution.
+- SBE parses top-level and ecosystem-specific command grammars to decide which
+  lockfiles and outputs to pre-create. This logic will always trail the tools it
+  is trying to emulate.
+- Startup may recursively scan large writable caches for hard links. The cost
+  grows with unrelated historical cache content, and the scan still cannot
+  establish that the same-user host was uncompromised before SBE started.
+- User-managed symlinks are treated as evidence of an attack even when they are
+  the normal representation of Homebrew, rustup, mise, asdf, Nix, external
+  disks, or monorepo build roots.
+- Project configuration is either mostly ignored or entirely trusted for one
+  run. There is no durable, narrow approval for the actual authority delta.
+- Proposed sccache support adds a Cargo-config parser, a special adapter, a
+  private server protocol, supervision, locking, and cache fallback. Repeating
+  this pattern for Gradle, Bazel, language servers, test runners, and future
+  wrappers would turn SBE into a second process manager for the build
+  ecosystem.
+- Proposed `cargo install` support reimplements Cargo target discovery,
+  installation registries, locking, atomic activation, overwrite ownership,
+  and rollback. That is package-manager logic, not sandbox policy.
+
+The issue is not that these attacks are impossible. The issue is that SBE 0.4
+does not distinguish:
+
+- a boundary necessary to stop the primary attack;
+- a cheap defense-in-depth measure;
+- a high-assurance measure with a substantial compatibility cost; and
+- an attempt to make hostile output trustworthy after the sandbox ends.
+
+## 4. Threat model by mode
+
+### 4.1 Shared assumptions
+
+Both modes trust the kernel, the installed SBE executable, the user-selected
+host toolchain, and the host state that existed before invocation. They do not
+defend against a compromised kernel or SBE binary, a malicious same-user
+process racing SBE from outside the sandbox, hardware or timing side channels,
+or denial of service by CPU and memory exhaustion.
+
+The repository, manifests, dependencies, build scripts, compiler plugins, and
+all descendants of the requested command are untrusted. Stdin, stdout, and
+stderr are intentional user-granted capabilities.
+
+### 4.2 Standard mode
+
+Standard mode protects:
+
+- high-confidence credential files and secret-bearing environment variables;
+- shell startup files, SSH authorization, LaunchAgents, and other persistence
+  paths outside the workspace and expected tool data;
+- inherited file descriptors and ambient agent sockets;
+- setuid escalation and high-risk kernel interfaces where supported;
+- direct external network access where the platform can enforce the selected
+  policy without breaking ordinary local tooling; and
+- the SBE proxy and parent process from unbounded untrusted input.
+
+Standard mode deliberately does not protect:
+
+- integrity of the current workspace;
+- integrity or confidentiality of declared package caches and build outputs;
+- future execution of artifacts written during this or an earlier invocation;
+- local development services and build daemons needed by ordinary tooling;
+- strict destination-aware egress on Linux; or
+- an explicitly selected installation destination such as `~/.cargo/bin` for
+  a top-level install command.
+
+Workspace and cache contents are tainted after running untrusted code. Version
+control, lockfile verification, cache eviction, review, and CI isolation remain
+the appropriate tools for deciding whether to reuse them.
+
+### 4.3 Strict mode
+
+Strict mode additionally requires:
+
+- a read-only source tree unless exact writable outputs are declared;
+- non-executable or private dependency caches;
+- no persistent write/execute overlap;
+- no ambient local services;
+- a positive environment allowlist;
+- no unapproved project-origin authority expansion; and
+- truthful, destination-aware network confinement or no network.
+
+On a Linux backend without destination-aware mediation, `--strict` with domain
+egress is unsupported. Strict mode remains useful with a deny-all profile for
+an offline build. A future namespace, cgroup, firewall, or seccomp-notify
+backend may add strict Linux domain egress without changing this contract.
+
+## 5. Policy modes and capability reporting
+
+The policy model gains an explicit mode:
+
+```rust
+pub enum SecurityMode {
+    Standard,
+    Strict,
+}
+```
+
+Security features are reported independently rather than collapsed into one
+`secure` boolean:
+
+| Capability | Standard | Strict |
+| --- | --- | --- |
+| Secret file reads | Enforced | Enforced |
+| Ambient file descriptors | Closed | Closed |
+| Environment | Inherit non-sensitive values | Positive allowlist |
+| Workspace writes | Allowed and labeled tainted | Denied except declared outputs |
+| Persistent caches | Read/write, non-trusted | Non-executable or private |
+| Persistent W^X | Warn and label tainted | Rejected |
+| Local IPC | Allowed where normal tooling needs it | Denied unless explicitly granted |
+| macOS external egress | Exact proxy policy | Exact proxy policy |
+| Linux external egress | Best available, explicitly not strict | Refuse domain mode if unavailable |
+| Missing secondary capability | Continue with one concise warning | Refuse before spawn |
+
+`inspect` emits, for each capability, one of `enforced`, `bestEffort`,
+`unavailable`, `notRequested`, or `explicitlyAllowed`, plus the origin of the
+decision. Human output starts with a short summary; machine output retains the
+complete typed policy.
+
+Warnings are deduplicated. A normal run does not print a page of threat-model
+text. Persistent platform limitations may be acknowledged in trusted global
+configuration, but acknowledgement never changes strict-mode semantics.
+
+## 6. Filesystem policy
+
+### 6.1 Standard authority envelope
+
+Standard mode grants writes to:
+
+- the current workspace;
+- the profile's conventional package caches and build data;
+- SBE's private per-run temporary directory; and
+- an installation root only when the user's top-level command clearly requests
+  an install operation.
+
+It denies writes everywhere else. In particular, home-directory persistence,
+credentials, shell startup, SSH authorization, user service configuration, and
+system locations remain outside the envelope.
+
+Recognizing `cargo install` as install intent is acceptable; parsing Cargo
+metadata and recreating Cargo's installation transaction is not. The package
+manager owns its destination format, locking, overwrite behavior, and rollback.
+Inspection must say that the selected install root is writable and that the
+installed result is untrusted.
+
+Built-in profiles should remain small declarations of roots, domains, reserved
+environment names, and optional local IPC needs. They must not contain a second
+grammar for every supported package manager.
+
+### 6.2 Strict authority envelope
+
+Strict mode does not infer fine-grained output authority from arbitrary command
+arguments. Writable roots come from small built-in strict profiles, trusted
+global configuration, explicit CLI grants, or approved project requirements.
+Temporary build roots are preferred. If a tool cannot operate without broad
+source writes or persistent W+X, strict mode returns an actionable error and
+standard mode remains available.
+
+### 6.3 Hard links
+
+Standard mode performs no recursive hard-link scan. Such a scan has unbounded
+cost relative to the requested command and assumes it can validate historical
+same-user state. Standard mode already treats writable workspace and cache
+inodes as untrusted.
+
+Strict mode avoids the problem structurally by using newly created private
+roots. For an explicitly granted existing literal file, it may reject
+`link_count > 1` with an O(1) metadata check. It must not recursively walk a
+large user cache before launch.
+
+## 7. Symlink semantics
+
+### 7.1 Principle
+
+A policy grant names an object through a path. If the path contains a symlink,
+the grant applies to the resolved referent, not to the spelling of the path.
+The question is therefore not “does this path contain a symlink?” but “is this
+referent within the authority the grant source may confer?”
+
+SBE must never reject a path merely because it contains an ordinary symlink.
+It always rejects magic links such as `/proc/*/fd/*` as policy inputs.
+
+### 7.2 Rules by operation and origin
+
+| Operation | Built-in or unapproved project path | Trusted global/CLI/approved path |
+| --- | --- | --- |
+| Read | Follow if the referent does not intersect a protected read denial | Follow; protected reads still require an explicit secret override |
+| Write | Follow only when the referent remains inside the mode's writable envelope | The resolved referent is the authority the user explicitly granted |
+| Execute | Follow tool-manager and system aliases; validate the referent under an executable/readable root | Authorize the exact resolved referent or resolved subtree |
+| Deny | Deny both the lexical path and the current referent when it exists | Same |
+
+Examples:
+
+- `/opt/homebrew/bin/rustup -> ../Cellar/rustup/.../rustup-init` is valid. The
+  immutable resolved tool is what executes.
+- `~/.cargo/bin/cargo -> rustup` is valid. A user-managed toolchain symlink is
+  normal host state, not a project attack.
+- `$PWD/target -> /Volumes/build/sbe-target` requires the resolved target to
+  be in a trusted writable root. Otherwise SBE prints the exact target and
+  offers a one-time or durable narrow approval; it does not tell the user to
+  remove the symlink.
+- `$PWD/output -> ~/.ssh` is not authorized by the built-in workspace grant.
+- A source symlink into an ordinary sibling checkout is readable in standard
+  mode, but a symlink into `~/.aws` remains denied.
+
+### 7.3 Resolution and race handling
+
+The trusted parent resolves each existing grant before the child starts and
+records both lexical and resolved paths. On Linux it opens the final object with
+descriptor-relative kernel resolution, rejects magic links, validates the
+opened object's type and boundary, and installs the Landlock rule from that
+file descriptor. It does not require `RESOLVE_NO_SYMLINKS` for ordinary grants.
+
+On macOS it resolves and validates the target before rendering both necessary
+SBPL spellings. Because the untrusted child has not started and cannot write
+the protected ancestors after launch, a malicious same-user process racing
+that snapshot is part of the pre-compromised-host exclusion, not a reason to
+reject every user symlink.
+
+Missing optional built-in alternatives are skipped. A broken or cyclic
+explicit grant is an error because its authority is ambiguous. A missing
+literal write target is created beneath an already approved, safely opened
+parent; its parent may itself resolve through an approved symlink.
+
+### 7.4 Deny paths
+
+A deny path that is missing or contains a broken symlink does not prevent an
+unrelated command from starting. SBE installs every denial it can represent,
+reports unresolved strict denials as unavailable, and in strict mode fails only
+when an overlapping allow could expose that unresolved location.
+
+Landlock's inode semantics must be described honestly: pathname aliases cannot
+be distinguished after they reach the same inode. Standard mode does not scan
+the filesystem looking for all possible aliases. Strict mode uses isolated
+roots rather than claiming that an exhaustive alias proof is practical.
+
+## 8. Environment, descriptors, and process execution
+
+### 8.1 Environment
+
+Standard mode inherits ordinary build configuration such as compiler flags,
+feature switches, terminal settings, and tool paths. It removes:
+
+- names matching a maintained high-confidence secret pattern such as tokens,
+  passwords, private keys, and cloud credentials;
+- known credential variables independent of spelling convention;
+- agent and credential socket variables;
+- dynamic-loader injection variables; and
+- SBE-reserved proxy, runtime, and policy variables.
+
+The user may pass a removed value explicitly. `inspect` shows names and origins,
+never values. Strict mode retains 0.4's positive allowlist behavior.
+
+This is an intentional difference in guarantee: a denylist cannot prove that
+standard mode removed every application-specific secret, so standard mode does
+not claim that it did.
+
+### 8.2 Descriptors and privilege
+
+Closing ambient descriptors, using private temporary storage, setting
+`no_new_privs`, blocking dangerous kernel interfaces, and using the
+single-threaded Linux launcher have low compatibility cost and remain in both
+modes.
+
+Execution allowlisting is weak against malicious native code and creates
+continuous toolchain breakage. The target standard design therefore blocks
+small, reviewed sets of true capability brokers where the OS can enforce that
+distinction, and relies on filesystem, secret, network, and `no_new_privs`
+boundaries for the primary protection. 0.4.1 keeps the existing curated list
+but resolves normal tool-manager aliases and adds black-box compatibility tests;
+removing that list safely is follow-up work. Strict mode retains a positive
+execute allowlist.
+
+## 9. Network and local IPC
+
+### 9.1 macOS
+
+Standard mode uses the domain proxy for external traffic and permits local IPC
+needed by developer tools: loopback TCP and ordinary same-user Unix sockets are
+inside the standard trust envelope. Agent and credential socket variables are
+still removed, but standard mode does not claim isolation from discoverable
+local services. Strict mode permits only SBE-owned proxy/private IPC endpoints
+explicitly present in the final policy.
+
+### 9.2 Linux
+
+Landlock destination-port filtering is not domain filtering and cannot express
+“any dynamic port on loopback, but no remote host.” Standard mode permits the
+TCP needed by dynamic loopback tools. Therefore it cannot force hostile Linux
+code through the proxy; proxy-compatible package managers still use the
+injected proxy settings, but capability output labels external egress
+`bestEffort`. SBE keeps the filesystem, environment, descriptor, privilege,
+and proxy defenses instead of refusing the entire command.
+
+Strict Linux domain egress remains unavailable until a destination-aware
+backend exists. This limitation is a capability result, not a command-line
+option named “insecure” that every Linux user must routinely paste.
+
+### 9.3 Proxy
+
+Proxy parser bounds, timeouts, destination validation, authentication, and
+structured shutdown remain. They protect a trusted component from hostile
+input and have negligible ecosystem compatibility cost.
+
+## 10. sccache and other host tools
+
+### 10.1 No vendoring
+
+SBE must not vendor sccache. Vendoring is justified only when SBE patches,
+builds, or ships that source, or when a reproducible source snapshot is itself
+a released product input. SBE does none of those things.
+
+The temporary local sccache checkout was useful for a one-time source study and
+line-level references. That makes it research material, not a product
+dependency. Ordinary Rust libraries remain declared dependencies
+resolved by Cargo and pinned through `Cargo.lock`; external tool source trees
+do not become repository dependencies merely because SBE interoperates with
+them.
+
+A vendored tree does not prove runtime compatibility with the user's installed
+binary. It creates an update obligation, increases repository and review
+surface, can mislead reviewers into treating sccache as part of SBE's audited
+TCB, and establishes a pattern that cannot scale to every wrapper and daemon.
+
+Research documents use immutable upstream permalinks. CI exercises a bounded
+matrix of released sccache binaries through their public CLI and environment
+contract, with versions and downloaded artifacts pinned by checksum in test
+metadata. Test fixtures are not linked into or shipped with SBE.
+
+### 10.2 No first-class adapter
+
+Standard mode treats a user-installed compiler wrapper or build daemon as part
+of the trusted host toolchain. Symlinked wrapper executables and ordinary local
+IPC work under the standard local-tool policy. SBE does not parse Cargo's
+layered configuration, replace sccache configuration, own the cache server,
+or implement sccache-specific locking and fallback.
+
+This means an ambient helper can perform work outside the sandbox. Standard
+mode reports that local helpers are trusted and does not claim otherwise.
+Strict mode denies ambient helper IPC unless the user provides a narrow strict
+helper policy; it may require disabling the wrapper. This honest boundary is
+preferable to quietly implementing a partial clone of each tool's supervisor.
+
+The same rule applies to Gradle daemons, Bazel servers, language-server
+helpers, and future compiler wrappers.
+
+## 11. Configuration and approval UX
+
+Configuration is separated into requirements and trusted authority:
+
+- A repository `.sbe.yaml` may select a profile, add restrictions, and request
+  additional capabilities.
+- Requests already inside the active mode's authority envelope are applied
+  automatically.
+- Requests that cross the envelope are shown as a concise diff and require a
+  trusted CLI/global grant or a stored approval.
+- `sbe trust` stores the repository identity, normalized capability delta, and
+  config digest. Editing the authority-relevant portion invalidates approval.
+- CI never prompts. It can verify a committed policy against separately
+  provisioned trusted configuration or an explicit digest.
+
+Approval is per capability, not “trust the entire project config.” Adding one
+external build root must not also authorize arbitrary environment variables,
+all network access, or future unrelated edits.
+
+Errors name the blocked operation, lexical path, resolved target, source of the
+request, and smallest safe remediation. SBE must not recommend a broad network,
+home-directory, or executable-tree grant when a narrow one suffices.
+
+## 12. Security-control disposition
+
+| 0.4 or proposed control | New disposition | Reason |
+| --- | --- | --- |
+| Empty network allowlist and helper failure fail closed | Keep in both modes | Fixes a real fail-open transition |
+| Ambient descriptor closure | Keep in both modes | Strong protection, low compatibility cost |
+| SBPL encoding and bounded config parsing | Keep in both modes | Untrusted data must not become policy syntax |
+| Descriptor-based Linux rule installation | Keep, but follow ordinary symlinks | Prevent races without banning normal layouts |
+| Single-threaded Linux launcher | Keep | Avoids unsafe post-fork runtime behavior |
+| Proxy parser/resource/destination hardening | Keep | Protects the trusted broker cheaply |
+| Release checksums, attestations, least privilege | Keep | Protects SBE's own distribution chain; no runtime UX cost |
+| Positive environment allowlist | Strict only | Strong guarantee, significant build compatibility cost |
+| Per-binary executable enumeration | Strict only | High maintenance and limited value against native malicious code |
+| Exact workspace output and lockfile inference | Remove from standard | Reimplements changing package-manager grammars |
+| Recursive hard-link scans | Remove | Unbounded startup cost and mismatched pre-host assumption |
+| Persistent W^X rejection | Strict only | Standard outputs and environments routinely transition from write to execute |
+| Project config all-or-nothing trust flag | Replace | Narrow durable approvals preserve provenance with less friction |
+| Linux strict-domain startup refusal | Strict only | Partial sandboxing remains useful in standard mode |
+| Correlated audit as launch requirement | Strict request only | Observability must not disable unrelated enforcement |
+| Vendored sccache/Cargo sources | Remove | SBE neither patches nor ships them |
+| Sccache managed adapter | Remove | Does not scale across host tools; changes the trust boundary silently |
+| Trusted-parent `cargo install` reimplementation | Remove | Attempts to recreate Cargo and bless hostile output |
+
+## 13. Supply-chain attack analysis
+
+Not every possible supply-chain attack requires every 0.4 mechanism.
+
+- Credential theft is primarily reduced by secret-path denial, environment
+  filtering, descriptor closure, agent isolation, and network controls.
+- Persistence outside the repository is primarily reduced by the write
+  envelope and `no_new_privs`, not by scanning package caches for hard links.
+- C2 and second-stage download are reduced by macOS egress enforcement and the
+  proxy. Linux standard mode cannot honestly close this channel with current
+  primitives, but filesystem and credential containment still reduce impact.
+- Writes to toolchain and install roots are prevented during an ordinary strict
+  invocation. Standard mode accepts that mutable caches, explicit install
+  roots, wrappers, and workspace artifacts are part of the user's development
+  state and labels them tainted.
+- Release supply-chain attacks against SBE itself require checksums,
+  attestations, pinned CI actions, and least-privilege publishing; those
+  controls remain fully necessary.
+
+The right comparison is not “perfect sandbox versus no attack.” It is “SBE
+enabled for routine work versus SBE bypassed because routine work fails.” A
+default control is successful only if it both blocks meaningful attacks and
+stays enabled.
+
+## 14. Acceptance criteria
+
+### 14.1 Standard usability
+
+The following work on supported macOS and Linux hosts with no project
+`.sbe.yaml`, no trust flag, and no broad escape flag:
+
+```text
+sbe run -- cargo build
+sbe run -- cargo test
+sbe run -- cargo install --path apps/cli
+sbe run -- npm install
+sbe run -- npm test
+sbe run -- uv sync
+sbe run -- uv run pytest
+sbe run -- ./gradlew build
+```
+
+The matrix includes Homebrew, rustup, mise/asdf-style symlinks, a globally
+configured sccache, concurrent builds, an approved external target-directory
+symlink, and warm package caches.
+
+Standard policy compilation never recursively scans unrelated caches or the
+workspace for hard links. Read-denial carving may inspect siblings along the
+small number of protected paths, but its cost does not grow with unrelated
+cache history. A missing optional tool path, broken unrelated deny path,
+unavailable audit stream, or unsupported strict network primitive does not
+prevent launch.
+
+### 14.2 Standard security
+
+Existing hostile fixtures must still fail to read known credential files,
+inherit sentinel credential environment variables or descriptors, modify
+shell/SSH persistence targets outside the workspace, invoke privilege
+escalation successfully, or exhaust/crash the trusted proxy. Tests separately
+assert and document the weaker Linux network and workspace/cache integrity
+properties.
+
+### 14.3 Strict security
+
+Strict adversarial tests prove the positive environment allowlist, read-only
+source policy, private/read-only caches, persistent W^X, no ambient local IPC,
+no unapproved project authority, and truthful network capability refusal.
+Tests do not claim strict Linux domain egress until a destination-aware backend
+exists.
+
+### 14.4 Configuration and diagnostics
+
+An external symlinked output requires at most one narrow approval. A changed
+authority delta invalidates only the affected approval. Every denial gives one
+copyable narrow remediation, and `inspect` accurately distinguishes enforced
+from best-effort behavior without exposing values or secrets.
+
+## 15. Migration from 0.4
+
+1. Introduce `SecurityMode` and capability reporting before removing old
+   checks. Initially map 0.4 behavior to `strict` for regression comparison.
+2. Make `standard` the default and remove the Linux routine opt-in named
+   `--allow-insecure-linux-network`. Preserve the option only for an explicit
+   strict port-only compatibility request.
+3. Replace recursive hard-link validation and command-specific lockfile/output
+   preparation in standard mode with the authority envelope.
+4. Change Linux path opening from “reject every non-system symlink” to “open
+   the referent, validate its boundary, install the rule from its FD.”
+5. Replace `--trust-project-config` with narrow approval records while keeping
+   the flag as a one-run compatibility mechanism during migration.
+6. Remove the proposed sccache adapter and Cargo-install promotion work from
+   the roadmap. Remove vendored tool sources before merge; retain only
+   black-box research conclusions and immutable upstream references.
+7. Rewrite README claims around the standard/strict distinction. Never call
+   Linux standard networking domain-confined.
+
+Implementation should delete superseded complexity rather than leave dormant
+command parsers and validators behind. Strict mode keeps only mechanisms that
+are part of its explicit contract.
+
+## 16. Non-goals
+
+- Making untrusted build artifacts safe to execute outside SBE.
+- Certifying the integrity of a pre-existing user toolchain or package cache.
+- Managing the lifecycle of every build daemon and compiler wrapper.
+- Reproducing package-manager transaction semantics.
+- Identical enforcement mechanisms across macOS and Linux.
+- Protecting against a malicious same-user process already running outside
+  SBE.
+- Trading all useful containment for a single unavailable platform guarantee.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -280,6 +280,10 @@ user home; its root and `init.d` remain immutable. The effective user-home root
 is readable so Gradle can load root-level properties, initialization scripts,
 and wrapper metadata without making those persistence-capable files writable.
 
+The standard Java profile follows an inherited `COURSIER_CACHE` and replaces
+its conventional writable cache grants. Relative selections are anchored to
+the command project.
+
 For Maven commands, `-D`/`--define maven.repo.local=path` on the actual command
 selects the writable local repository, followed in precedence by `MAVEN_ARGS`,
 project `.mvn/maven.config`, `MAVEN_OPTS`, project `.mvn/jvm.config`, and the
@@ -507,6 +511,9 @@ feature switches, terminal settings, and tool paths. It removes:
 - Python package configuration locators `PIP_CONFIG_FILE` and
   `UV_CONFIG_FILE`, and Poetry's `POETRY_CONFIG_DIR`, because those files or
   directories can contain authenticated indexes;
+- Git's environment-backed configuration transports `GIT_CONFIG_COUNT`,
+  `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, and `GIT_CONFIG_PARAMETERS`, because
+  they can carry authorization headers and other credentials directly;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -238,7 +238,8 @@ Standard mode grants writes to:
   an install operation.
 
 For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then a simple
-project `.npmrc` `cache=path`, user `~/.npmrc`, then the default `~/.npm`.
+project `.npmrc` `cache=path`, user `~/.npmrc`, an explicitly selected global
+npmrc, then the default `~/.npm`.
 An npm `--userconfig` or explicitly restored user-config locator selects the
 user layer. The effective existing user configuration receives an exact read
 grant so the child npm, npx, or pnpm process sees the same configuration SBE
@@ -246,11 +247,11 @@ used without opening the containing directory. An explicitly restored or
 command-selected global configuration likewise receives only an exact file
 grant.
 pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
-`.npmrc` select its store in the same manner. The effective cache/store replaces
-the corresponding default writable grant; relative paths are anchored to the
-command project. Without an override, `PNPM_HOME/store` precedes the XDG and
-conventional defaults. A repository-selected external path requires
-`--allow-write`.
+`.npmrc`, then an explicitly selected global npmrc select its store in the same
+manner. The effective cache/store replaces the corresponding default writable
+grant; relative paths are anchored to the command project. Without an override,
+`PNPM_HOME/store` precedes the XDG and conventional defaults. A
+repository-selected external path requires `--allow-write`.
 
 For uv and pip commands, `--cache-dir` overrides the corresponding
 `UV_CACHE_DIR` or `PIP_CACHE_DIR`. uv then resolves a simple `cache-dir` from

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -250,8 +250,10 @@ dependencies belong outside an untrusted workspace or require strict mode.
 Recognizing `cargo install` as install intent is acceptable; parsing Cargo
 metadata and recreating Cargo's installation transaction is not. The package
 manager owns its destination format, locking, overwrite behavior, and rollback.
-Inspection must say that the selected install root is writable and that the
-installed result is untrusted.
+An explicit `--root` is the selected install root and takes precedence over
+`CARGO_INSTALL_ROOT`, `CARGO_HOME`, and the default. Inspection must say that
+the selected install root is writable and that the installed result is
+untrusted.
 
 Built-in profiles should remain small declarations of roots, domains, reserved
 environment names, and optional local IPC needs. They must not contain a second
@@ -320,6 +322,10 @@ records both lexical and resolved paths. On Linux it opens the final object with
 descriptor-relative kernel resolution, rejects magic links, validates the
 opened object's type and boundary, and installs the Landlock rule from that
 file descriptor. It does not require `RESOLVE_NO_SYMLINKS` for ordinary grants.
+For the built-in workspace read grant, standard mode discovers symlinks in the
+source tree without descending into conventional generated dependency and
+output directories, then installs separate read rules for safe external
+referents. Referents overlapping protected read denials are omitted.
 
 On macOS it resolves and validates the target before rendering both necessary
 SBPL spellings. Because the untrusted child has not started and cannot write
@@ -542,9 +548,9 @@ sbe run -- uv run pytest
 sbe run -- ./gradlew build
 ```
 
-The matrix includes Homebrew, rustup, mise/asdf-style symlinks, a globally
-configured sccache, concurrent builds, an approved external target-directory
-symlink, and warm package caches.
+The matrix includes Homebrew, rustup, mise/asdf-style symlinks, a source link
+into a sibling checkout, a globally configured sccache, concurrent builds, an
+approved external target-directory symlink, and warm package caches.
 
 Standard policy compilation never recursively scans unrelated caches or the
 workspace for hard links. Read-denial carving may inspect siblings along the

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -342,8 +342,10 @@ For the built-in workspace read grant, standard mode discovers symlinks in the
 source tree without descending into conventional generated dependency and
 output directories, then installs separate read rules for safe external
 referents. External directory referents are inspected for nested source links;
-canonical directory identities break cycles. Referents overlapping protected
-read denials are omitted.
+canonical directory identities break cycles, and fixed entry/depth budgets
+bound startup time and memory. Exceeding either budget fails policy resolution
+instead of continuing with a partial authority view. Referents overlapping
+protected read denials are omitted.
 
 On macOS it resolves and validates the target before rendering its canonical
 SBPL grant. Because the untrusted child has not started and cannot write
@@ -378,7 +380,8 @@ feature switches, terminal settings, and tool paths. It removes:
 - names matching a maintained high-confidence secret pattern such as tokens,
   passwords, private keys, and cloud credentials;
 - known credential variables independent of spelling convention, including
-  prefix-encoded forms such as Terraform's `TF_TOKEN_<host>`;
+  prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
+  platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -332,10 +332,12 @@ Examples:
 ### 7.3 Resolution and race handling
 
 The trusted parent resolves each existing grant before the child starts and
-records both lexical and resolved paths. On Linux it opens the final object with
-descriptor-relative kernel resolution, rejects magic links, validates the
-opened object's type and boundary, and installs the Landlock rule from that
-file descriptor. It does not require `RESOLVE_NO_SYMLINKS` for ordinary grants.
+retains the lexical spelling for audit, but replaces writable/executable
+symlink grants with their canonical snapshot. The launcher therefore never
+reopens a mutable lexical link after its referent was approved. On Linux it
+opens the canonical final object with descriptor-relative kernel resolution,
+rejects magic links, validates the opened object's type and boundary, and
+installs the Landlock rule from that file descriptor.
 For the built-in workspace read grant, standard mode discovers symlinks in the
 source tree without descending into conventional generated dependency and
 output directories, then installs separate read rules for safe external
@@ -343,8 +345,8 @@ referents. External directory referents are inspected for nested source links;
 canonical directory identities break cycles. Referents overlapping protected
 read denials are omitted.
 
-On macOS it resolves and validates the target before rendering both necessary
-SBPL spellings. Because the untrusted child has not started and cannot write
+On macOS it resolves and validates the target before rendering its canonical
+SBPL grant. Because the untrusted child has not started and cannot write
 the protected ancestors after launch, a malicious same-user process racing
 that snapshot is part of the pre-compromised-host exclusion, not a reason to
 reject every user symlink.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -244,12 +244,15 @@ to the command's project. Only runtime subdirectories such as `.tmp`, caches,
 wrapper distributions, daemons, and toolchains are writable; the user-home root
 and `init.d` remain immutable.
 
-For Maven commands, `-D`/`--define maven.repo.local=path` selects the writable
-local repository, followed in precedence by `MAVEN_OPTS`, project
-`.mvn/jvm.config`, and the default `~/.m2/repository`. Within JVM option sources
-the last property wins, matching Java. Relative selections are anchored to the
-command project; quoted, expanded, or otherwise ambiguous option values fail
-with guidance to use a direct unambiguous command property.
+For Maven commands, `-D`/`--define maven.repo.local=path` on the actual command
+selects the writable local repository, followed in precedence by `MAVEN_ARGS`,
+project `.mvn/maven.config`, `MAVEN_OPTS`, project `.mvn/jvm.config`, and the
+default `~/.m2/repository`. Within each source the last property wins. This
+matches Maven's CLI merge, where environment arguments precede actual CLI
+arguments and CLI user properties override project configuration and JVM system
+properties. Relative selections are anchored to the command project; quoted,
+expanded, or otherwise ambiguous option values fail with guidance to use a
+direct unambiguous command property.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and
@@ -415,8 +418,9 @@ feature switches, terminal settings, and tool paths. It removes:
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
   platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
   paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
-  as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, `AZURE_CONFIG_DIR`, and
-  Docker client TLS key directories selected by `DOCKER_CERT_PATH`;
+  as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, `AZURE_CONFIG_DIR`, Azure
+  client certificates selected by `AZURE_CLIENT_CERTIFICATE_PATH`, and Docker
+  client TLS key directories selected by `DOCKER_CERT_PATH`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -249,18 +249,21 @@ selects the writable local repository, followed in precedence by `MAVEN_ARGS`,
 project `.mvn/maven.config`, `MAVEN_OPTS`, project `.mvn/jvm.config`, and the
 effective settings `<localRepository>`, then the default `~/.m2/repository`.
 Settings selection follows the actual command, `MAVEN_ARGS`, project
-`.mvn/maven.config`, then the default user settings. Within each source the
-last property wins. This
+`.mvn/maven.config`, then the default user settings. An explicit
+`-gs`/`--global-settings` selection is read as the fallback when the effective
+user settings do not provide `<localRepository>`. The effective default user
+settings and repository roots follow `-Duser.home` from `MAVEN_OPTS`, then
+project `.mvn/jvm.config`. Within each source the last property wins. This
 matches Maven's CLI merge, where environment arguments precede actual CLI
 arguments and CLI user properties override project configuration and JVM system
 properties. Relative selections are anchored to the command project; quoted,
 expanded, or otherwise ambiguous option values fail with guidance to use a
 direct unambiguous command property.
 Because `.mvn/maven.config` and `.mvn/jvm.config` are repository-controlled,
-their selected repository may expand authority automatically only inside the
-workspace or conventional `~/.m2/repository` namespace. An external referent
-requires a matching explicit writable grant; command and host-environment
-sources continue to represent direct user intent.
+their selected repository, settings, or effective home may expand authority
+automatically only inside the workspace or conventional `~/.m2/repository`
+namespace. An external referent requires a matching explicit writable grant;
+command and host-environment sources continue to represent direct user intent.
 
 It denies writes everywhere else. In particular, home-directory persistence,
 credentials, shell startup, SSH authorization, user service configuration, and

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -265,6 +265,9 @@ Path grants derived from environment variables use the same final precedence
 as the child environment: trusted configuration and explicit CLI environment
 values override the parent environment. Policy compilation must not authorize
 one Cargo target or install root and then launch Cargo with another.
+Explicit tool arguments remain higher precedence still: Cargo `--target-dir`
+overrides target environment/config paths, while Gradle's user-home flags and
+`gradle.user.home` system property override `GRADLE_USER_HOME`.
 
 Built-in profiles should remain small declarations of roots, domains, reserved
 environment names, and optional local IPC needs. They must not contain a second

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -238,9 +238,11 @@ Standard mode grants writes to:
   an install operation.
 
 For npm and npx commands, `--cache` overrides `NPM_CONFIG_CACHE`, then a simple
-project `.npmrc` `cache=path`, then the default `~/.npm`. The effective cache
-replaces the default writable grant; relative paths are anchored to the command
-project. A repository-selected external cache requires `--allow-write`.
+project `.npmrc` `cache=path`, user `~/.npmrc`, then the default `~/.npm`.
+pnpm's `--store-dir`, configuration environment, project `.npmrc`, and user
+`.npmrc` select its store in the same manner. The effective cache/store replaces
+the corresponding default writable grant; relative paths are anchored to the
+command project. A repository-selected external path requires `--allow-write`.
 
 For Gradle commands, the conventional cache grant follows Gradle's effective
 user home: `--gradle-user-home`, every accepted `-g` form including `-g/path`,
@@ -471,7 +473,7 @@ feature switches, terminal settings, and tool paths. It removes:
   locators; npm user-config files selected by `NPM_CONFIG_USERCONFIG` are
   withheld because they commonly contain registry authentication tokens, as
   are Kerberos ticket-cache/keytab locators `KRB5CCNAME`, `KRB5_KTNAME`, and
-  `KRB5_CLIENT_KTNAME`;
+  `KRB5_CLIENT_KTNAME`, plus the custom netrc locator `NETRC`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -401,7 +401,7 @@ feature switches, terminal settings, and tool paths. It removes:
   prefix-encoded forms such as Terraform's `TF_TOKEN_<host>` and concatenated
   platform names such as Azure Pipelines' `SYSTEM_ACCESSTOKEN`, plus OIDC bearer
   paths such as `AWS_WEB_IDENTITY_TOKEN_FILE` and custom credential stores such
-  as `AWS_SHARED_CREDENTIALS_FILE`;
+  as `AWS_SHARED_CREDENTIALS_FILE`, `CLOUDSDK_CONFIG`, and `AZURE_CONFIG_DIR`;
 - agent and credential socket variables;
 - dynamic-loader injection variables; and
 - SBE-reserved proxy, runtime, and policy variables.


### PR DESCRIPTION
## Summary

- bump the workspace and verified action default to 0.4.1
- make practical standard mode the default and retain the 0.4 fail-closed contract behind `--strict`
- let standard builds use normal workspace outputs, non-sensitive build environment variables, local developer services, compiler wrappers, and top-level Cargo installation
- treat ordinary symlinks by their opened referent while keeping protected paths denied and rejecting project-output links that escape the built-in workspace envelope
- support installed sccache through executable/cache/local-IPC grants without vendoring its source or managing its lifecycle
- report Linux domain egress honestly as best-effort in standard mode; strict mode retains fail-closed or explicitly acknowledged port-only behavior
- update CI to test both the new standard contract and explicit strict regressions

## Security retained in standard mode

- known host credential paths outside the selected workspace and canonical-referent read denials
- high-confidence credential/API-key environment filtering and agent-socket removal
- inherited descriptor closure and private runtime storage
- privilege-broker execution linting and dangerous syscall restrictions
- authenticated, bounded, destination-validating proxy
- restrictive-by-default project configuration provenance

The selected workspace is deliberately treated as readable, untrusted input in standard mode, including `.env*`. This is required for general create/read/write package-manager semantics on Linux. Use `--strict` when project-local secret-file confidentiality is part of the threat model.

## Design

The accepted design is in `specs/usable-security-design.md`. The sccache source study uses immutable upstream links; neither `vendors/` nor `.gitmodules` is part of this PR.

## Verification

- `cargo +nightly fmt`
- `cargo build --workspace --all-targets`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check --workspace --all-targets --target aarch64-unknown-linux-gnu`
- `cargo audit`
- `cargo deny check advisories bans licenses sources`
- live default sandbox build with globally configured Homebrew sccache
- live strict sandbox Cargo build
- live standard `cargo install --path` into an external install root
- hostile Rust fixture: all 10 credential, persistence, privilege, and fetch probes remained SAFE
