### PR TITLE
release: sbexec 0.4.2 usable standard defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file. See [conven
   and macOS. Strict mode remains unchanged.
 - Detect standalone `uvx` and `corepack` invocations and cover common
   Homebrew/user-managed Node and uv tool locations in standard mode.
+- Preserve `denyExec` precedence after standard-mode helper symlinks are
+  resolved, so a helper cannot reauthorize its denied canonical target on
+  Linux.
 - Do not inherit language-runtime launcher and code-injection environment
   variables such as `JAVA_TOOL_OPTIONS`, `NODE_OPTIONS`, and `PYTHONPATH`;
   reviewed values can still be supplied explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file. See [conven
 - Preserve `denyExec` precedence after standard-mode helper symlinks are
   resolved, so a helper cannot reauthorize its denied canonical target on
   Linux.
+- Let standard-mode Go helpers execute the compiler tools in the resolved
+  `GOROOT/pkg/tool/` subtree without opening a broad package-manager directory.
 - Do not inherit language-runtime launcher and code-injection environment
   variables such as `JAVA_TOOL_OPTIONS`, `NODE_OPTIONS`, and `PYTHONPATH`;
   reviewed values can still be supplied explicitly.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
-## Unreleased
+## [sbexec-v0.4.2](https://github.com/tyrchen/sbe/compare/sbexec-v0.4.1..sbexec-v0.4.2) - 2026-09-05
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
+## Unreleased
+
+### Bug Fixes
+
+- Allow standard-mode project configs to declare ordinary registry and
+  build-time download domains without requiring `--trust-project-config`.
+- Include common build helpers such as downloaders, scripting runtimes,
+  `perl`, `protoc`, OpenSSL, native code generators, and Xcode tools in the
+  standard-mode executable policy so normal build scripts can run on Linux
+  and macOS. Strict mode remains unchanged.
+- Detect standalone `uvx` and `corepack` invocations and cover common
+  Homebrew/user-managed Node and uv tool locations in standard mode.
+- Do not inherit language-runtime launcher and code-injection environment
+  variables such as `JAVA_TOOL_OPTIONS`, `NODE_OPTIONS`, and `PYTHONPATH`;
+  reviewed values can still be supplied explicitly.
+
 ---
 ## [sbexec-v0.4.1](https://github.com/tyrchen/sbe/compare/sbexec-v0.4.0..sbexec-v0.4.1) - 2026-08-29
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sbe-core"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "dirs",
  "idna",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "sbe-proxy"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "base64",
  "getrandom 0.4.3",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "sbexec"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "apps/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Tyr Chen <tyr.chen@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -45,5 +45,5 @@ getrandom = "0.4.3"
 idna = "1.1.0"
 
 # workspace crates
-sbe-core = { path = "crates/core", version = "0.4.1" }
-sbe-proxy = { path = "crates/proxy", version = "0.4.1" }
+sbe-core = { path = "crates/core", version = "0.4.2" }
+sbe-proxy = { path = "crates/proxy", version = "0.4.2" }

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ install hooks, compiler plugins, and build scripts. It protects host
 credentials and limits filesystem, process, environment, and network access.
 The operating-system kernel and the installed SBE executable remain trusted.
 
-Current release: [`0.4.1`](https://github.com/tyrchen/sbe/releases/tag/sbexec-v0.4.1)
+Current release: [`0.4.2`](https://github.com/tyrchen/sbe/releases/tag/sbexec-v0.4.2)
 
 ## Install
 
 Install the `sbexec` crate, which provides the `sbe` command:
 
 ```bash
-cargo install sbexec --version 0.4.1 --locked
+cargo install sbexec --version 0.4.2 --locked
 sbe --version
 ```
 
@@ -85,7 +85,7 @@ failures use 126.
 
 ## Choose a security mode
 
-Version 0.4.1 uses `standard` mode by default and provides the original 0.4
+Version 0.4.2 uses `standard` mode by default and provides the original 0.4
 fail-closed boundary through `--strict`.
 
 | | Standard (default) | Strict (`--strict`) |
@@ -128,9 +128,10 @@ for later execution outside the sandbox.
 
 ## GitHub Actions
 
-The setup action installs the published `0.4.1` binary, verifies its SHA-256
+The setup action installs the published `0.4.2` binary, verifies its SHA-256
 checksum and GitHub build-provenance attestation, and adds it to `PATH`.
-Pinning both the action code and installed binary makes upgrades explicit:
+The action now defaults to the current release, so a normal workflow needs no
+extra version configuration:
 
 ```yaml
 name: build
@@ -146,21 +147,20 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install SBE
-        uses: tyrchen/sbe@5271cff35f898262b560492c4d2252adfb215053 # sbexec-v0.4.1
-        with:
-          version: '0.4.1'
+        uses: tyrchen/sbe@sbexec-v0.4.2
       - run: sbe --version
       - run: sbe run -- cargo build
 ```
 
-You may use `tyrchen/sbe@sbexec-v0.4.1` when a movable Git tag is acceptable.
-For high-assurance workflows, use the full commit SHA shown above.
+For high-assurance workflows, pin the action code to the immutable commit SHA
+for `sbexec-v0.4.2` from the release page. The installed archive is always
+checked against both its release checksum and GitHub build provenance.
 
-The `version` input accepts `0.4.1`, `v0.4.1`, or `sbexec-v0.4.1`. It defaults
-to `0.4.1`. Use `latest` only when you deliberately want automatic upgrades to
-the latest stable GitHub release. The optional `github-token` input defaults to
-`github.token`. The action exposes the resolved release tag as `version` and
-the installed executable as `bin-path`.
+The optional `version` input accepts `0.4.2`, `v0.4.2`, `sbexec-v0.4.2`, or
+`latest`; it defaults to `0.4.2`. Use it only to override the default or when
+you deliberately want automatic upgrades to the latest stable GitHub release.
+The optional `github-token` defaults to `github.token`. The action exposes the
+resolved release tag as `version` and the installed executable as `bin-path`.
 
 Release binaries are available for:
 
@@ -296,12 +296,21 @@ Policy sources are merged in this order:
 5. CLI options.
 
 An auto-discovered project file is untrusted by default. In standard mode it
-may add the project's ordinary network requirements with `allowDomains` and
-`allowFetch`, or tighten policy with `denyRead`, `denyExec`, and
-`denyDomains`. It cannot grant filesystem, execution, environment, proxy, or
-degraded-mode authority. Strict mode keeps the restrictive-only behavior.
-Inspect a repository-controlled expansion before trusting broader authority
-for one invocation:
+may add the project's ordinary registry or download domains with
+`allowDomains` and `allowFetch`, or tighten policy with `denyRead`, `denyExec`,
+and `denyDomains`. A private registry therefore works without a trust flag:
+
+```yaml
+# .sbe.yaml
+profiles:
+  rust:
+    allowDomains:
+      - "cargo-index.int.example.com"
+```
+
+It cannot grant filesystem, execution, environment, proxy, or degraded-mode
+authority. Strict mode keeps the restrictive-only behavior. Inspect before
+trusting a repository-controlled expansion that needs broader authority:
 
 ```bash
 sbe inspect --trust-project-config -- npm install
@@ -309,22 +318,7 @@ sbe run --trust-project-config -- npm install
 ```
 
 Global configuration, an explicitly selected file, and CLI options are treated
-as trusted user choices. Example project configuration for a private registry:
-
-```yaml
-profiles:
-  node:
-    allowWrite:
-      - "$PWD/dist/"
-    allowDomains:
-      - "api.example.com"
-    denyDomains:
-      - "github.com"
-    allowFetch:
-      - "downloads.example.com"
-    env:
-      NODE_ENV: production
-```
+as trusted user choices.
 
 Configuration rejects unknown fields, unsafe paths, malformed domains and
 environment names, oversized input, missing bases, and cyclic `extends`
@@ -395,7 +389,7 @@ Frequently used security options are:
 | `--deny-exec PATH` | Remove an executable path |
 | `--keep-env NAME` | Preserve one parent variable |
 | `--env NAME=VALUE` | Set one child variable |
-| `--trust-project-config` | Allow discovered project policy to add grants |
+| `--trust-project-config` | Allow broader filesystem, execution, or environment grants from project config |
 | `--no-proxy` | Use direct TCP 443 compatibility mode |
 | `--allow-all-network` | Remove network confinement |
 | `--allow-insecure-linux-network` | Acknowledge strict Linux port-only networking |
@@ -405,7 +399,7 @@ Frequently used security options are:
 
 - [Architecture](docs/arch.md)
 - [Security hardening design and threat model](specs/security-hardening-design.md)
-- [0.4.1 usable-security design](specs/usable-security-design.md)
+- [0.4.2 usable-security design](specs/usable-security-design.md)
 - [Changelog](CHANGELOG.md)
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -103,6 +103,18 @@ outputs, and package caches. Because the whole workspace is readable in this
 mode, do not keep real credentials in repository files such as `.env`. Put
 them outside the workspace or use strict mode.
 
+The standard profiles also include common child build tools—downloaders,
+scripting runtimes, OpenSSL, `protoc`, native code generators, and platform
+toolchain launchers—using explicit per-platform paths. This covers helpers
+launched by npm scripts, uv or pip builds, Cargo build scripts, Maven/Gradle,
+and native extension builds. These compatibility grants are standard-only;
+strict mode keeps its smaller executable allowlist.
+
+Standard mode also removes language-runtime launcher variables such as
+`JAVA_TOOL_OPTIONS`, `NODE_OPTIONS`, and `PYTHONPATH` from the inherited
+environment. Pass a reviewed value with `--keep-env` when a build genuinely
+needs one; SBE-controlled variables remain reserved.
+
 Strict mode is intentionally less convenient. It is most useful with a warm,
 reviewed dependency cache and a command that does not need the network:
 
@@ -165,9 +177,9 @@ SBE detects these built-in profiles:
 
 | Ecosystem | Commands | Project files |
 |---|---|---|
-| Node.js | `node`, `npm`, `npx`, `yarn`, `pnpm`, `bun` | `package.json` |
+| Node.js | `node`, `npm`, `npx`, `corepack`, `yarn`, `pnpm`, `bun` | `package.json` |
 | Rust | `cargo`, `rustc`, `rustup` | `Cargo.toml` |
-| Python | `python`, `pip`, `uv`, `poetry`, `pdm`, `rye` | `pyproject.toml`, requirements files |
+| Python | `python`, `pip`, `uv`, `uvx`, `poetry`, `pdm`, `rye` | `pyproject.toml`, requirements files |
 | Elixir | `mix`, `elixir`, `iex` | `mix.exs` |
 | Java/Scala | `java`, `javac`, `mvn`, `gradle`, `sbt`, `scala` | Maven, Gradle, and sbt descriptors |
 
@@ -283,10 +295,13 @@ Policy sources are merged in this order:
 4. a file selected with `--config`; and
 5. CLI options.
 
-An auto-discovered project file is untrusted by default. It may tighten policy
-with `denyRead`, `denyExec`, or `denyDomains`, but it cannot grant filesystem,
-execution, environment, fetch, network, or degraded-mode authority. Inspect a
-repository-controlled expansion before trusting it for one invocation:
+An auto-discovered project file is untrusted by default. In standard mode it
+may add the project's ordinary network requirements with `allowDomains` and
+`allowFetch`, or tighten policy with `denyRead`, `denyExec`, and
+`denyDomains`. It cannot grant filesystem, execution, environment, proxy, or
+degraded-mode authority. Strict mode keeps the restrictive-only behavior.
+Inspect a repository-controlled expansion before trusting broader authority
+for one invocation:
 
 ```bash
 sbe inspect --trust-project-config -- npm install
@@ -294,7 +309,7 @@ sbe run --trust-project-config -- npm install
 ```
 
 Global configuration, an explicitly selected file, and CLI options are treated
-as trusted user choices. Example:
+as trusted user choices. Example project configuration for a private registry:
 
 ```yaml
 profiles:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,10 @@ The standard profiles also include common child build tools—downloaders,
 scripting runtimes, OpenSSL, `protoc`, native code generators, and platform
 toolchain launchers—using explicit per-platform paths. This covers helpers
 launched by npm scripts, uv or pip builds, Cargo build scripts, Maven/Gradle,
-and native extension builds. These compatibility grants are standard-only;
+and native extension builds. For Go, SBE derives the matching
+`GOROOT/pkg/tool/` directory from the resolved standard `go` launcher so its
+compiler subprocesses work without granting a broad package-manager directory.
+These compatibility grants are standard-only;
 strict mode keeps its smaller executable allowlist.
 
 Standard mode also removes language-runtime launcher variables such as

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   version:
-    description: 'SBE version to install (defaults to 0.4.1; accepts v0.4.1, sbexec-v0.4.1, or latest)'
+    description: 'SBE version to install (defaults to 0.4.2; accepts v0.4.2, sbexec-v0.4.2, or latest)'
     required: false
-    default: '0.4.1'
+    default: '0.4.2'
   github-token:
     description: 'GitHub token used to query releases and download assets (avoids API rate limits)'
     required: false
@@ -17,7 +17,7 @@ inputs:
 
 outputs:
   version:
-    description: 'The resolved release tag that was installed (e.g. "sbexec-v0.4.1")'
+    description: 'The resolved release tag that was installed (e.g. "sbexec-v0.4.2")'
     value: ${{ steps.resolve.outputs.tag }}
   bin-path:
     description: 'Absolute path to the installed sbe binary'

--- a/apps/cli/src/cli.rs
+++ b/apps/cli/src/cli.rs
@@ -89,8 +89,9 @@ pub struct RunArgs {
     #[arg(long)]
     pub allow_insecure_linux_network: bool,
 
-    /// Trust an automatically discovered project `.sbe.yaml` to expand the
-    /// sandbox. Without this flag project config may only restrict policy.
+    /// Trust an automatically discovered project `.sbe.yaml` to add
+    /// filesystem, execution, environment, or broad-network grants.
+    /// Standard mode already accepts project network requirements.
     #[arg(long)]
     pub trust_project_config: bool,
 
@@ -185,7 +186,8 @@ pub struct InspectArgs {
     #[arg(long)]
     pub allow_insecure_linux_network: bool,
 
-    /// Trust an automatically discovered project `.sbe.yaml` to expand policy.
+    /// Trust an automatically discovered project `.sbe.yaml` to add
+    /// filesystem, execution, environment, or broad-network grants.
     #[arg(long)]
     pub trust_project_config: bool,
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -2943,10 +2943,64 @@ fn resolve_standard_path_aliases(
     snapshot_standard_write_aliases(profile, home, project_dir)?;
     snapshot_standard_exec_aliases(profile)?;
     profile.enforce_deny_exec();
+    grant_standard_go_tool_directory(profile);
+    profile.enforce_deny_exec();
     snapshot_standard_read_aliases(profile)?;
     #[cfg(target_os = "linux")]
     append_standard_workspace_read_aliases(profile, project_dir)?;
     Ok(())
+}
+
+#[allow(
+    clippy::disallowed_methods,
+    reason = "standard mode derives Go's immutable tool directory from its resolved built-in \
+              launcher"
+)]
+fn grant_standard_go_tool_directory(profile: &mut SandboxProfile) {
+    // `go build` launches compile, asm, link, cgo, and other implementation
+    // tools from `$GOROOT/pkg/tool/<platform>`. The directory is version- and
+    // package-manager-specific (notably Homebrew's Cellar layout), so derive
+    // it from the already-resolved standard launcher rather than granting a
+    // broad parent such as /usr/lib or /opt/homebrew/Cellar.
+    //
+    // Only standardAllowExec entries are candidates. Project config cannot
+    // populate that list, and a launcher removed by denyExec is not used to
+    // infer any extra execution authority.
+    let launchers: Vec<PathBuf> = profile
+        .standard_allow_exec
+        .iter()
+        .filter(|helper| helper.path.file_name().is_some_and(|name| name == "go"))
+        .map(|helper| helper.path.clone())
+        .collect();
+    for launcher in launchers {
+        let Ok(resolved_launcher) = std::fs::canonicalize(&launcher) else {
+            continue;
+        };
+        if !profile
+            .allow_exec
+            .iter()
+            .any(|grant| grant.path == resolved_launcher)
+        {
+            continue;
+        }
+        let Some(bin_dir) = resolved_launcher.parent() else {
+            continue;
+        };
+        if bin_dir.file_name().is_none_or(|name| name != "bin") {
+            continue;
+        }
+        let Some(goroot) = bin_dir.parent() else {
+            continue;
+        };
+        let tool_root = goroot.join("pkg/tool");
+        let Ok(tool_root) = std::fs::canonicalize(tool_root) else {
+            continue;
+        };
+        if !tool_root.is_dir() {
+            continue;
+        }
+        insert_builtin_path_grant(profile, GrantKind::AllowExec, SandboxPath::dir(tool_root));
+    }
 }
 
 #[cfg(target_os = "linux")]
@@ -5549,6 +5603,65 @@ mod tests {
                 && (record.value == alias.to_string_lossy()
                     || record.value == target.to_string_lossy())
         }));
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test creates an isolated Go installation symlink fixture"
+    )]
+    fn standard_go_helper_grants_its_resolved_tool_directory() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let go_root = root.path().join("go");
+        let go_binary = go_root.join("bin/go");
+        let tool_root = go_root.join("pkg/tool");
+        let compile = tool_root.join("test-platform/compile");
+        let launcher = root.path().join("bin/go");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(go_binary.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(compile.parent().unwrap()).unwrap();
+        std::fs::create_dir_all(launcher.parent().unwrap()).unwrap();
+        std::fs::write(&go_binary, "#!/bin/sh\n").unwrap();
+        std::fs::write(&compile, "#!/bin/sh\n").unwrap();
+        std::os::unix::fs::symlink(&go_binary, &launcher).unwrap();
+
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &project);
+        profile.standard_allow_exec = vec![SandboxPath::file(launcher)];
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+
+        resolve_standard_path_aliases(&mut profile, &home, &project).unwrap();
+
+        let resolved_tool_root = std::fs::canonicalize(&tool_root).unwrap();
+        assert!(
+            profile
+                .allow_exec
+                .contains(&SandboxPath::dir(resolved_tool_root)),
+            "a standard Go launcher must include its resolved GOROOT/pkg/tool subtree"
+        );
+
+        profile.merge_overrides(&ProfileOverrides {
+            deny_exec: vec![SandboxPath::file(compile.clone())],
+            ..ProfileOverrides::default()
+        });
+        resolve_standard_path_aliases(&mut profile, &home, &project).unwrap();
+
+        let resolved_compile = std::fs::canonicalize(&compile).unwrap();
+        assert!(
+            !profile
+                .allow_exec
+                .iter()
+                .any(|grant| paths_overlap(&grant.path, &resolved_compile)),
+            "a denyExec for a Go child tool must suppress the inferred tool-directory grant"
+        );
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -169,6 +169,11 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         origin: GrantOrigin::Runtime,
     });
     profile.ephemeral_write_exec.push(runtime_temp_path.clone());
+    // Standard helper and runtime grants can become aliases of a denied
+    // executable only after their final path is resolved. Reconcile after all
+    // grants so Linux's allowlist preserves denyExec precedence just as
+    // macOS's explicit deny rule does.
+    profile.enforce_deny_exec();
     // Normal execution performs the filesystem identity scan exactly once in
     // the platform backend immediately before spawn. Inspection has no spawn,
     // so its branch below runs the complete validation explicitly.
@@ -2937,6 +2942,7 @@ fn resolve_standard_path_aliases(
 ) -> anyhow::Result<()> {
     snapshot_standard_write_aliases(profile, home, project_dir)?;
     snapshot_standard_exec_aliases(profile)?;
+    profile.enforce_deny_exec();
     snapshot_standard_read_aliases(profile)?;
     #[cfg(target_os = "linux")]
     append_standard_workspace_read_aliases(profile, project_dir)?;
@@ -5488,6 +5494,61 @@ mod tests {
                 .any(|allowed| paths_overlap(&allowed.path, &output)),
             "an inferred output grant must not override an explicit execute denial"
         );
+    }
+
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test creates an isolated standard-helper symlink fixture"
+    )]
+    fn standard_profile_reapplies_execute_denials_after_helper_alias_resolution() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let tools = root.path().join("tools");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&tools).unwrap();
+
+        let target = tools.join("protoc-real");
+        let alias = tools.join("protoc");
+        std::fs::write(&target, "#!/bin/sh\n").unwrap();
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &project);
+        profile.standard_allow_exec = vec![SandboxPath::file(alias.clone())];
+        profile.merge_overrides(&ProfileOverrides {
+            deny_exec: vec![SandboxPath::file(target.clone())],
+            ..ProfileOverrides::default()
+        });
+
+        apply_standard_profile(
+            &mut profile,
+            &["cargo".to_owned(), "build".to_owned()],
+            &home,
+            &project,
+        )
+        .unwrap();
+        assert!(
+            profile
+                .allow_exec
+                .contains(&SandboxPath::file(alias.clone())),
+            "the lexical helper grant demonstrates the pre-snapshot state"
+        );
+
+        resolve_standard_path_aliases(&mut profile, &home, &project).unwrap();
+
+        assert!(
+            !profile
+                .allow_exec
+                .iter()
+                .any(|allowed| paths_overlap(&allowed.path, &target))
+        );
+        assert!(!profile.grant_origins.iter().any(|record| {
+            record.kind == GrantKind::AllowExec
+                && (record.value == alias.to_string_lossy()
+                    || record.value == target.to_string_lossy())
+        }));
     }
 
     #[test]

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -15,7 +15,10 @@ use anyhow::Context;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64_STANDARD};
 use sbe_core::{
     BackendOptions, Sandbox, SandboxBackend, SecurityMode,
-    config::{PathKind, SandboxPath, expand_path, load_configs, resolve_profile},
+    config::{
+        PathKind, ProjectConfigMode, SandboxPath, expand_path, load_configs,
+        resolve_profile_with_mode,
+    },
     detect::{self, Ecosystem},
     error::CoreError,
     profile::{
@@ -99,7 +102,14 @@ async fn execute_inner(args: &RunArgs) -> anyhow::Result<ExitCode> {
         configure_node_workspace(&mut profile, &args.command, &pwd, !args.strict)?;
     }
     let configs = load_configs(&pwd, args.config.as_deref(), args.trust_project_config).await?;
-    resolve_profile(&mut profile, &configs, &home, &pwd)?;
+    let project_config_mode = if args.trust_project_config {
+        ProjectConfigMode::Trusted
+    } else if args.strict {
+        ProjectConfigMode::Restricted
+    } else {
+        ProjectConfigMode::Standard
+    };
+    resolve_profile_with_mode(&mut profile, &configs, &home, &pwd, project_config_mode)?;
 
     let overrides = build_overrides(args, &home, &pwd)?;
     let cli_allow_degraded = overrides.allow_degraded;
@@ -679,6 +689,26 @@ fn is_sensitive_environment_name(name: &str) -> bool {
         "UV_EXTRA_INDEX_URL",
         "UV_INDEX",
         "UV_INDEX_URL",
+        // Tool-specific launcher and code-injection options are intentionally
+        // not inherited. SBE supplies its own JVM/proxy options at runtime;
+        // users can still pass a reviewed value explicitly with --keep-env
+        // (except for SBE-reserved JAVA_TOOL_OPTIONS).
+        "BASH_ENV",
+        "ENV",
+        "GRADLE_OPTS",
+        "JAVA_TOOL_OPTIONS",
+        "JDK_JAVA_OPTIONS",
+        "MAVEN_OPTS",
+        "NODE_OPTIONS",
+        "PERL5LIB",
+        "PERL5OPT",
+        "PYTHONHOME",
+        "PYTHONPATH",
+        "PYTHONSTARTUP",
+        "RUBYLIB",
+        "RUBYOPT",
+        "_JAVA_OPTIONS",
+        "GOPROXY",
     ];
     const RESERVED: &[&str] = &[
         "HTTP_PROXY",
@@ -739,6 +769,12 @@ fn apply_standard_profile(
         GrantKind::AllowWrite,
         SandboxPath::dir(project_dir.to_path_buf()),
     );
+    // Standard mode favors compatibility for ordinary build scripts. These
+    // are common local code-generation/download helpers, and their use still
+    // remains subject to the resolved network policy and protected reads.
+    for helper in &profile.standard_allow_exec.clone() {
+        insert_builtin_path_grant(profile, GrantKind::AllowExec, helper.clone());
+    }
     for output in project_outputs {
         if resolves_within(&output, project_dir) {
             // The Linux backend must open an executable directory before it
@@ -1620,8 +1656,8 @@ fn simple_uv_cache_path(value: &str, source: &Path) -> anyhow::Result<PathBuf> {
         let unquoted = &value[1..value.len() - 1];
         if unquoted.contains('\\') || unquoted.contains('"') {
             anyhow::bail!(
-                "uv configuration '{}' uses an escaped or multiline cache-dir; use an explicit \
-                 uv --cache-dir path",
+                "uv configuration '{}' uses an escaped or multiline cache-dir; use an explicit uv \
+                 --cache-dir path",
                 source.display()
             );
         }
@@ -4640,7 +4676,7 @@ fn workspace_component_matches(pattern: &str, value: &str) -> bool {
 }
 
 /// Determine which Yarn linker outputs are required without executing Yarn or
-/// following project-controlled symlinks. Yarn Berry uses PnP by default when
+/// following project-controlled symlinks. Yarn Berry uses Plug'n'Play by default when
 /// a `.yarnrc.yml` is present; `packageManager: yarn@2+` is the other explicit
 /// modern-Yarn signal. Classic/unspecified Yarn remains lockfile-only so SBE
 /// does not create an unrelated empty `.pnp.cjs`.
@@ -4980,6 +5016,10 @@ pub fn print_profiles() -> anyhow::Result<()> {
         for p in &profile.allow_exec {
             println!("    - {p}");
         }
+        println!("  Standard-only compatibility executables:");
+        for p in &profile.standard_allow_exec {
+            println!("    - {p}");
+        }
         println!();
     }
     Ok(())
@@ -5067,6 +5107,19 @@ mod tests {
                 ("SSH_AUTH_SOCK".to_owned(), "/tmp/agent".to_owned()),
                 ("SYSTEM_ACCESSTOKEN".to_owned(), "sentinel".to_owned()),
                 ("NPM_TOKEN".to_owned(), "sentinel".to_owned()),
+                (
+                    "JAVA_TOOL_OPTIONS".to_owned(),
+                    "-javaagent:/tmp/a.jar".to_owned(),
+                ),
+                (
+                    "NODE_OPTIONS".to_owned(),
+                    "--require=/tmp/hook.js".to_owned(),
+                ),
+                ("PYTHONPATH".to_owned(), "/tmp/hooks".to_owned()),
+                (
+                    "GOPROXY".to_owned(),
+                    "https://user:sentinel@example.com".to_owned(),
+                ),
                 (
                     "NPM_CONFIG_GLOBALCONFIG".to_owned(),
                     "/tmp/global-npmrc".to_owned(),
@@ -5345,6 +5398,12 @@ mod tests {
                 .allow_write
                 .contains(&SandboxPath::dir(project.path().join("target")))
         );
+        for helper in &profile.standard_allow_exec {
+            assert!(
+                profile.allow_exec.contains(helper),
+                "standard mode should allow configured helper {helper}"
+            );
+        }
         assert!(!profile.deny_read.iter().any(|grant| {
             grant.path.parent() == Some(project.path())
                 && grant.path.file_name().is_some_and(|name| name == ".env")
@@ -6402,7 +6461,8 @@ mod tests {
                 .allow_write
                 .iter()
                 .any(|grant| grant.path == home.join(".cache/coursier")),
-            "the launcher must receive the reconstructed canonical target, not its symlinked spelling"
+            "the launcher must receive the reconstructed canonical target, not its symlinked \
+             spelling"
         );
     }
 

--- a/apps/cli/src/executor.rs
+++ b/apps/cli/src/executor.rs
@@ -5598,10 +5598,12 @@ mod tests {
                 .iter()
                 .any(|allowed| paths_overlap(&allowed.path, &target))
         );
+        let resolved_target = std::fs::canonicalize(&target).unwrap();
         assert!(!profile.grant_origins.iter().any(|record| {
             record.kind == GrantKind::AllowExec
                 && (record.value == alias.to_string_lossy()
-                    || record.value == target.to_string_lossy())
+                    || record.value == target.to_string_lossy()
+                    || record.value == resolved_target.to_string_lossy())
         }));
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -119,6 +119,23 @@ pub enum ConfigOrigin {
     Explicit,
 }
 
+/// How an automatically discovered project configuration may affect policy.
+///
+/// Standard mode accepts the small set of project settings that describe the
+/// project's network dependencies. Filesystem, execution, environment, and
+/// broad-network grants still require an explicit trust decision. Strict mode
+/// uses [`Self::Restricted`] so repository-controlled configuration cannot
+/// expand any authority.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProjectConfigMode {
+    /// Only settings that tighten the resolved policy are accepted.
+    Restricted,
+    /// Accept ordinary project network requirements, but not authority grants.
+    Standard,
+    /// The caller explicitly authorized the project file to add grants.
+    Trusted,
+}
+
 /// A configuration plus the provenance needed to enforce monotonic project
 /// policy and explain the final profile.
 #[derive(Debug, Clone)]
@@ -426,6 +443,34 @@ impl ProfileConfig {
         }
         Ok(())
     }
+
+    /// Validate the compatibility subset accepted from an untrusted project
+    /// file in standard mode.
+    ///
+    /// A project must be able to name its registries and build-time download
+    /// hosts without making every invocation carry `--trust-project-config`.
+    /// Those settings remain constrained by the proxy (or are reported as
+    /// best-effort on Linux). They do not grant filesystem, process, or
+    /// environment authority. Everything else remains opt-in.
+    fn validate_standard_project(&self, path: &Path) -> Result<(), CoreError> {
+        let expands_authority = self.extends.is_some()
+            || !self.allow_write.is_empty()
+            || !self.allow_read.is_empty()
+            || !self.allow_exec.is_empty()
+            || !self.env.is_empty()
+            || self.allow_all_network == Some(true)
+            || self.enable_proxy == Some(false)
+            || self.allow_degraded == Some(true);
+        if expands_authority {
+            return Err(config_policy(
+                path,
+                "standard project configuration may add allowDomains/denyDomains or allowFetch, \
+                 but filesystem, execution, environment, proxy, and degraded-mode changes require \
+                 --trust-project-config",
+            ));
+        }
+        Ok(())
+    }
 }
 
 fn record_path(
@@ -642,6 +687,17 @@ pub fn resolve_profile(
     home: &Path,
     pwd: &Path,
 ) -> Result<(), CoreError> {
+    resolve_profile_with_mode(base, configs, home, pwd, ProjectConfigMode::Restricted)
+}
+
+/// Resolve the final profile with the requested project-configuration policy.
+pub fn resolve_profile_with_mode(
+    base: &mut SandboxProfile,
+    configs: &[LoadedConfig],
+    home: &Path,
+    pwd: &Path,
+    project_mode: ProjectConfigMode,
+) -> Result<(), CoreError> {
     let profile_name = base.name.clone();
 
     for loaded in configs {
@@ -649,7 +705,11 @@ pub fn resolve_profile(
         // Apply matching profile config
         if let Some(pc) = config.profiles.get(&profile_name) {
             if loaded.origin == ConfigOrigin::Project && !loaded.trusted {
-                pc.validate_untrusted_project(&loaded.path)?;
+                match project_mode {
+                    ProjectConfigMode::Restricted => pc.validate_untrusted_project(&loaded.path)?,
+                    ProjectConfigMode::Standard => pc.validate_standard_project(&loaded.path)?,
+                    ProjectConfigMode::Trusted => {}
+                }
             }
             let grant_origin = match &loaded.origin {
                 ConfigOrigin::Global => GrantOrigin::Global(loaded.path.clone()),
@@ -836,7 +896,7 @@ profiles:
 
     #[test]
     fn test_should_reject_unknown_config_fields() {
-        let yaml = "profiles:\n  node:\n    allowNetwrok: true\n";
+        let yaml = "profiles:\n  node:\n    allowUnknownField: true\n";
         assert!(serde_yaml::from_str::<SbeConfig>(yaml).is_err());
     }
 
@@ -983,6 +1043,84 @@ profiles:
                 .iter()
                 .any(|domain| domain.0 == "registry.npmjs.org")
         );
+    }
+
+    #[test]
+    fn test_should_allow_standard_project_network_requirements() {
+        let home = PathBuf::from("/home/test");
+        let pwd = PathBuf::from("/work/project");
+        let mut config = SbeConfig::default();
+        config.profiles.insert(
+            "rust".to_owned(),
+            ProfileConfig {
+                allow_domains: vec!["cargo-index.example.com".to_owned()],
+                allow_fetch: vec!["downloads.example.com".to_owned()],
+                ..ProfileConfig::default()
+            },
+        );
+        let loaded = LoadedConfig {
+            config,
+            origin: ConfigOrigin::Project,
+            path: pwd.join(".sbe.yaml"),
+            trusted: false,
+        };
+        let mut profile =
+            SandboxProfile::for_ecosystem(crate::detect::Ecosystem::Rust, &home, &pwd);
+
+        resolve_profile_with_mode(
+            &mut profile,
+            &[loaded],
+            &home,
+            &pwd,
+            ProjectConfigMode::Standard,
+        )
+        .unwrap();
+
+        assert!(
+            profile
+                .allow_domains
+                .iter()
+                .any(|domain| domain.0 == "cargo-index.example.com")
+        );
+        assert!(
+            profile
+                .allow_fetch
+                .iter()
+                .any(|domain| domain.0 == "downloads.example.com")
+        );
+    }
+
+    #[test]
+    fn test_should_keep_standard_project_authority_expansion_opt_in() {
+        let home = PathBuf::from("/home/test");
+        let pwd = PathBuf::from("/work/project");
+        let mut config = SbeConfig::default();
+        config.profiles.insert(
+            "rust".to_owned(),
+            ProfileConfig {
+                allow_write: vec!["$PWD/generated/".to_owned()],
+                ..ProfileConfig::default()
+            },
+        );
+        let loaded = LoadedConfig {
+            config,
+            origin: ConfigOrigin::Project,
+            path: pwd.join(".sbe.yaml"),
+            trusted: false,
+        };
+        let mut profile =
+            SandboxProfile::for_ecosystem(crate::detect::Ecosystem::Rust, &home, &pwd);
+
+        let error = resolve_profile_with_mode(
+            &mut profile,
+            &[loaded],
+            &home,
+            &pwd,
+            ProjectConfigMode::Standard,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("--trust-project-config"));
     }
 
     #[test]

--- a/crates/core/src/detect.rs
+++ b/crates/core/src/detect.rs
@@ -61,11 +61,11 @@ fn detect_from_command(command: &str) -> Option<Ecosystem> {
 
     match basename {
         // Node.js
-        "node" | "npm" | "npx" | "yarn" | "pnpm" | "bun" => Some(Ecosystem::Node),
+        "node" | "npm" | "npx" | "yarn" | "pnpm" | "bun" | "corepack" => Some(Ecosystem::Node),
         // Rust
         "cargo" | "rustc" | "rustup" => Some(Ecosystem::Rust),
         // Python
-        "python" | "python3" | "pip" | "pip3" | "uv" | "poetry" | "pdm" | "rye" => {
+        "python" | "python3" | "pip" | "pip3" | "uv" | "uvx" | "poetry" | "pdm" | "rye" => {
             Some(Ecosystem::Python)
         }
         // Elixir
@@ -119,6 +119,7 @@ mod tests {
         assert_eq!(detect_from_command("yarn"), Some(Ecosystem::Node));
         assert_eq!(detect_from_command("pnpm"), Some(Ecosystem::Node));
         assert_eq!(detect_from_command("bun"), Some(Ecosystem::Node));
+        assert_eq!(detect_from_command("corepack"), Some(Ecosystem::Node));
     }
 
     #[test]
@@ -130,6 +131,7 @@ mod tests {
     fn test_should_detect_python_from_pip() {
         assert_eq!(detect_from_command("pip"), Some(Ecosystem::Python));
         assert_eq!(detect_from_command("uv"), Some(Ecosystem::Python));
+        assert_eq!(detect_from_command("uvx"), Some(Ecosystem::Python));
         assert_eq!(detect_from_command("poetry"), Some(Ecosystem::Python));
     }
 

--- a/crates/core/src/profile/defaults-linux.yaml
+++ b/crates/core/src/profile/defaults-linux.yaml
@@ -162,6 +162,53 @@ common:
     - "/usr/bin/git"
     - "/usr/local/bin/git"
 
+  # Compatibility helpers used by ordinary standard-mode build scripts.
+  # Strict mode deliberately does not inherit this list.
+  standardAllowExec:
+    - "/usr/bin/curl"
+    - "/usr/local/bin/curl"
+    - "/usr/bin/wget"
+    - "/usr/local/bin/wget"
+    - "/usr/bin/perl"
+    - "/usr/local/bin/perl"
+    - "/usr/bin/protoc"
+    - "/usr/local/bin/protoc"
+    - "/usr/bin/openssl"
+    - "/usr/local/bin/openssl"
+    # Cross-language build helpers commonly launched by package scripts,
+    # build.rs files, and native extension builds.
+    - "/usr/bin/python"
+    - "/usr/bin/python3"
+    - "/usr/local/bin/python"
+    - "/usr/local/bin/python3"
+    - "/usr/bin/node"
+    - "/usr/local/bin/node"
+    - "/usr/bin/ruby"
+    - "/usr/local/bin/ruby"
+    - "/usr/bin/go"
+    - "/usr/local/bin/go"
+    - "/usr/local/go/bin/go"
+    - "/usr/bin/dotnet"
+    - "/usr/local/bin/dotnet"
+    - "/usr/bin/javac"
+    - "/usr/bin/jar"
+    - "/usr/bin/xcodebuild"
+    - "/usr/bin/xcrun"
+    # Native and generated-code build tools that are not part of every
+    # ecosystem profile.
+    - "/usr/bin/ninja"
+    - "/usr/local/bin/ninja"
+    - "/usr/bin/meson"
+    - "/usr/local/bin/meson"
+    - "/usr/bin/m4"
+    - "/usr/bin/autoconf"
+    - "/usr/bin/automake"
+    - "/usr/bin/libtool"
+    - "/usr/bin/libtoolize"
+    - "/usr/bin/bison"
+    - "/usr/bin/flex"
+    - "/usr/bin/swig"
+
 profiles:
   node:
     allowWrite:
@@ -193,6 +240,8 @@ profiles:
       - "/usr/bin/npx"
       - "/usr/local/bin/npm"
       - "/usr/local/bin/npx"
+      - "/usr/bin/corepack"
+      - "/usr/local/bin/corepack"
       - "/usr/local/bin/yarn"
       - "/usr/local/bin/pnpm"
       - "/usr/local/bin/bun"
@@ -207,6 +256,9 @@ profiles:
       - "~/.local/share/mise/"
       # asdf shim layout
       - "~/.asdf/"
+    standardAllowExec:
+      - "~/.bun/"
+      - "~/.local/share/pnpm/"
 
   rust:
     allowRead:
@@ -266,6 +318,8 @@ profiles:
       - "/usr/local/bin/pip3"
       - "/usr/local/bin/uv"
       - "/usr/bin/uv"
+      - "/usr/local/bin/uvx"
+      - "/usr/bin/uvx"
       # GitHub Actions setup-python installs versioned interpreters here.
       - "/opt/hostedtoolcache/Python/"
       # GitHub Actions setup-uv installs versioned binaries here.

--- a/crates/core/src/profile/defaults-macos.yaml
+++ b/crates/core/src/profile/defaults-macos.yaml
@@ -132,6 +132,63 @@ common:
     - "/usr/local/bin/cmake"
     - "/opt/homebrew/bin/pkg-config"
     - "/usr/local/bin/pkg-config"
+
+  # Compatibility helpers used by ordinary standard-mode build scripts.
+  # Strict mode deliberately does not inherit this list.
+  standardAllowExec:
+    - "/usr/bin/curl"
+    - "/opt/homebrew/bin/curl"
+    - "/usr/local/bin/curl"
+    - "/opt/homebrew/bin/wget"
+    - "/usr/local/bin/wget"
+    - "/usr/bin/perl"
+    - "/opt/homebrew/bin/perl"
+    - "/usr/local/bin/perl"
+    - "/usr/bin/openssl"
+    - "/opt/homebrew/bin/openssl"
+    - "/usr/local/bin/openssl"
+    - "/usr/bin/protoc"
+    - "/opt/homebrew/bin/protoc"
+    - "/usr/local/bin/protoc"
+    # Cross-language build helpers commonly launched by package scripts,
+    # build.rs files, and native extension builds.
+    - "/usr/bin/python"
+    - "/usr/bin/python3"
+    - "/opt/homebrew/bin/python3"
+    - "/usr/local/bin/python3"
+    - "/opt/homebrew/bin/node"
+    - "/usr/local/bin/node"
+    - "/usr/bin/ruby"
+    - "/opt/homebrew/bin/ruby"
+    - "/usr/local/bin/ruby"
+    - "/opt/homebrew/bin/go"
+    - "/usr/local/bin/go"
+    - "/usr/local/go/bin/go"
+    - "/usr/bin/dotnet"
+    - "/opt/homebrew/share/dotnet/dotnet"
+    - "/usr/local/share/dotnet/dotnet"
+    - "/usr/bin/javac"
+    - "/usr/bin/jar"
+    - "/usr/bin/xcodebuild"
+    - "/usr/bin/xcrun"
+    - "/usr/bin/swift"
+    - "/usr/bin/swiftc"
+    # Native and generated-code build tools that are not part of every
+    # ecosystem profile.
+    - "/opt/homebrew/bin/ninja"
+    - "/usr/local/bin/ninja"
+    - "/opt/homebrew/bin/meson"
+    - "/usr/local/bin/meson"
+    - "/usr/bin/m4"
+    - "/usr/bin/autoconf"
+    - "/usr/bin/automake"
+    - "/opt/homebrew/bin/libtool"
+    - "/usr/local/bin/libtool"
+    - "/usr/bin/bison"
+    - "/usr/bin/flex"
+    - "/opt/homebrew/bin/swig"
+    - "/usr/local/bin/swig"
+
 profiles:
   node:
     allowWrite:
@@ -160,6 +217,12 @@ profiles:
     allowExec:
       - "/usr/local/bin/node"
       - "/opt/homebrew/bin/node"
+      - "/opt/homebrew/bin/corepack"
+      - "/usr/local/bin/corepack"
+      - "/opt/homebrew/bin/yarn"
+      - "/opt/homebrew/bin/pnpm"
+      - "/opt/homebrew/bin/bun"
+      - "/usr/local/bin/bun"
       # actions/setup-node installs into this non-system toolcache on hosted runners.
       - "/Users/runner/hostedtoolcache/node/"
       - "~/.nvm/"
@@ -171,6 +234,9 @@ profiles:
       - "~/.local/share/mise/"
       - "/usr/bin/xcodebuild"
       - "/usr/bin/xcrun"
+    standardAllowExec:
+      - "~/.bun/"
+      - "~/.local/share/pnpm/"
 
   rust:
     allowWrite:
@@ -249,6 +315,8 @@ profiles:
       - "/usr/local/bin/python3"
       - "/usr/local/bin/pip3"
       - "/usr/local/bin/uv"
+      - "/opt/homebrew/bin/uvx"
+      - "/usr/local/bin/uvx"
       # actions/setup-python uses a fixed, non-relocatable macOS toolcache.
       - "/Users/runner/hostedtoolcache/Python/"
       # Toolcache launchers resolve into this fixed framework installation.

--- a/crates/core/src/profile/mod.rs
+++ b/crates/core/src/profile/mod.rs
@@ -242,6 +242,13 @@ pub struct SandboxProfile {
     #[serde(default)]
     pub allow_exec: Vec<SandboxPath>,
 
+    /// Additional compatibility executables enabled only by standard mode.
+    ///
+    /// These remain separate from `allow_exec` so strict mode does not
+    /// inherit compatibility grants outside its smaller contract.
+    #[serde(skip)]
+    pub standard_allow_exec: Vec<SandboxPath>,
+
     /// Requested proxy setting retained while configuration is merged.
     #[serde(skip)]
     pub enable_proxy: bool,
@@ -315,6 +322,13 @@ impl SandboxProfile {
             .allow_exec
             .iter()
             .chain(eco_cfg.allow_exec.iter())
+            .map(|p| expand_path(p, home, pwd))
+            .collect();
+
+        let standard_allow_exec: Vec<SandboxPath> = common
+            .standard_allow_exec
+            .iter()
+            .chain(eco_cfg.standard_allow_exec.iter())
             .map(|p| expand_path(p, home, pwd))
             .collect();
 
@@ -436,6 +450,7 @@ impl SandboxProfile {
             allow_domains,
             deny_exec,
             allow_exec,
+            standard_allow_exec,
             enable_proxy,
             allow_all_network: false,
             network_mode,
@@ -974,6 +989,8 @@ struct CommonDefaults {
     deny_exec: Vec<String>,
     #[serde(default)]
     allow_exec: Vec<String>,
+    #[serde(default)]
+    standard_allow_exec: Vec<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -987,6 +1004,8 @@ struct EcosystemDefaults {
     allow_domains: Vec<String>,
     #[serde(default)]
     allow_exec: Vec<String>,
+    #[serde(default)]
+    standard_allow_exec: Vec<String>,
     /// Whether to start the domain-filtering proxy. Some ecosystems whose
     /// HTTP stack does not respect `HTTP_PROXY` env (notably JVM tools like
     /// Maven and Gradle) cannot benefit from the proxy and need the kernel
@@ -1268,6 +1287,20 @@ mod tests {
                 "missing osascript deny for {eco}"
             );
         }
+    }
+
+    #[test]
+    fn test_should_keep_standard_compatibility_exec_separate() {
+        let home = PathBuf::from("/Users/test");
+        let pwd = PathBuf::from("/Users/test/project");
+        let profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &pwd);
+
+        assert!(has(&profile.standard_allow_exec, "/usr/bin/curl"));
+        assert!(has(&profile.standard_allow_exec, "/usr/bin/perl"));
+        assert!(has(&profile.standard_allow_exec, "/usr/bin/protoc"));
+        assert!(!has(&profile.allow_exec, "/usr/bin/curl"));
+        assert!(!has(&profile.allow_exec, "/usr/bin/perl"));
+        assert!(!has(&profile.allow_exec, "/usr/bin/protoc"));
     }
 
     #[test]

--- a/crates/core/src/profile/mod.rs
+++ b/crates/core/src/profile/mod.rs
@@ -617,6 +617,7 @@ impl SandboxProfile {
             }
         }
 
+        self.enforce_deny_exec();
         self.recompute_network_mode();
     }
 
@@ -725,16 +726,39 @@ impl SandboxProfile {
     /// no subtractive rule, so an overlapping allow entry is removed in full;
     /// this can be stricter than the requested path but never weaker.
     pub(crate) fn add_deny_exec(&mut self, path: SandboxPath, origin: GrantOrigin) {
-        let old_boundary = self.first_user_allow_exec;
+        self.deny_exec.push(path.clone());
+        self.enforce_deny_exec();
+        self.grant_origins.push(GrantRecord {
+            kind: GrantKind::DenyExec,
+            value: path.path.to_string_lossy().into_owned(),
+            origin,
+        });
+    }
+
+    /// Ensure that every remaining execution denial wins over current
+    /// allowlist entries.
+    ///
+    /// Standard mode snapshots executable symlink referents immediately
+    /// before launch. A denial that was lexical when it was added can then
+    /// overlap an allow entry only after that resolution, so this reconciliation
+    /// is required after any allow-exec rewrite or runtime grant.
+    pub fn enforce_deny_exec(&mut self) {
+        if self.deny_exec.is_empty() {
+            return;
+        }
+
+        let deny_exec = self.deny_exec.clone();
+        let old_boundary = self.first_user_allow_exec.min(self.allow_exec.len());
         let mut built_in_remaining = 0_usize;
-        let mut removed = Vec::new();
         self.allow_exec = self
             .allow_exec
             .drain(..)
             .enumerate()
             .filter_map(|(index, allowed)| {
-                if paths_overlap(&allowed.path, &path.path) {
-                    removed.push(allowed.path.to_string_lossy().into_owned());
+                if deny_exec
+                    .iter()
+                    .any(|denied| paths_overlap(&allowed.path, &denied.path))
+                {
                     None
                 } else {
                     if index < old_boundary {
@@ -746,14 +770,11 @@ impl SandboxProfile {
             .collect();
         self.first_user_allow_exec = built_in_remaining;
         self.grant_origins.retain(|record| {
-            record.kind != GrantKind::AllowExec || !removed.contains(&record.value)
+            record.kind != GrantKind::AllowExec
+                || !deny_exec
+                    .iter()
+                    .any(|denied| paths_overlap(Path::new(&record.value), &denied.path))
         });
-        self.grant_origins.push(GrantRecord {
-            kind: GrantKind::DenyExec,
-            value: path.path.to_string_lossy().into_owned(),
-            origin,
-        });
-        self.deny_exec.push(path);
     }
 
     /// Apply an execute grant at the current precedence level, removing an
@@ -1199,6 +1220,54 @@ mod tests {
         }));
     }
 
+    #[test]
+    #[allow(
+        clippy::disallowed_methods,
+        reason = "the unit test creates an isolated executable symlink fixture"
+    )]
+    fn execution_denials_win_after_an_alias_is_added_later() {
+        let root = tempfile::tempdir().unwrap();
+        let home = root.path().join("home");
+        let project = root.path().join("project");
+        let tools = root.path().join("tools");
+        std::fs::create_dir_all(&home).unwrap();
+        std::fs::create_dir_all(&project).unwrap();
+        std::fs::create_dir_all(&tools).unwrap();
+
+        let target = tools.join("protoc-real");
+        let alias = tools.join("protoc");
+        std::fs::write(&target, "#!/bin/sh\n").unwrap();
+        std::os::unix::fs::symlink(&target, &alias).unwrap();
+
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &project);
+        profile.add_deny_exec(SandboxPath::file(target.clone()), GrantOrigin::Cli);
+
+        // This mirrors a standard-mode helper that is inserted after the
+        // denial was merged but before executable aliases are snapshotted.
+        let index = profile.first_user_allow_exec;
+        profile
+            .allow_exec
+            .insert(index, SandboxPath::file(alias.clone()));
+        profile.first_user_allow_exec += 1;
+        profile.grant_origins.push(GrantRecord {
+            kind: GrantKind::AllowExec,
+            value: alias.to_string_lossy().into_owned(),
+            origin: GrantOrigin::BuiltIn,
+        });
+
+        profile.enforce_deny_exec();
+
+        assert!(
+            !profile
+                .allow_exec
+                .iter()
+                .any(|allowed| paths_overlap(&allowed.path, &target))
+        );
+        assert!(!profile.grant_origins.iter().any(|record| {
+            record.kind == GrantKind::AllowExec && record.value == alias.to_string_lossy()
+        }));
+    }
+
     /// Both YAML defaults files must deserialize through [`DefaultsFile`]
     /// (regression guard for the macOS/Linux schema split).
     #[test]
@@ -1344,6 +1413,23 @@ mod tests {
         assert!(has(&profile.allow_exec, "/usr/bin/curl"));
         assert!(has(&profile.allow_exec, "/usr/bin/wget"));
         assert!(profile.allow_domains.iter().any(|d| d.0 == "example.com"));
+    }
+
+    #[test]
+    fn finalize_does_not_resurrect_a_denied_fetch_helper() {
+        let home = PathBuf::from("/Users/test");
+        let pwd = PathBuf::from("/Users/test/project");
+        let mut profile = SandboxProfile::for_ecosystem(Ecosystem::Rust, &home, &pwd);
+
+        profile.merge_overrides(&ProfileOverrides {
+            allow_fetch: vec![DomainPattern::from("example.com")],
+            deny_exec: vec![SandboxPath::file(PathBuf::from("/usr/bin/curl"))],
+            ..ProfileOverrides::default()
+        });
+        profile.finalize();
+
+        assert!(!has(&profile.allow_exec, "/usr/bin/curl"));
+        assert!(has(&profile.allow_exec, "/usr/bin/wget"));
     }
 
     #[test]

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -16,8 +16,10 @@ Both modes retain these cross-platform invariants:
 
 1. the child receives no ambient file descriptors or high-confidence
    credential/capability environment variables;
-2. an auto-discovered project configuration cannot expand authority without
-   `--trust-project-config`;
+2. an auto-discovered project configuration cannot add filesystem, execution,
+   environment, proxy, or degraded-mode authority without
+   `--trust-project-config`; standard mode may add ordinary project network
+   requirements;
 3. an empty allowlist never becomes broader network access;
 4. the local proxy is authenticated, destination-restricted, and bounded; and
 5. capability output does not claim a guarantee the running backend lacks.
@@ -61,11 +63,12 @@ Policy sources are applied in this order:
 4. an explicit `--config` file; and
 5. CLI options.
 
-Project configuration is restrictive-only by default. It may add read/execute
-denials, remove destinations, or disable previously granted broad modes. It may
-not add filesystem, execution, environment, fetch, network, or degradation
-authority. Configuration schemas reject unknown fields and enforce file, list,
-string, environment, domain, and inheritance limits.
+Project configuration is restrictive-only in strict mode. Standard mode also
+accepts `allowDomains` and `allowFetch`, which describe ordinary project
+network requirements without granting filesystem, execution, environment,
+proxy, or degraded-mode authority. Broader project grants still require
+`--trust-project-config`. Configuration schemas reject unknown fields and
+enforce file, list, string, environment, domain, and inheritance limits.
 
 The network booleans used while merging are converted into one exhaustive
 effective mode:

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,6 +1,6 @@
 # sbe Architecture
 
-> **Status:** Current for SBE 0.4.1. Standard mode is the default; `--strict`
+> **Status:** Current for SBE 0.4.2. Standard mode is the default; `--strict`
 > retains the 0.4 fail-closed boundary. Security requirements and finding IDs are
 > defined in the [security hardening design](../specs/security-hardening-design.md).
 

--- a/docs/images/arrayref-build-malware-sbe.svg
+++ b/docs/images/arrayref-build-malware-sbe.svg
@@ -1,0 +1,226 @@
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="0 0 1920 1080"
+     width="100%"
+     height="auto"
+     preserveAspectRatio="xMidYMid meet"
+     style="display:block;max-width:100%;height:auto">
+  <defs>
+    <marker id="arrow-red" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#c2413a"/>
+    </marker>
+    <marker id="arrow-blue" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#2563a8"/>
+    </marker>
+
+    <symbol id="icon-package" viewBox="0 0 48 48">
+      <path d="M7 14 24 5l17 9-17 9L7 14Z" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M7 14v20l17 9 17-9V14M24 23v20" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="icon-code" viewBox="0 0 48 48">
+      <rect x="5" y="7" width="38" height="34" rx="4" fill="none" stroke="currentColor" stroke-width="3"/>
+      <path d="m17 18-7 6 7 6M31 18l7 6-7 6M27 14l-6 20" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="icon-network" viewBox="0 0 48 48">
+      <circle cx="24" cy="24" r="18" fill="none" stroke="currentColor" stroke-width="3"/>
+      <path d="M6 24h36M24 6c6 6 9 12 9 18s-3 12-9 18c-6-6-9-12-9-18s3-12 9-18Z" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="icon-file" viewBox="0 0 48 48">
+      <path d="M11 5h18l9 9v29H11V5Z" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+      <path d="M29 5v10h9M17 25h15M17 32h15" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
+    </symbol>
+    <symbol id="icon-shield" viewBox="0 0 48 48">
+      <path d="M24 4 40 10v12c0 11-6 18-16 22C14 40 8 33 8 22V10l16-6Z" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
+      <path d="m16 24 5 5 11-12" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+    <symbol id="icon-host" viewBox="0 0 48 48">
+      <rect x="5" y="7" width="38" height="28" rx="3" fill="none" stroke="currentColor" stroke-width="3"/>
+      <path d="M17 43h14M24 35v8M14 20l6 6 14-14" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    </symbol>
+  </defs>
+
+  <style>
+    .canvas { fill: #f7f9fc; }
+    .title { font: 700 48px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #172033; letter-spacing: 0; }
+    .subtitle { font: 400 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #526077; letter-spacing: 0; }
+    .lane { stroke-width: 2; rx: 8; }
+    .lane-attack { fill: #fff8f7; stroke: #efc7c2; }
+    .lane-sbe { fill: #f4f9ff; stroke: #bfd7ee; }
+    .lane-label { font: 700 18px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0; }
+    .lane-note { font: 500 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #667085; letter-spacing: 0; }
+    .card { stroke-width: 2; rx: 8; }
+    .card-red { fill: #ffffff; stroke: #d97970; }
+    .card-blue { fill: #ffffff; stroke: #69a1d3; }
+    .card-amber { fill: #fffaf0; stroke: #d49a37; }
+    .card-green { fill: #f4fbf7; stroke: #58a875; }
+    .card-stop { fill: #fff5f4; stroke: #c2413a; stroke-width: 3; }
+    .card-title { font: 700 19px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #172033; letter-spacing: 0; }
+    .card-body { font: 400 15px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #526077; letter-spacing: 0; }
+    .mono { font: 600 14px ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; fill: #344054; letter-spacing: 0; }
+    .icon-red { color: #b33c35; }
+    .icon-blue { color: #2563a8; }
+    .icon-amber { color: #a26312; }
+    .icon-green { color: #287a48; }
+    .attack-line { fill: none; stroke: #c2413a; stroke-width: 4; marker-end: url(#arrow-red); }
+    .sbe-line { fill: none; stroke: #2563a8; stroke-width: 4; marker-end: url(#arrow-blue); }
+    .blocked-line { fill: none; stroke: #c2413a; stroke-width: 4; stroke-dasharray: 10 9; }
+    .flow-label { font: 700 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #8c3430; letter-spacing: 0; }
+    .pill { rx: 7; }
+    .pill-red { fill: #fce5e2; }
+    .pill-blue { fill: #deeffc; }
+    .pill-green { fill: #dff3e6; }
+    .pill-text { font: 700 13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: 0; }
+    .stop-ring { fill: #ffffff; stroke: #c2413a; stroke-width: 5; }
+    .stop-x { fill: none; stroke: #c2413a; stroke-width: 6; stroke-linecap: round; }
+    .footer { fill: #fff9eb; stroke: #dfb55b; stroke-width: 2; rx: 8; }
+    .footer-title { font: 700 15px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #7a4b06; letter-spacing: 0; }
+    .footer-text { font: 400 14px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #675533; letter-spacing: 0; }
+  </style>
+
+  <rect class="canvas" width="1920" height="1080"/>
+
+  <text class="title" x="60" y="68">Rust build-time malware: where sbe stops the chain</text>
+  <text class="subtitle" x="60" y="108">The malicious build script still starts; kernel-enforced egress control prevents its fixed-IP payload download.</text>
+
+  <!-- Attack lane -->
+  <rect class="lane lane-attack" x="60" y="145" width="1800" height="360"/>
+  <text class="lane-label" x="92" y="187" fill="#a8322c">WITHOUT SBE</text>
+  <text class="lane-note" x="242" y="187">ambient developer and CI permissions</text>
+
+  <!-- Attack connectors -->
+  <path class="attack-line" d="M374 328 H420"/>
+  <path class="attack-line" d="M714 328 H760"/>
+  <path class="attack-line" d="M1054 328 H1100"/>
+  <path class="attack-line" d="M1394 328 H1440"/>
+
+  <!-- Attack cards -->
+  <rect class="card card-red" x="90" y="225" width="284" height="206"/>
+  <use href="#icon-package" x="112" y="246" width="44" height="44" class="icon-red"/>
+  <text class="card-title" x="170" y="266">Compromised crate</text>
+  <text class="card-body" x="112" y="315">
+    <tspan x="112" dy="0">arrayref 0.3.10 adds a</tspan>
+    <tspan x="112" dy="24">transitive dependency on</tspan>
+    <tspan x="112" dy="24">the proc-macro1 typosquat.</tspan>
+  </text>
+  <rect class="pill pill-red" x="112" y="386" width="156" height="28"/>
+  <text class="pill-text" x="126" y="405" fill="#9f302a">supply-chain entry</text>
+
+  <rect class="card card-red" x="420" y="225" width="294" height="206"/>
+  <use href="#icon-code" x="442" y="246" width="44" height="44" class="icon-red"/>
+  <text class="card-title" x="500" y="266">Cargo executes build.rs</text>
+  <text class="card-body" x="442" y="315">
+    <tspan x="442" dy="0">Compiling the dependency is</tspan>
+    <tspan x="442" dy="24">enough to run attacker code</tspan>
+    <tspan x="442" dy="24">with the user's authority.</tspan>
+  </text>
+  <text class="mono" x="442" y="401">cargo build</text>
+
+  <rect class="card card-red" x="760" y="225" width="294" height="206"/>
+  <use href="#icon-network" x="782" y="246" width="44" height="44" class="icon-red"/>
+  <text class="card-title" x="840" y="266">Direct TLS download</text>
+  <text class="card-body" x="782" y="315">
+    <tspan x="782" dy="0">The in-process HTTP client</tspan>
+    <tspan x="782" dy="24">fetches an architecture-</tspan>
+    <tspan x="782" dy="24">specific second stage.</tspan>
+  </text>
+  <text class="mono" x="782" y="401">23.254.165.112:9089</text>
+
+  <rect class="card card-red" x="1100" y="225" width="294" height="206"/>
+  <use href="#icon-file" x="1122" y="246" width="44" height="44" class="icon-red"/>
+  <text class="card-title" x="1180" y="266">Drop and execute</text>
+  <text class="card-body" x="1122" y="315">
+    <tspan x="1122" dy="0">Write the payload, mark it</tspan>
+    <tspan x="1122" dy="24">executable, and detach it</tspan>
+    <tspan x="1122" dy="24">from the Cargo process.</tspan>
+  </text>
+  <text class="mono" x="1122" y="401">/tmp/rust-setup</text>
+
+  <rect class="card card-red" x="1440" y="225" width="326" height="206"/>
+  <use href="#icon-host" x="1462" y="246" width="44" height="44" class="icon-red"/>
+  <text class="card-title" x="1520" y="266">Payload and C2</text>
+  <text class="card-body" x="1462" y="315">
+    <tspan x="1462" dy="0">The second stage connects to</tspan>
+    <tspan x="1462" dy="24">C2, reads accessible data,</tspan>
+    <tspan x="1462" dy="24">and attempts persistence.</tspan>
+  </text>
+  <text class="mono" x="1462" y="401">23.254.165.112:443</text>
+
+  <!-- sbe lane -->
+  <rect class="lane lane-sbe" x="60" y="535" width="1800" height="390"/>
+  <text class="lane-label" x="92" y="577" fill="#1f629b">WITH SBE DEFAULTS</text>
+  <text class="lane-note" x="300" y="577">macOS Seatbelt or Linux Landlock v4+; proxy enabled</text>
+
+  <!-- sbe connectors -->
+  <path class="sbe-line" d="M374 744 H420"/>
+  <path class="sbe-line" d="M714 744 H760"/>
+  <path class="blocked-line" d="M1054 744 H1172"/>
+  <path class="sbe-line" d="M1242 744 H1440"/>
+
+  <!-- sbe cards -->
+  <rect class="card card-blue" x="90" y="630" width="284" height="226"/>
+  <use href="#icon-package" x="112" y="652" width="44" height="44" class="icon-blue"/>
+  <text class="card-title" x="170" y="672">Crate is downloaded</text>
+  <text class="card-body" x="112" y="721">
+    <tspan x="112" dy="0">Cargo registry domains are</tspan>
+    <tspan x="112" dy="24">allowlisted, so dependency</tspan>
+    <tspan x="112" dy="24">resolution still works.</tspan>
+  </text>
+  <rect class="pill pill-blue" x="112" y="806" width="176" height="28"/>
+  <text class="pill-text" x="126" y="825" fill="#1f629b">not package detection</text>
+
+  <rect class="card card-amber" x="420" y="630" width="294" height="226"/>
+  <use href="#icon-code" x="442" y="652" width="44" height="44" class="icon-amber"/>
+  <text class="card-title" x="500" y="672">build.rs still runs</text>
+  <text class="card-body" x="442" y="721">
+    <tspan x="442" dy="0">sbe treats build-time code as</tspan>
+    <tspan x="442" dy="24">untrusted but does not stop</tspan>
+    <tspan x="442" dy="24">Cargo from executing it.</tspan>
+  </text>
+  <rect class="pill" x="442" y="806" width="150" height="28" fill="#f8e7bd"/>
+  <text class="pill-text" x="456" y="825" fill="#82500c">sandboxed process</text>
+
+  <rect class="card card-blue" x="760" y="630" width="294" height="226"/>
+  <use href="#icon-shield" x="782" y="652" width="44" height="44" class="icon-blue"/>
+  <text class="card-title" x="840" y="672">Kernel egress boundary</text>
+  <text class="card-body" x="782" y="721">
+    <tspan x="782" dy="0">Direct outbound TCP is denied.</tspan>
+    <tspan x="782" dy="24">Only the local sbe proxy is</tspan>
+    <tspan x="782" dy="24">reachable by default.</tspan>
+  </text>
+  <text class="mono" x="782" y="817">localhost:&lt;proxy-port&gt;</text>
+
+  <!-- Block point -->
+  <circle class="stop-ring" cx="1207" cy="744" r="35"/>
+  <path class="stop-x" d="M1193 730 1221 758M1221 730 1193 758"/>
+  <text class="flow-label" x="1138" y="681">DIRECT SOCKET DENIED</text>
+  <text class="mono" x="1100" y="805">connect(:9089) -&gt; EPERM</text>
+  <text class="card-body" x="1085" y="838">
+    <tspan x="1085" dy="0">No payload bytes reach /tmp.</tspan>
+  </text>
+
+  <rect class="card card-green" x="1440" y="630" width="326" height="226"/>
+  <use href="#icon-host" x="1462" y="652" width="44" height="44" class="icon-green"/>
+  <text class="card-title" x="1520" y="672">Attack chain broken</text>
+  <text class="card-body" x="1462" y="721">
+    <tspan x="1462" dy="0">No rust-setup executable and</tspan>
+    <tspan x="1462" dy="24">no second-stage C2. Sensitive</tspan>
+    <tspan x="1462" dy="24">reads and persistence writes</tspan>
+    <tspan x="1462" dy="24">remain kernel-denied.</tspan>
+  </text>
+  <rect class="pill pill-green" x="1462" y="818" width="164" height="28"/>
+  <text class="pill-text" x="1476" y="837" fill="#287a48">host impact contained</text>
+
+  <!-- Scope and caveat -->
+  <rect class="footer" x="60" y="950" width="1800" height="92"/>
+  <text class="footer-title" x="88" y="976">CONTAINMENT SCOPE</text>
+  <text class="footer-text" x="88" y="1000">
+    Blocks this fixed-IP, fixed-port download under default macOS and Linux 6.7+ policies.
+  </text>
+  <text class="footer-text" x="88" y="1026">
+    <tspan font-weight="700">Residual risk:</tspan>
+    <tspan> embedded payloads or downloads from allowlisted supply-chain hosts can still run; avoid Linux </tspan>
+    <tspan font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-weight="700">--allow-degraded</tspan>
+    <tspan> for hostile builds and combine sbe with dependency vetting and networkless build phases.</tspan>
+  </text>
+</svg>

--- a/specs/index.md
+++ b/specs/index.md
@@ -5,4 +5,4 @@
 - [sbe Implementation Plan](sbe-impl-plan.md) — 3-phase roadmap: core sandbox → network proxy → audit & polish
 - [Cross-Platform Backend Design](cross-platform-backend-design.md) — `SandboxBackend` trait, macOS/Linux parity matrix, Landlock+seccomp port, per-OS profile defaults, phased migration
 - [Security Hardening Design](security-hardening-design.md) — Threat model, prioritized security findings, process/network/filesystem hardening, supply-chain controls, and adversarial acceptance tests
-- [Usable Security Design](usable-security-design.md) — SBE 0.4.1 product contract: usable standard mode, opt-in strict mode, referent-based symlink policy, no vendored tool adapters, and a control-by-control simplification audit
+- [Usable Security Design](usable-security-design.md) — SBE 0.4.2 product contract: usable standard mode, opt-in strict mode, referent-based symlink policy, no vendored tool adapters, and a control-by-control simplification audit

--- a/specs/security-hardening-design.md
+++ b/specs/security-hardening-design.md
@@ -403,11 +403,11 @@ manager's parsed top-level subcommand can update that specific lockfile.
 Supported aliases and default install forms are recognized, while option
 values, nested commands, `--` payloads, informational flags, mutually exclusive
 manager outputs, and read-only commands must not acquire empty lockfiles as a
-launcher side effect. Yarn PnP outputs are selected only when bounded,
-no-follow project metadata identifies Berry/PnP, including the optional ESM
+launcher side effect. Yarn Plug'n'Play outputs are selected only when bounded,
+no-follow project metadata identifies Berry/Plug'n'Play, including the optional ESM
 loader flag. Nested projects walk ancestors through the Git boundary using that
 same bounded metadata, select the nearest matching Node workspace root, and add
-only the active manager's exact dependency and lock/PnP outputs. Explicit
+only the active manager's exact dependency and lock/Plug'n'Play outputs. Explicit
 lockfile opt-outs, including npm's negative and false-valued forms, suppress
 pre-creation. Project-relocation options are rejected before profile preparation
 so the launcher cannot create outputs relative to a different directory.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -1,10 +1,10 @@
 # SBE Usable Security Design
 
-- Status: Accepted for 0.4.1
-- Delivery: 0.4.1 implements the standard/strict split and immediate
+- Status: Delivered in 0.4.2
+- Delivery: 0.4.2 implements the standard/strict split and immediate
   compatibility changes; narrow persistent approvals remain follow-up work
 - Owner: SBE
-- Last updated: 2026-08-28
+- Last updated: 2026-09-05
 - Supersedes the 0.4 hardening design as the default product contract while
   retaining it as the strict-mode contract:
   [Security Hardening Design](security-hardening-design.md)
@@ -42,9 +42,9 @@ requested mode and the guarantees actually enforced. Standard mode degrades
 individual capabilities instead of failing the whole command; strict mode
 still fails before launch when one of its promised capabilities is missing.
 
-### 1.1 0.4.1 delivery boundary
+### 1.1 0.4.2 delivery boundary
 
-0.4.1 delivers the mode split, standard workspace/output behavior,
+0.4.2 delivers the mode split, standard workspace/output behavior,
 non-sensitive environment inheritance, referent-aware symlinks, ordinary
 sccache compatibility, top-level Cargo install intent, local developer
 services, and truthful Linux best-effort networking. It preserves the 0.4
@@ -556,7 +556,7 @@ Execution allowlisting is weak against malicious native code and creates
 continuous toolchain breakage. The target standard design therefore blocks
 small, reviewed sets of true capability brokers where the OS can enforce that
 distinction, and relies on filesystem, secret, network, and `no_new_privs`
-boundaries for the primary protection. 0.4.1 keeps the existing curated list
+boundaries for the primary protection. 0.4.2 keeps the existing curated list
 but resolves normal tool-manager aliases and adds black-box compatibility tests;
 removing that list safely is follow-up work. Strict mode retains a positive
 execute allowlist.

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -78,6 +78,11 @@ The default promise is:
 > ambient credentials and its ability to persist outside the project and
 > expected tool data, while preserving normal build-tool behavior.
 
+Normal build-tool behavior includes common child helpers such as downloaders,
+Perl/Python/Node/Ruby scripting runtimes, OpenSSL, `protoc`, native code
+generators, and platform compiler launchers. These are declared in the
+embedded per-OS standard defaults and are not inherited by strict mode.
+
 The strict promise is:
 
 > If SBE reports that a strict command started, every requested strict
@@ -215,6 +220,15 @@ Security features are reported independently rather than collapsed into one
 | macOS external egress | Exact proxy policy | Exact proxy policy |
 | Linux external egress | Best available, explicitly not strict | Refuse domain mode if unavailable |
 | Missing secondary capability | Continue with one concise warning | Refuse before spawn |
+
+Standard mode treats an automatically discovered project configuration as
+untrusted, but accepts `allowDomains`, `denyDomains`, and `allowFetch` because
+these are ordinary descriptions of where a build obtains dependencies. The
+proxy (or Linux's explicitly best-effort network mode) still governs the
+resulting traffic. Filesystem, executable, environment, proxy, and
+degraded-mode changes remain blocked unless the user explicitly passes
+`--trust-project-config`. Strict mode keeps the restrictive-only project
+policy.
 
 `inspect` emits, for each capability, one of `enforced`, `bestEffort`,
 `unavailable`, `notRequested`, or `explicitlyAllowed`, plus the origin of the


### PR DESCRIPTION
## 0.4.2 release update

This PR prepares `sbexec`, `sbe-core`, and `sbe-proxy` for `0.4.2`, updates the setup action's default release to `0.4.2`, and refreshes the README around the simplified standard-mode experience.

### Standard-mode usability with bounded authority

- Auto-discovered standard-mode `.sbe.yaml` may declare ordinary `allowDomains`, `denyDomains`, and `allowFetch` requirements without `--trust-project-config`.
- Filesystem, execution, environment, proxy, degraded-mode, and profile-inheritance expansion still requires `--trust-project-config`.
- Strict mode remains restrictive-only.
- The README now shows a private Cargo registry in `.sbe.yaml` working with no trust flag, and a GitHub Actions installation with no `version` input.

### Build-tool compatibility and security

- Adds config-driven per-OS `standardAllowExec` compatibility defaults for common build helpers: curl/wget, Perl, OpenSSL, protoc, scripting runtimes, native generators, Xcode tools, Homebrew paths, Bun/pnpm locations, plus `uvx` and `corepack` detection.
- Those grants are promoted only in standard mode; strict mode does not inherit them.
- Filters language-runtime launcher/code-injection variables from standard ambient inheritance.
- `sbe profiles` exposes standard-only compatibility executables.

This addresses the 0.4.1 CI failures: `perl` denied by `openssl-sys`, `protoc` denied by status builds, curl denied by `utoipa-swagger-ui`, and standard-mode rejection of private project registries.

## Verification

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo deny check advisories bans licenses sources`
- `ruby .github/scripts/check-workflow-security.rb`
- `cargo run -p sbexec -- --version` → `sbe 0.4.2`
- Against TFX: standard `inspect -- cargo build` resolves `cargo-index.int.tubi.io` without a trust flag, and standard `run -- cargo metadata --manifest-path tfx/Cargo.toml --no-deps --format-version 1` succeeds.

The in-tree dogfood workflows intentionally continue to bootstrap from the last published `0.4.1` asset; they cannot consume `0.4.2` until its tagged release has been built and attested.
