### PR TITLE
fix(macos): allow sandboxed workers to terminate child processes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,10 +52,10 @@ jobs:
       # archive checksum and GitHub build-provenance attestation before install.
       # nextest stays outside because its proxy tests bind random localhost TCP
       # ports.
-      - name: Install sbe 0.4.1 (dogfood)
-        uses: tyrchen/sbe@5271cff35f898262b560492c4d2252adfb215053 # sbexec-v0.4.1
+      - name: Install sbe 0.4.2 (dogfood)
+        uses: tyrchen/sbe@dba413595698f878a07c2106b45bf7b115ad1bea # sbexec-v0.4.2
         with:
-          version: '0.4.1'
+          version: '0.4.2'
       - name: sbe smoke
         run: |
           sbe --version

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -85,10 +85,10 @@ jobs:
       # setup action verifies both checksum and build provenance. On native
       # targets the sandboxed build warms the upload action's cache;
       # cross-musl targets use a host-native sandboxed check.
-      - name: Install sbe 0.4.1 (dogfood)
-        uses: tyrchen/sbe@5271cff35f898262b560492c4d2252adfb215053 # sbexec-v0.4.1
+      - name: Install sbe 0.4.2 (dogfood)
+        uses: tyrchen/sbe@dba413595698f878a07c2106b45bf7b115ad1bea # sbexec-v0.4.2
         with:
-          version: '0.4.1'
+          version: '0.4.2'
       - name: Pre-build under sbe (dogfood)
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file. See [conventional commits](https://www.conventionalcommits.org/) for commit guidelines.
 
 ---
+## [sbexec-v0.4.3](https://github.com/tyrchen/sbe/compare/sbexec-v0.4.2..sbexec-v0.4.3) - 2026-09-05
+
+### Bug Fixes
+
+- allow sandboxed processes to signal their own child workers during teardown
+
+---
 ## [sbexec-v0.4.2](https://github.com/tyrchen/sbe/compare/sbexec-v0.4.1..sbexec-v0.4.2) - 2026-09-05
 
 ### Miscellaneous Chores

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,7 +562,7 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "sbe-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "dirs",
  "idna",
@@ -580,7 +580,7 @@ dependencies = [
 
 [[package]]
 name = "sbe-proxy"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "base64",
  "getrandom 0.4.3",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "sbexec"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*", "apps/*"]
 resolver = "3"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Tyr Chen <tyr.chen@gmail.com>"]
 edition = "2024"
 license = "MIT"
@@ -45,5 +45,5 @@ getrandom = "0.4.3"
 idna = "1.1.0"
 
 # workspace crates
-sbe-core = { path = "crates/core", version = "0.4.2" }
-sbe-proxy = { path = "crates/proxy", version = "0.4.2" }
+sbe-core = { path = "crates/core", version = "0.4.3" }
+sbe-proxy = { path = "crates/proxy", version = "0.4.3" }

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ install hooks, compiler plugins, and build scripts. It protects host
 credentials and limits filesystem, process, environment, and network access.
 The operating-system kernel and the installed SBE executable remain trusted.
 
-Current release: [`0.4.2`](https://github.com/tyrchen/sbe/releases/tag/sbexec-v0.4.2)
+Current release: [`0.4.3`](https://github.com/tyrchen/sbe/releases/tag/sbexec-v0.4.3)
 
 ## Install
 
 Install the `sbexec` crate, which provides the `sbe` command:
 
 ```bash
-cargo install sbexec --version 0.4.2 --locked
+cargo install sbexec --version 0.4.3 --locked
 sbe --version
 ```
 
@@ -85,7 +85,7 @@ failures use 126.
 
 ## Choose a security mode
 
-Version 0.4.2 uses `standard` mode by default and provides the original 0.4
+Version 0.4.3 uses `standard` mode by default and provides the original 0.4
 fail-closed boundary through `--strict`.
 
 | | Standard (default) | Strict (`--strict`) |
@@ -131,7 +131,7 @@ for later execution outside the sandbox.
 
 ## GitHub Actions
 
-The setup action installs the published `0.4.2` binary, verifies its SHA-256
+The setup action installs the published `0.4.3` binary, verifies its SHA-256
 checksum and GitHub build-provenance attestation, and adds it to `PATH`.
 The action now defaults to the current release, so a normal workflow needs no
 extra version configuration:
@@ -150,17 +150,17 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install SBE
-        uses: tyrchen/sbe@sbexec-v0.4.2
+        uses: tyrchen/sbe@sbexec-v0.4.3
       - run: sbe --version
       - run: sbe run -- cargo build
 ```
 
 For high-assurance workflows, pin the action code to the immutable commit SHA
-for `sbexec-v0.4.2` from the release page. The installed archive is always
+for `sbexec-v0.4.3` from the release page. The installed archive is always
 checked against both its release checksum and GitHub build provenance.
 
-The optional `version` input accepts `0.4.2`, `v0.4.2`, `sbexec-v0.4.2`, or
-`latest`; it defaults to `0.4.2`. Use it only to override the default or when
+The optional `version` input accepts `0.4.3`, `v0.4.3`, `sbexec-v0.4.3`, or
+`latest`; it defaults to `0.4.3`. Use it only to override the default or when
 you deliberately want automatic upgrades to the latest stable GitHub release.
 The optional `github-token` defaults to `github.token`. The action exposes the
 resolved release tag as `version` and the installed executable as `bin-path`.
@@ -402,7 +402,7 @@ Frequently used security options are:
 
 - [Architecture](docs/arch.md)
 - [Security hardening design and threat model](specs/security-hardening-design.md)
-- [0.4.2 usable-security design](specs/usable-security-design.md)
+- [0.4.3 usable-security design](specs/usable-security-design.md)
 - [Changelog](CHANGELOG.md)
 
 ## Development

--- a/action.yml
+++ b/action.yml
@@ -7,9 +7,9 @@ branding:
 
 inputs:
   version:
-    description: 'SBE version to install (defaults to 0.4.2; accepts v0.4.2, sbexec-v0.4.2, or latest)'
+    description: 'SBE version to install (defaults to 0.4.3; accepts v0.4.3, sbexec-v0.4.3, or latest)'
     required: false
-    default: '0.4.2'
+    default: '0.4.3'
   github-token:
     description: 'GitHub token used to query releases and download assets (avoids API rate limits)'
     required: false
@@ -17,7 +17,7 @@ inputs:
 
 outputs:
   version:
-    description: 'The resolved release tag that was installed (e.g. "sbexec-v0.4.2")'
+    description: 'The resolved release tag that was installed (e.g. "sbexec-v0.4.3")'
     value: ${{ steps.resolve.outputs.tag }}
   bin-path:
     description: 'Absolute path to the installed sbe binary'

--- a/crates/core/src/sandbox/macos/sbpl.rs
+++ b/crates/core/src/sandbox/macos/sbpl.rs
@@ -263,7 +263,11 @@ fn section_misc(sb: &mut String) {
     .ok();
     writeln!(sb, "    (global-name-regex #\"^com\\.apple\\.lsd\\.\")").ok();
     writeln!(sb, ")").ok();
-    writeln!(sb, "(allow signal (target self))").ok();
+    // A sandboxed process must be able to tear down workers and other
+    // descendants it created. Target-scoping keeps the capability narrow:
+    // it does not authorize signals to the parent, siblings, or unrelated
+    // same-user processes.
+    writeln!(sb, "(allow signal (target self) (target children))").ok();
 }
 
 /// Write an SBPL path filter from a `SandboxPath`.
@@ -495,6 +499,18 @@ mod tests {
         assert!(!sbpl.contains("(allow mach-lookup)"));
         assert!(!sbpl.contains("com.apple.SecurityServer"));
         assert!(!sbpl.contains("ipc-posix-shm"));
+    }
+
+    #[test]
+    fn test_should_scope_signals_to_self_and_children() {
+        let home = PathBuf::from("/Users/test");
+        let pwd = PathBuf::from("/Users/test/project");
+        let profile = SandboxProfile::for_ecosystem(Ecosystem::Node, &home, &pwd);
+        let sbpl = generate(&profile, Some(12345), strict_options()).unwrap();
+
+        assert!(sbpl.contains("(allow signal (target self) (target children))"));
+        assert!(!sbpl.contains("(allow signal*)"));
+        assert!(!sbpl.contains("(allow signal)"));
     }
 
     #[test]

--- a/docs/arch.md
+++ b/docs/arch.md
@@ -1,6 +1,6 @@
 # sbe Architecture
 
-> **Status:** Current for SBE 0.4.2. Standard mode is the default; `--strict`
+> **Status:** Current for SBE 0.4.3. Standard mode is the default; `--strict`
 > retains the 0.4 fail-closed boundary. Security requirements and finding IDs are
 > defined in the [security hardening design](../specs/security-hardening-design.md).
 

--- a/specs/index.md
+++ b/specs/index.md
@@ -5,4 +5,4 @@
 - [sbe Implementation Plan](sbe-impl-plan.md) — 3-phase roadmap: core sandbox → network proxy → audit & polish
 - [Cross-Platform Backend Design](cross-platform-backend-design.md) — `SandboxBackend` trait, macOS/Linux parity matrix, Landlock+seccomp port, per-OS profile defaults, phased migration
 - [Security Hardening Design](security-hardening-design.md) — Threat model, prioritized security findings, process/network/filesystem hardening, supply-chain controls, and adversarial acceptance tests
-- [Usable Security Design](usable-security-design.md) — SBE 0.4.2 product contract: usable standard mode, opt-in strict mode, referent-based symlink policy, no vendored tool adapters, and a control-by-control simplification audit
+- [Usable Security Design](usable-security-design.md) — SBE 0.4.3 product contract: usable standard mode, opt-in strict mode, referent-based symlink policy, no vendored tool adapters, and a control-by-control simplification audit

--- a/specs/usable-security-design.md
+++ b/specs/usable-security-design.md
@@ -1,7 +1,7 @@
 # SBE Usable Security Design
 
-- Status: Delivered in 0.4.2
-- Delivery: 0.4.2 implements the standard/strict split and immediate
+- Status: Delivered in 0.4.3
+- Delivery: 0.4.3 implements the standard/strict split and immediate
   compatibility changes; narrow persistent approvals remain follow-up work
 - Owner: SBE
 - Last updated: 2026-09-05
@@ -42,9 +42,9 @@ requested mode and the guarantees actually enforced. Standard mode degrades
 individual capabilities instead of failing the whole command; strict mode
 still fails before launch when one of its promised capabilities is missing.
 
-### 1.1 0.4.2 delivery boundary
+### 1.1 0.4.3 delivery boundary
 
-0.4.2 delivers the mode split, standard workspace/output behavior,
+0.4.3 delivers the mode split, standard workspace/output behavior,
 non-sensitive environment inheritance, referent-aware symlinks, ordinary
 sccache compatibility, top-level Cargo install intent, local developer
 services, and truthful Linux best-effort networking. It preserves the 0.4
@@ -556,7 +556,7 @@ Execution allowlisting is weak against malicious native code and creates
 continuous toolchain breakage. The target standard design therefore blocks
 small, reviewed sets of true capability brokers where the OS can enforce that
 distinction, and relies on filesystem, secret, network, and `no_new_privs`
-boundaries for the primary protection. 0.4.2 keeps the existing curated list
+boundaries for the primary protection. 0.4.3 keeps the existing curated list
 but resolves normal tool-manager aliases and adds black-box compatibility tests;
 removing that list safely is follow-up work. Strict mode retains a positive
 execute allowlist.


### PR DESCRIPTION
## Summary

- allow sandboxed processes to signal their own child processes on macOS
- keep signal targets scoped to `self` and `children`, so parent, sibling, and unrelated processes remain denied
- add an SBPL regression test for the target scope
- bump the workspace and crates to 0.4.3
- update the setup action default/docs to 0.4.3
- update CI and release bootstrap workflows to use the published 0.4.2 action while building 0.4.3

This fixes Vitest fork-pool teardown failures where `kill(workerPid)` returned `EPERM` after all tests had passed.

## Validation

- `cargo build --locked`
- `cargo test --workspace --all-features --locked`
- `cargo clippy --workspace --all-targets --all-features --locked -- -D warnings`
- `cargo +nightly fmt --all -- --check`
- `cargo audit --quiet`
- `cargo deny check advisories bans licenses sources`
- workflow security checks

The stricter `clippy::pedantic` mode still reports pre-existing repository-wide findings unrelated to this change.